### PR TITLE
CY-680: adding support for blueprint import

### DIFF
--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -48,6 +48,10 @@ MERGEABLE_FROM_DSL_VERSION_1_3 = [
     constants.NODE_TEMPLATES
 ]
 
+DONT_OVERWRITE = set([
+    constants.DESCRIPTION
+])
+
 IGNORE = set([
     constants.DSL_DEFINITIONS,
     constants.IMPORTS,
@@ -263,6 +267,8 @@ def _merge_parsed_into_combined(combined_parsed_dsl_holder,
             pass
         elif key_holder.value not in combined_parsed_dsl_holder:
             combined_parsed_dsl_holder.value[key_holder] = value_holder
+        elif key_holder.value in DONT_OVERWRITE:
+            pass
         elif key_holder.value in merge_no_override:
             _, to_dict = combined_parsed_dsl_holder.get_item(key_holder.value)
             _merge_into_dict_or_throw_on_duplicate(

--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -22,6 +22,8 @@ from dsl_parser import (exceptions,
                         constants,
                         version as _version,
                         utils)
+from dsl_parser.import_resolver.abstract_import_resolver import\
+    is_remote_resource
 from dsl_parser.framework.elements import (Element,
                                            Leaf,
                                            List)
@@ -136,8 +138,7 @@ def _dsl_location_to_url(dsl_location, resources_base_path):
 def _get_resource_location(resource_name,
                            resources_base_path,
                            current_resource_context=None):
-    url_parts = resource_name.split(':')
-    if url_parts[0] in ['http', 'https', 'file', 'ftp', 'plugin']:
+    if is_remote_resource(resource_name):
         return resource_name
 
     if os.path.exists(resource_name):

--- a/dsl_parser/import_resolver/abstract_import_resolver.py
+++ b/dsl_parser/import_resolver/abstract_import_resolver.py
@@ -28,6 +28,12 @@ MAX_NUMBER_RETRIES = 5
 DEFAULT_REQUEST_TIMEOUT = 10
 
 
+def is_remote_resource(resource_url):
+    url_parts = resource_url.split(':')
+    if url_parts[0] in ['http', 'https', 'file', 'ftp', 'plugin', 'blueprint']:
+        return True
+
+
 class AbstractImportResolver(object):
     """
     This class is abstract and should be inherited by concrete
@@ -43,8 +49,7 @@ class AbstractImportResolver(object):
         raise NotImplementedError
 
     def fetch_import(self, import_url):
-        url_parts = import_url.split(':')
-        if url_parts[0] in ['http', 'https', 'ftp', 'file']:
+        if is_remote_resource(import_url):
             return self.resolve(import_url)
         return read_import(import_url)
 

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -3020,6 +3020,48 @@ node_templates:
             'prop1': 'val2',
         }, node2['properties'])
 
+    def test_description_in_imports_with_source_description(self):
+        import_description = "import"
+        app_description = "app"
+        imported_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
+description: """ + import_description + """
+node_types:
+  type1:
+     properties:
+"""
+        imported_yaml_filename = self.make_yaml_file(imported_yaml)
+        app = self.BASIC_VERSION_SECTION_DSL_1_3 + """
+description: """ + app_description + """
+imports:
+    - {0}
+node_templates:
+  node1:
+    type: type1
+    """.format(imported_yaml_filename)
+
+        plan = self.parse(app)
+        self.assertEqual(plan[constants.DESCRIPTION], app_description)
+
+    def test_description_in_imports_without_source_description(self):
+        import_description = "import"
+        imported_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
+description: """ + import_description + """
+node_types:
+  type1:
+     properties:
+"""
+        imported_yaml_filename = self.make_yaml_file(imported_yaml)
+        app = self.BASIC_VERSION_SECTION_DSL_1_3 + """
+imports:
+    - {0}
+node_templates:
+  node1:
+    type: type1
+    """.format(imported_yaml_filename)
+
+        plan = self.parse(app)
+        self.assertEqual(plan[constants.DESCRIPTION], import_description)
+
     def test_null_default(self):
         yaml = """
 plugins:


### PR DESCRIPTION
- Added recognition of blueprint catalog import.
- Removed not needed functions in the abstract resolver.
- Added the ability to parse a blueprint and receive the merged blueprint, this is for being able to import a blueprint from the catalog.

- Add fixing CY-689: description from imported blueprint should not try to overwrite the existing one 