### PR TITLE
CY-874 default import resolver: fallback - make configurable

### DIFF
--- a/dsl_parser/import_resolver/default_import_resolver.py
+++ b/dsl_parser/import_resolver/default_import_resolver.py
@@ -75,7 +75,7 @@ class DefaultImportResolver(AbstractImportResolver):
     be resolved, the original url will be tried anyway.
     """
 
-    def __init__(self, rules=None, fallback=True):
+    def __init__(self, rules=None, fallback=False):
         # set the rules
         self.rules = rules
         self._fallback = fallback

--- a/dsl_parser/import_resolver/default_import_resolver.py
+++ b/dsl_parser/import_resolver/default_import_resolver.py
@@ -70,11 +70,15 @@ class DefaultImportResolver(AbstractImportResolver):
 
         In case that all the resolve attempts will fail,
         a DSLParsingLogicException will be raise.
+
+    If ``fallback`` is set (the default), then in case all rules fail to
+    be resolved, the original url will be tried anyway.
     """
 
-    def __init__(self, rules=None):
+    def __init__(self, rules=None, fallback=True):
         # set the rules
         self.rules = rules
+        self._fallback = fallback
         if self.rules is None:
             self.rules = DEFAULT_RULES
         self._validate_rules()
@@ -82,11 +86,13 @@ class DefaultImportResolver(AbstractImportResolver):
     def resolve(self, import_url):
         failed_urls = {}
         # trying to find a matching rule that can resolve this url
+        matched_any_rule = False
         for rule in self.rules:
             # the validate method checks that the dict has exactly 1 element
             prefix, value = list(rule.items())[0]
             prefix_len = len(prefix)
             if prefix == import_url[:prefix_len]:
+                matched_any_rule = True
                 # found a matching rule
                 url_to_resolve = value + import_url[prefix_len:]
                 # trying to resolve the resolved_url
@@ -98,6 +104,13 @@ class DefaultImportResolver(AbstractImportResolver):
                         # failed to resolve current rule,
                         # continue to the next one
                         failed_urls[url_to_resolve] = str(ex)
+
+        if matched_any_rule and not self._fallback:
+            msg = 'Failed to resolve the following urls: {0}'.format(
+                failed_urls)
+            ex = DSLParsingLogicException(13, msg)
+            ex.failed_import = import_url
+            raise ex
 
         # failed to resolve the url using the rules
         # trying to open the original url

--- a/dsl_parser/tests/test_deafult_import_resolver.py
+++ b/dsl_parser/tests/test_deafult_import_resolver.py
@@ -74,9 +74,6 @@ class TestDefaultResolver(testtools.TestCase):
             expected_urls_to_resolve=[ORIGINAL_V2_URL, ORIGINAL_V1_URL],
             expected_failure=True,
             partial_err_msg='Failed to resolve the following urls: {0}. '
-                            "In addition, failed to resolve the original "
-                            "import url - Import failed: "
-                            "Unable to open import url {1}"
             .format(str(expected_failed_urls), ORIGINAL_V1_URL))
 
     def test_illegal_resolved_url_from_rules(self):
@@ -94,9 +91,6 @@ class TestDefaultResolver(testtools.TestCase):
             expected_urls_to_resolve=[ILLEGAL_URL, ORIGINAL_V1_URL],
             expected_failure=True,
             partial_err_msg='Failed to resolve the following urls: {0}. '
-                            "In addition, failed to resolve the original "
-                            "import url - Import failed: "
-                            "Unable to open import url {1}"
             .format(str(expected_failed_urls), ORIGINAL_V1_URL))
 
     def test_no_rule_matches(self):

--- a/dsl_parser/tests/test_deafult_import_resolver.py
+++ b/dsl_parser/tests/test_deafult_import_resolver.py
@@ -60,6 +60,17 @@ class TestDefaultResolver(testtools.TestCase):
             expected_urls_to_resolve=[
                 INVALID_V1_URL, ILLEGAL_URL, VALID_V1_URL])
 
+    def test_resolve_fallback(self):
+        # with fallback, it first tries the resolved url, and when that fails,
+        # the originally passed url
+        rules = [
+            {VALID_V1_PREFIX: INVALID_URL_PREFIX},
+        ]
+        self._test_default_resolver(
+            import_url=VALID_V1_URL, rules=rules, fallback=True,
+            expected_urls_to_resolve=[
+                INVALID_V1_URL, VALID_V1_URL])
+
     def test_not_accesible_url_from_rules(self):
         rules = [
             {ORIGINAL_V1_PREFIX: ORIGINAL_V2_PREFIX}
@@ -71,9 +82,9 @@ class TestDefaultResolver(testtools.TestCase):
         }
         self._test_default_resolver(
             import_url=ORIGINAL_V1_URL, rules=rules,
-            expected_urls_to_resolve=[ORIGINAL_V2_URL, ORIGINAL_V1_URL],
+            expected_urls_to_resolve=[ORIGINAL_V2_URL],
             expected_failure=True,
-            partial_err_msg='Failed to resolve the following urls: {0}. '
+            partial_err_msg='Failed to resolve the following urls: {0}'
             .format(str(expected_failed_urls), ORIGINAL_V1_URL))
 
     def test_illegal_resolved_url_from_rules(self):
@@ -88,9 +99,30 @@ class TestDefaultResolver(testtools.TestCase):
 
         self._test_default_resolver(
             import_url=ORIGINAL_V1_URL, rules=rules,
+            expected_urls_to_resolve=[ILLEGAL_URL],
+            expected_failure=True,
+            partial_err_msg='Failed to resolve the following urls: {0}'
+            .format(str(expected_failed_urls), ORIGINAL_V1_URL))
+
+    def test_illegal_resolved_url_from_rules_fallback(self):
+        rules = [
+            {ORIGINAL_V1_PREFIX: ILLEGAL_URL_PREFIX}
+        ]
+        expected_failed_urls = {
+            ILLEGAL_URL:
+                'Import failed: Unable to open import url {0}'
+                '; unknown url type: {0}'.format(ILLEGAL_URL)
+        }
+
+        self._test_default_resolver(
+            import_url=ORIGINAL_V1_URL, rules=rules,
             expected_urls_to_resolve=[ILLEGAL_URL, ORIGINAL_V1_URL],
             expected_failure=True,
+            fallback=True,
             partial_err_msg='Failed to resolve the following urls: {0}. '
+                            "In addition, failed to resolve the original "
+                            "import url - Import failed: "
+                            "Unable to open import url {1}"
             .format(str(expected_failed_urls), ORIGINAL_V1_URL))
 
     def test_no_rule_matches(self):
@@ -172,7 +204,8 @@ class TestDefaultResolver(testtools.TestCase):
     def _test_default_resolver(self, import_url, rules,
                                expected_urls_to_resolve=[],
                                expected_failure=False,
-                               partial_err_msg=None):
+                               partial_err_msg=None,
+                               fallback=False):
 
         urls_to_resolve = []
         number_of_attempts = []
@@ -207,7 +240,7 @@ class TestDefaultResolver(testtools.TestCase):
                     else:
                         return None
 
-        resolver = DefaultImportResolver(rules=rules)
+        resolver = DefaultImportResolver(rules=rules, fallback=fallback)
         with mock.patch('requests.get', new=mock_requests_get,
                         create=True):
             with mock.patch(


### PR DESCRIPTION
Falling back to the original url can now be configured from the
pctx level