### PR TITLE
coverage: setting to a specific version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ deps =
     pytest-cov
     pytest-xdist
     testfixtures
+    coverage==4.5.1 
+# coverage - This is done because of coverage pyhotn package bug, https://github.com/nedbat/coveragepy/issues/716
 
 [testenv:py27_dsl_parser]
 #Number simultaneously unit tests run is setted to be a specified value, because auto setting yields unstable results.


### PR DESCRIPTION
This is done because of a recent bug in coverage  5.0a3 version

https://github.com/nedbat/coveragepy/issues/716