### PR TITLE
amqp_client: forward errors to the calling thread

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -303,7 +303,7 @@ class AMQPConnection(object):
             raise RuntimeError(
                 'Cannot wait when sending from the connection thread')
 
-        # the message will likely be sent from another thread (the .consume
+        # the message is going to be sent from another thread (the .consume
         # thread). If an error happens there, we must have a way to get it
         # back out, so we pass a Queue together with the message, that will
         # contain either an exception instance, or None

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -288,6 +288,14 @@ class AMQPConnection(object):
                      If true, an exception will be raised if the message
                      cannot be sent.
         """
+        if wait and self._consumer_thread \
+                and self._consumer_thread is threading.current_thread():
+            # when sending from the connection thread, we can't wait because
+            # then we wouldn't allow the actual send loop (._process_publish)
+            # to run, because we'd block on the err_queue here
+            raise RuntimeError(
+                'Cannot wait when sending from the connection thread')
+
         # the message will likely be sent from another thread (the .consume
         # thread). If an error happens there, we must have a way to get it
         # back out, so we pass a Queue together with the message, that will

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -262,6 +262,7 @@ class AMQPConnection(object):
             except Exception as e:
                 if err_queue:
                     err_queue.put(e)
+                raise
             else:
                 if err_queue:
                     err_queue.put(None)

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -284,7 +284,7 @@ class AMQPConnection(object):
                 'Attempted to open a channel on a closed connection')
         return self._pika_connection.channel()
 
-    def publish(self, message, wait=True):
+    def publish(self, message, wait=True, timeout=None):
         """Schedule a message to be sent.
 
         :param message: Kwargs for the pika basic_publish call. Should at
@@ -313,9 +313,10 @@ class AMQPConnection(object):
             'err_queue': err_queue
         }
         self._publish_queue.put(envelope)
-        err = err_queue.get()
-        if isinstance(err, Exception):
-            raise err
+        if err_queue:
+            err = err_queue.get(timeout=timeout)
+            if isinstance(err, Exception):
+                raise err
 
 
 class TaskConsumer(object):

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -305,7 +305,7 @@ class AMQPConnection(object):
             'message': 'message',
             'err_queue': err_queue
         }
-        self._output_queue.put(envelope)
+        self._publish_queue.put(envelope)
         err = err_queue.get()
         if isinstance(err, Exception):
             raise err

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -250,6 +250,7 @@ class AMQPConnection(object):
             # to the calling thread - see the publish method
             message = envelope['message']
             err_queue = envelope.get('err_queue')
+            message.setdefault('mandatory', True)
 
             try:
                 channel.publish(**message)

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -309,7 +309,7 @@ class AMQPConnection(object):
         # contain either an exception instance, or None
         err_queue = Queue.Queue() if wait else None
         envelope = {
-            'message': 'message',
+            'message': message,
             'err_queue': err_queue
         }
         self._publish_queue.put(envelope)

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -180,6 +180,7 @@ class AMQPConnection(object):
             raise e
 
         out_channel = self._pika_connection.channel()
+        out_channel.confirm_delivery()
         for handler in self._handlers:
             handler.register(self)
             logger.info('Registered handler for {0} [{1}]'
@@ -251,7 +252,7 @@ class AMQPConnection(object):
             err_queue = envelope.get('err_queue')
 
             try:
-                channel.basic_publish(**message)
+                channel.publish(**message)
             except pika.exceptions.ConnectionClosed:
                 if self._closed:
                     return


### PR DESCRIPTION
Implement a `publish` method on the `AMQPConnection` that makes
sure errors while publishing are bubbled up, and use that method
in handlers.