### PR TITLE
rest-client-kerberos-check-env-fix

### DIFF
--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -99,7 +99,7 @@ class HTTPClient(object):
                                               self.port, self.api_version)
 
     def has_kerberos(self):
-        if self.kerberos_env:
+        if self.kerberos_env is not None:
             return self.kerberos_env
         return bool(HTTPKerberosAuth) and is_kerberos_env()
 


### PR DESCRIPTION
take into consideration that self.kerberos_env can be false in order not to use kerberos in a kerberos environment.