### PR TITLE
TaskDispatcher: dont join the consumer thread from callback

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -257,9 +257,9 @@ class AMQPConnection(object):
                 self._publish_queue.put(msg)
                 raise
 
-    def close(self):
+    def close(self, wait=True):
         self._closed = True
-        if self._consumer_thread:
+        if self._consumer_thread and wait:
             self._consumer_thread.join()
             self._consumer_thread = None
 

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1262,7 +1262,7 @@ class _TaskDispatcher(object):
         if self._tasks[client]:
             return
         self._tasks.pop(client)
-        client.close()
+        client.close(wait=False)
 
 
 class RemoteContextHandler(CloudifyWorkflowContextHandler):

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1262,6 +1262,8 @@ class _TaskDispatcher(object):
         if self._tasks[client]:
             return
         self._tasks.pop(client)
+        # we are running in a callback - on the consumer thread. No reason to
+        # try and wait (join) for the thread we're running on to be closed
         client.close(wait=False)
 
 


### PR DESCRIPTION
The callback is called in that thread, it makes no sense to join
from there