### PR TITLE
amqp_client: add connect_timeout

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -133,8 +133,8 @@ class AMQPConnection(object):
             except pika.exceptions.AMQPConnectionError:
                 time.sleep(self._get_reconnect_backoff())
                 if deadline and time.time() > deadline:
-                    self.connect_wait.set()
                     self._error = ConnectionTimeoutError()
+                    self.connect_wait.set()
                     raise self._error
             else:
                 self._reset_reconnect_backoff()

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -183,6 +183,7 @@ class AMQPConnection(object):
 
     def __enter__(self):
         self.consume_in_thread()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -62,6 +62,8 @@ class AMQPParams(object):
                 'ca_certs': ssl_cert_path,
                 'cert_reqs': ssl.CERT_REQUIRED,
             }
+        if not broker_ssl_options:
+            broker_ssl_options = broker_config.broker_ssl_options
 
         self._amqp_params = {
             'host': amqp_host or broker_config.broker_hostname,
@@ -69,8 +71,7 @@ class AMQPParams(object):
             'virtual_host': amqp_vhost or broker_config.broker_vhost,
             'credentials': credentials,
             'ssl': ssl_enabled or broker_config.broker_ssl_enabled,
-            'ssl_options': (broker_ssl_options or
-                            broker_config.broker_ssl_options),
+            'ssl_options': broker_ssl_options,
             'heartbeat': HEARTBEAT_INTERVAL,
             'socket_timeout': socket_timeout
         }

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -212,6 +212,8 @@ class AMQPConnection(object):
 
     def add_handler(self, handler):
         self._handlers.append(handler)
+        if self.connection:
+            handler.register(self.connection, self.publish_queue)
 
 
 class TaskConsumer(object):

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -69,8 +69,8 @@ class AMQPParams(object):
             'virtual_host': amqp_vhost or broker_config.broker_vhost,
             'credentials': credentials,
             'ssl': ssl_enabled or broker_config.broker_ssl_enabled,
-            'ssl_options': broker_ssl_options or
-                           broker_config.broker_ssl_options,
+            'ssl_options': (broker_ssl_options or
+                            broker_config.broker_ssl_options),
             'heartbeat': HEARTBEAT_INTERVAL,
             'socket_timeout': socket_timeout
         }


### PR DESCRIPTION
Add a connect timeout, and socket_timeout for pika. This means each
connection attempt will take a limited amount of time, and after
connect_timeout time has passed, we'll throw an error.

In case of a blocking .consume(), this error will simply be raised.
In case of .consume_in_thread, the error must be extracted out to the
calling thread, and raised there.