### PR TITLE
CY-746 Add ability to get_input nested property

### DIFF
--- a/dsl_parser/exceptions.py
+++ b/dsl_parser/exceptions.py
@@ -31,6 +31,15 @@ class UnknownInputError(Exception):
         super(UnknownInputError, self).__init__(*args, **kwargs)
 
 
+class InputEvaluationError(Exception):
+    """
+    An error raised when the provided input cannot be evaluated (e.g. when
+    it's missing an attribute that has been required)
+    """
+    def __init__(self, *args, **kwargs):
+        super(InputEvaluationError, self).__init__(*args, **kwargs)
+
+
 class FunctionEvaluationError(Exception):
     """
     An error raised when an intrinsic function was unable to get evaluated.

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -147,25 +147,69 @@ class Function(object):
 class GetInput(Function):
 
     def __init__(self, args, **kwargs):
-        self.input_name = None
+        self.input_value = None
         super(GetInput, self).__init__(args, **kwargs)
 
     def parse_args(self, args):
-        valid_args_type = isinstance(args, basestring)
-        if not valid_args_type:
+        if not isinstance(args, basestring) \
+                and not (isinstance(args, list) and len(args) >= 1):
             raise ValueError(
-                "get_input function argument should be a string, "
-                "but is '{0}'.".format(args))
-        self.input_name = args
+                "Illegal argument(s) passed to {0} function. Expected either"
+                "a string or a list [input_name [, key1/index1 [,...]]] but "
+                "got {1}".format(self.name, args))
+        self.input_value = args
 
     def validate(self, plan):
-        if self.input_name not in plan.inputs:
+        if isinstance(self.input_value, list):
+            if self.input_value[0] not in plan.inputs:
+                raise exceptions.UnknownInputError(
+                    "get_input function references an "
+                    "unknown input '{0}' in the function args '{1}'.".format(
+                        self.input_value[0], self.input_value))
+        elif self.input_value not in plan.inputs:
             raise exceptions.UnknownInputError(
                 "get_input function references an "
-                "unknown input '{0}'.".format(self.input_name))
+                "unknown input '{0}'.".format(self.input_value))
 
     def evaluate(self, plan):
-        return plan.inputs[self.input_name]
+        if isinstance(self.input_value, list):
+            return self._get_input_attribute(plan.inputs[self.input_value[0]])
+        return plan.inputs[self.input_value]
+
+    def _get_input_attribute(self, root):
+        if isinstance(root, dict) and 'default' in root:
+            value = root['default']
+        else:
+            value = root
+        for index, attr in enumerate(self.input_value[1:]):
+            if isinstance(value, dict):
+                if attr not in value:
+                    raise exceptions.InputEvaluationError(
+                        "Input attribute '{0}' of '{1}', "
+                        "doesn't exist.".format(
+                            attr, '.'.join(self.input_value[:index + 1])))
+
+                value = value[attr]
+            elif isinstance(value, list):
+                try:
+                    value = value[attr]
+                except TypeError:
+                    raise exceptions.InputEvaluationError(
+                        "Item in index {0} in the get_input arguments list "
+                        "'{1}' is expected to be an int but got {2}.".format(
+                            index, self.input_value, type(attr).__name__))
+                except IndexError:
+                    raise exceptions.InputEvaluationError(
+                        "List size of '{0}' is {1} but got index {2}.".format(
+                            '.'.join(self.input_value[:index + 1]),
+                            len(value),
+                            attr))
+            else:
+                raise exceptions.FunctionEvaluationError(
+                    self.name,
+                    "Object {0} has no attribute {1}"
+                        .format('.'.join(self.input_value[:index + 1]), attr))
+        return value
 
     def evaluate_runtime(self, storage):
         raise RuntimeError('runtime evaluation for {0} is not supported'


### PR DESCRIPTION
`get_input` now behaves as `get_property` but also supports the old
syntax.

This enables acquiring a nested property of a provided input, in the
same way that get_property does.