### PR TITLE
amqp_client: ReqResp declares the queue/exchange it sends to

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -273,10 +273,10 @@ def agent_queue_name(queue, routing_key):
 class ProcessMixin(object):
     """Implement processing incoming messages using a threadpool"""
 
-    def __init__(self, *args, **kwargs):
-        super(ProcessMixin, self).__init__(*args, **kwargs)
-        self.threadpool_size = kwargs.get('threadpool_size', 5)
+    def __init__(self, threadpool_size=5, *args, **kwargs):
+        self.threadpool_size = threadpool_size
         self._sem = threading.Semaphore(self.threadpool_size)
+        super(ProcessMixin, self).__init__(*args, **kwargs)
 
     def process(self, channel, method, properties, body):
         try:

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -403,9 +403,9 @@ class _RequestResponseHandlerBase(object):
         self.in_channel.confirm_delivery()
         self.in_channel.exchange_declare(
             exchange=self.exchange, auto_delete=False, durable=True)
-        for queue in [self.queue, self.send_queue]:
-            self.in_channel.queue_declare(
-                queue=queue, exclusive=True, durable=True)
+        self.in_channel.queue_declare(
+            queue=self.queue, exclusive=True, durable=True)
+        self.in_channel.queue_declare(queue=self.send_queue, durable=True)
         self.in_channel.basic_consume(self.process, self.queue)
 
     def publish(self, message, correlation_id=None, routing_key=''):


### PR DESCRIPTION
Also split TaskConsumer into the consumer base and a mixin that
adds the threadpool processing (turned out to not be required but
i suppose still nice).