### PR TITLE
Python 2.6-compatible waiting for event

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -26,6 +26,7 @@ from urlparse import urlsplit, urlunsplit
 import pika
 import pika.exceptions
 
+from cloudify import utils
 from cloudify import constants
 from cloudify import exceptions
 from cloudify import broker_config
@@ -224,11 +225,7 @@ class AMQPConnection(object):
         self._consumer_thread = threading.Thread(target=self.consume)
         self._consumer_thread.daemon = True
         self._consumer_thread.start()
-
-        # poll instead of waiting indefinitely so that signals can be handled
-        while True:
-            if self.connect_wait.wait(0.5):
-                break
+        utils.wait_for_event(self.connect_wait)
 
         if self._error is not None:
             raise self._error

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -392,7 +392,7 @@ if sys.version_info > (2, 6):
         (ie. doesnt block ^C)
         """
         while True:
-            if evt.wait(0.5):
+            if evt.wait(poll_interval):
                 return
 else:
     def wait_for_event(evt, poll_interval=None):

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -385,6 +385,26 @@ def _shlex_split(command):
     return list(lex)
 
 
+if sys.version_info > (2, 6):
+    # requires 2.7+
+    def wait_for_event(evt, poll_interval=0.5):
+        """Wait for a threading.Event by polling, which allows handling signals.
+        (ie. doesnt block ^C)
+        """
+        while True:
+            if evt.wait(0.5):
+                return
+else:
+    def wait_for_event(evt, poll_interval=None):
+        """Wait for a threading.Event. Stub for compatibility."""
+        # in python 2.6, Event.wait always returns None, so we can either:
+        #  - .wait() without a timeout and block ^C which is inconvenient
+        #  - .wait() with timeout and then check .is_set(),
+        #     which is not threadsafe
+        # We choose the inconvenient but safe method.
+        evt.wait()
+
+
 class Internal(object):
 
     @staticmethod


### PR DESCRIPTION
`evt.wait()` in python 2.6 always returns None, so doing
`if evt.wait(0.5)` is never true, and in a loop, leads to a busyloop
which never allows the code to continue