### PR TITLE
amqp_client: dont set the mandatory flag by default

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -250,7 +250,6 @@ class AMQPConnection(object):
             # to the calling thread - see the publish method
             message = envelope['message']
             err_queue = envelope.get('err_queue')
-            message.setdefault('mandatory', True)
 
             try:
                 channel.publish(**message)


### PR DESCRIPTION
This breaks clients for which lack of a response also makes sense,
eg the ping sender