### PR TITLE
CY-199 consume_in_thread: poll instead of waiting indefinitely

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -208,7 +208,12 @@ class AMQPConnection(object):
         self._consumer_thread = threading.Thread(target=self.consume)
         self._consumer_thread.daemon = True
         self._consumer_thread.start()
-        self.connect_wait.wait()
+
+        # poll instead of waiting indefinitely so that signals can be handled
+        while True:
+            if self.connect_wait.wait(0.5):
+                break
+
         if self._error is not None:
             raise self._error
         return self._consumer_thread


### PR DESCRIPTION
just `.wait()`-ing on a event blocks signal handling, so eg. ctrl+C
won't have an effect during that time. Which means if an exception happens
inside the connect sequence (currently can only really happen due to
programming error, but still), there's no easy way to even close the program.