### PR TITLE
codecov: adding codecov support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ defaults:
       - run:
           name: Run tox of specfic environment
           command: tox -e $DO_ENV
+      - run:
+          name: Push coverage data to codecov
+          command: |
+            bash <(curl -s https://codecov.io/bash) -F $DO_ENV
 
   - &test_defaults_for_python26
     docker:
@@ -48,6 +52,10 @@ defaults:
       - run:
           name: Run tox of specfic environment
           command: tox -e $DO_ENV
+      - run:
+          name: Push coverage data to codecov
+          command: |
+            bash <(curl -s https://codecov.io/bash) -F $DO_ENV
 
   - &docs_defaults
     docker:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+comment: off
+coverage:
+  status:
+    patch:
+      default:
+        target: '80'
+    project:
+      dsl-parser:
+        paths:
+          - dsl_parser
+      cloudify-plugins-common:
+        paths:
+          - cloudify
+      script-runner:
+        paths:
+          - script_runner

--- a/tox.ini
+++ b/tox.ini
@@ -24,37 +24,37 @@ deps =
 #Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=pytest -n 4 --cov-report term-missing --cov=dsl_parser dsl_parser/tests
+commands=pytest -n 4 --cov-report xml --cov-report term-missing --cov=dsl_parser dsl_parser/tests
 
 [testenv:py27_plugins_common]
 # Does not support distributed run
 deps =
     {[testenv]deps}
-commands=pytest -s --cov-report term-missing --cov=cloudify cloudify/tests
+commands=pytest -s --cov-report xml --cov-report term-missing --cov=cloudify cloudify/tests
 
 [testenv:py27_script_plugin]
 #Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=pytest -n 4 --cov-report term-missing --cov=script_runner script_runner/tests
+commands=pytest -n 4 --cov-report xml --cov-report term-missing --cov=script_runner script_runner/tests
 
 [testenv:py26_dsl_parser]
 #Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=pytest -n 4 --cov-report term-missing --cov=dsl_parser dsl_parser/tests
+commands=pytest -n 4 --cov-report xml --cov-report term-missing --cov=dsl_parser dsl_parser/tests
 
 [testenv:py26_plugins_common]
 # Does not support distributed run
 deps =
     {[testenv]deps}
-commands=pytest -s --cov-report term-missing --cov=cloudify cloudify/tests
+commands=pytest -s --cov-report xml --cov-report term-missing --cov=cloudify cloudify/tests
 
 [testenv:py26_script_plugin]
 #Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.
 deps =
     {[testenv]deps}
-commands=pytest -n 4 --cov-report term-missing --cov=script_runner script_runner/tests
+commands=pytest -n 4 --cov-report xml --cov-report term-missing --cov=script_runner script_runner/tests
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Putting limits for the unit tests coverage level is:
- at the pull request's level will decrease from 80%
- at the projects level will not decrease at all