### PR TITLE
CY-430 : Switching nosetests to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.pytest_cache/
 .coverage
 .cache
 nosetests.xml

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -19,7 +19,6 @@ from os import path
 
 import testtools
 from testtools.matchers import MatchesAny, Equals, GreaterThan
-from nose.tools import nottest
 
 from cloudify import exceptions
 from cloudify.plugins import lifecycle
@@ -589,7 +588,6 @@ class TestRelationshipOrderInLifecycleWorkflows(testtools.TestCase):
         return self.env.storage.get_node_instances(node_id=node_id)[0]
 
 
-@nottest
 @operation
 def exec_op_test_operation(ctx, **kwargs):
     ctx.instance.runtime_properties['test_op_visited'] = True
@@ -597,7 +595,6 @@ def exec_op_test_operation(ctx, **kwargs):
         ctx.instance.runtime_properties['op_kwargs'] = kwargs
 
 
-@nottest
 @operation
 def exec_op_dependency_order_test_operation(ctx, **kwargs):
     ctx.instance.runtime_properties['visit_time'] = time.time()

--- a/cloudify/tests/test_decorators.py
+++ b/cloudify/tests/test_decorators.py
@@ -17,7 +17,6 @@
 import testtools
 
 from mock import patch
-from nose import tools
 
 from cloudify import ctx as ctx_proxy
 from cloudify import manager
@@ -63,14 +62,12 @@ def some_operation_impl(**kwargs):
     return ctx
 
 
-@tools.nottest
 @operation
-def test_op(**kwargs):
-    run(test_op_impl, **kwargs)
+def run_op(**kwargs):
+    run(assert_op_impl, **kwargs)
 
 
-@tools.nottest
-def test_op_impl(ctx, test_case, **kwargs):
+def assert_op_impl(ctx, test_case, **kwargs):
     test_case.assertEqual(ctx, ctx_proxy)
 
 
@@ -91,7 +88,7 @@ class OperationTest(testtools.TestCase):
         self.assertRaises(RuntimeError,
                           lambda: ctx_proxy.instance.id)
 
-        test_op(test_case=self)
+        run_op(test_case=self)
 
         self.assertRaises(RuntimeError,
                           lambda: ctx_proxy.instance.id)

--- a/cloudify/tests/test_local_workflows.py
+++ b/cloudify/tests/test_local_workflows.py
@@ -24,11 +24,10 @@ import threading
 import Queue
 
 import testtools
-import nose.tools
-import cloudify.logs
 from testtools.matchers import ContainsAll
-from cloudify.decorators import workflow, operation
 
+import cloudify.logs
+from cloudify.decorators import workflow, operation
 from cloudify.exceptions import NonRecoverableError
 from cloudify.workflows import local
 from cloudify.workflows import workflow_context
@@ -38,11 +37,9 @@ PLUGIN_PACKAGE_NAME = 'test-package'
 PLUGIN_PACKAGE_VERSION = '1.1.1'
 
 
-@nose.tools.nottest
-class BaseWorkflowTest(testtools.TestCase):
+class BaseWorkflowTest(object):
 
     def setUp(self):
-        super(BaseWorkflowTest, self).setUp()
         self.work_dir = tempfile.mkdtemp(prefix='cloudify-workflows-')
         self.blueprint_dir = os.path.join(self.work_dir, 'blueprint')
         self.storage_dir = os.path.join(self.work_dir, 'storage')
@@ -50,6 +47,7 @@ class BaseWorkflowTest(testtools.TestCase):
         self.env = None
         os.mkdir(self.storage_dir)
         self.addCleanup(self.cleanup)
+        testtools.TestCase.setUp(self)
 
     def cleanup(self):
         shutil.rmtree(self.work_dir)
@@ -415,8 +413,10 @@ class BaseWorkflowTest(testtools.TestCase):
                 'task_retries': global_retries})
 
 
-@nose.tools.nottest
 class LocalWorkflowTest(BaseWorkflowTest):
+    def setUp(self):
+        super(LocalWorkflowTest, self).setUp()
+
     def test_workflow_and_operation_logging_and_events(self):
 
         def assert_task_events(indexes, events):
@@ -940,16 +940,14 @@ class LocalWorkflowTest(BaseWorkflowTest):
         )
 
 
-@nose.tools.istest
-class LocalWorkflowTestInMemoryStorage(LocalWorkflowTest):
+class LocalWorkflowTestInMemoryStorage(LocalWorkflowTest, testtools.TestCase):
 
     def setUp(self):
         super(LocalWorkflowTestInMemoryStorage, self).setUp()
         self.storage_cls = local.InMemoryStorage
 
 
-@nose.tools.istest
-class LocalWorkflowTestFileStorage(LocalWorkflowTest):
+class LocalWorkflowTestFileStorage(LocalWorkflowTest, testtools.TestCase):
 
     def setUp(self):
         super(LocalWorkflowTestFileStorage, self).setUp()
@@ -957,8 +955,7 @@ class LocalWorkflowTestFileStorage(LocalWorkflowTest):
         self.storage_kwargs = {'storage_dir': self.storage_dir}
 
 
-@nose.tools.istest
-class FileStorageTest(BaseWorkflowTest):
+class FileStorageTest(BaseWorkflowTest, testtools.TestCase):
 
     def setUp(self):
         super(FileStorageTest, self).setUp()
@@ -1067,8 +1064,7 @@ class FileStorageTest(BaseWorkflowTest):
                                setup_env=False, load_env=True)
 
 
-@nose.tools.istest
-class LocalWorkflowEnvironmentTest(BaseWorkflowTest):
+class LocalWorkflowEnvironmentTest(BaseWorkflowTest, testtools.TestCase):
 
     def setUp(self):
         super(LocalWorkflowEnvironmentTest, self).setUp()

--- a/dsl_parser/tests/test_get_secret.py
+++ b/dsl_parser/tests/test_get_secret.py
@@ -175,7 +175,7 @@ node_templates:
                            "'user', 'webserver_port', " \
                            "'source_op_secret_id'\] don't exist in this tenant"
 
-        get_secret_not_found = MagicMock(side_effect=TestNotFoundException)
+        get_secret_not_found = MagicMock(side_effect=NotFoundException)
         self.assertRaisesRegexp(exceptions.UnknownSecretError,
                                 expected_message,
                                 prepare_deployment_plan,
@@ -195,9 +195,9 @@ node_templates:
                            " don't exist in this tenant"
 
         get_secret_not_found = MagicMock()
-        get_secret_not_found.side_effect = [None, None, TestNotFoundException,
+        get_secret_not_found.side_effect = [None, None, NotFoundException,
                                             None, None, None,
-                                            TestNotFoundException]
+                                            NotFoundException]
         self.assertRaisesRegexp(exceptions.UnknownSecretError,
                                 expected_message,
                                 prepare_deployment_plan,
@@ -248,7 +248,7 @@ node_templates:
         self.assertFalse(hasattr(parsed, 'secrets'))
 
 
-class TestNotFoundException(Exception):
+class NotFoundException(Exception):
     http_code = 404
 
 

--- a/script_runner/tests/test_script_runner.py
+++ b/script_runner/tests/test_script_runner.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 import requests
 import testtools
 from mock import patch
-from nose.tools import nottest, istest
+from pytest import mark
 
 from cloudify.state import current_ctx
 from cloudify.decorators import workflow
@@ -42,8 +42,7 @@ from script_runner.tasks import ILLEGAL_CTX_OPERATION_ERROR
 IS_WINDOWS = os.name == 'nt'
 
 
-@nottest
-class TestScriptRunner(testtools.TestCase):
+class BaseScriptRunner(object):
 
     def _get_temp_path(self):
         """Create a temporary file and return its absolute pathname.
@@ -602,30 +601,26 @@ if __name__ == '__main__':
         return os.path.normpath(os.path.normcase(path))
 
 
-@istest
-class TestScriptRunnerUnixCtxProxy(TestScriptRunner):
+@mark.skipif(IS_WINDOWS, reason='Test skipped on Windows')
+class TestScriptRunnerUnixCtxProxy(BaseScriptRunner, testtools.TestCase):
 
     def setUp(self):
-        if IS_WINDOWS:
-            self.skipTest('Test skipped on windows')
+        super(TestScriptRunnerUnixCtxProxy, self).setUp()
         self.ctx_proxy_type = 'unix'
-        super(TestScriptRunner, self).setUp()
 
 
-@istest
-class TestScriptRunnerTCPCtxProxy(TestScriptRunner):
+class TestScriptRunnerTCPCtxProxy(BaseScriptRunner, testtools.TestCase):
 
     def setUp(self):
+        super(TestScriptRunnerTCPCtxProxy, self).setUp()
         self.ctx_proxy_type = 'tcp'
-        super(TestScriptRunner, self).setUp()
 
 
-@istest
-class TestScriptRunnerHTTPCtxProxy(TestScriptRunner):
+class TestScriptRunnerHTTPCtxProxy(BaseScriptRunner, testtools.TestCase):
 
     def setUp(self):
+        super(TestScriptRunnerHTTPCtxProxy, self).setUp()
         self.ctx_proxy_type = 'http'
-        super(TestScriptRunner, self).setUp()
 
 
 class TestCtxProxyType(testtools.TestCase):
@@ -636,9 +631,8 @@ class TestCtxProxyType(testtools.TestCase):
     def test_tcp_ctx_type(self):
         self.assert_valid_ctx_proxy('tcp', TCPCtxProxy)
 
+    @mark.skipif(IS_WINDOWS, reason='Skipped on windows')
     def test_unix_ctx_type(self):
-        if IS_WINDOWS:
-            self.skipTest('Skipped on windows')
         self.assert_valid_ctx_proxy('unix', UnixCtxProxy)
 
     def test_none_ctx_type(self):

--- a/tox.ini
+++ b/tox.ini
@@ -15,40 +15,46 @@ envlist=
 deps =
     -rdev-requirements.txt
     -rtest-requirements.txt
-    coverage==3.7.1
-    nose
-    nose-cov
+    pytest
+    pytest-cov
+    pytest-xdist
     testfixtures
 
 [testenv:py27_dsl_parser]
+#Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=nosetests --with-cov --cov-report term-missing --cov dsl_parser dsl_parser/tests
+commands=pytest -n 4 --cov-report term-missing --cov=dsl_parser dsl_parser/tests
 
 [testenv:py27_plugins_common]
+# Does not support distributed run
 deps =
     {[testenv]deps}
-commands=nosetests -s --with-cov --cov cloudify cloudify/tests
+commands=pytest -s --cov-report term-missing --cov=cloudify cloudify/tests
 
 [testenv:py27_script_plugin]
+#Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=nosetests --with-cov --cov script_runner script_runner/tests
+commands=pytest -n 4 --cov-report term-missing --cov=script_runner script_runner/tests
 
 [testenv:py26_dsl_parser]
+#Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=nosetests --with-cov --cov-report term-missing --cov dsl_parser dsl_parser/tests
+commands=pytest -n 4 --cov-report term-missing --cov=dsl_parser dsl_parser/tests
 
 [testenv:py26_plugins_common]
+# Does not support distributed run
 deps =
     {[testenv]deps}
-commands=nosetests -s --with-cov --cov cloudify cloudify/tests
+commands=pytest -s --cov-report term-missing --cov=cloudify cloudify/tests
 
 [testenv:py26_script_plugin]
+#Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=nosetests --with-cov --cov script_runner script_runner/tests
+commands=pytest -n 4 --cov-report term-missing --cov=script_runner script_runner/tests
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
The switch was done because of lose of development of nosetests by it's maintainers.
Redesign of unit tests classes according to the best practices.
Incorporating distributed run of unit tests for speed gain when possible.