### PR TITLE
utils version check: handle minor/patch versions

### DIFF
--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -385,7 +385,7 @@ def _shlex_split(command):
     return list(lex)
 
 
-if sys.version_info > (2, 6):
+if sys.version_info >= (2, 7):
     # requires 2.7+
     def wait_for_event(evt, poll_interval=0.5):
         """Wait for a threading.Event by polling, which allows handling signals.


### PR DESCRIPTION
version_info might well be eg. (2,6,6) which is > (2,6),
but it's still not python 2.7