### PR TITLE
CY-199 Don't update env vars if they're not set

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -119,6 +119,10 @@ class AMQPConnection(object):
         """
         In cases where the broker IP has changed, we want to update the
         environment variables
+
+        This is only relevant when were running as the agent worker,
+        and should have no effect when AMQPConnection is used in other
+        places (eg. cfy-agent).
         """
         if constants.MANAGER_FILE_SERVER_URL_KEY not in os.environ:
             return

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -120,6 +120,8 @@ class AMQPConnection(object):
         In cases where the broker IP has changed, we want to update the
         environment variables
         """
+        if constants.MANAGER_FILE_SERVER_URL_KEY not in os.environ:
+            return
         split_url = urlsplit(os.environ[constants.MANAGER_FILE_SERVER_URL_KEY])
         new_url = split_url._replace(
             netloc='{0}:{1}'.format(new_host, split_url.port)


### PR DESCRIPTION
This happens when AMQPConnection is used from places that aren't the
agent worker (eg. cfy-agent daemons)