### PR TITLE
Added --ignore-plugin-installation-failure flag to 'cfy snapshot rest…

### DIFF
--- a/cloudify_rest_client/snapshots.py
+++ b/cloudify_rest_client/snapshots.py
@@ -146,7 +146,8 @@ class SnapshotsClient(object):
                 recreate_deployments_envs=True,
                 force=False,
                 restore_certificates=False,
-                no_reboot=False):
+                no_reboot=False,
+                ignore_plugin_installation_failure=False):
         """
         Restores the snapshot whose id matches the provided snapshot id.
 
@@ -158,6 +159,8 @@ class SnapshotsClient(object):
         :param restore_certificates: Whether to try and restore the
         certificates from the snapshot.
         :param no_reboot: Do not reboot after certificates restore.
+        :param ignore_plugin_installation_failure: Ignore any plugin
+        installation failures and continue with restore
         """
         assert snapshot_id
         uri = '/snapshots/{0}/restore'.format(snapshot_id)
@@ -165,7 +168,9 @@ class SnapshotsClient(object):
             'recreate_deployments_envs': recreate_deployments_envs,
             'force': force,
             'restore_certificates': restore_certificates,
-            'no_reboot': no_reboot
+            'no_reboot': no_reboot,
+            'ignore_plugin_installation_failure':
+                ignore_plugin_installation_failure
         }
         response = self.api.post(uri, data=params)
         return Execution(response)


### PR DESCRIPTION
…ore' command, will ignore any plugins failing to install during a snapshot restore operation.