### PR TITLE
CY-763 Add create_rabbitmq_user parameter to agents create

### DIFF
--- a/cloudify/agent_utils.py
+++ b/cloudify/agent_utils.py
@@ -25,16 +25,19 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 
 def create_agent_record(cloudify_agent,
                         state=AgentState.CREATING,
+                        create_rabbitmq_user=True,
                         client=None):
     # Proxy agents are not being saved in the agents table
     if _is_proxied(cloudify_agent):
         return
-    _initialize_rabbitmq_user(cloudify_agent)
+    if create_rabbitmq_user:
+        _initialize_rabbitmq_user(cloudify_agent)
     client = client or get_rest_client()
     client.agents.create(
         cloudify_agent['name'],
         cloudify_agent['node_instance_id'],
         state,
+        create_rabbitmq_user,
         ip=cloudify_agent.get('ip'),
         install_method=cloudify_agent.get('install_method'),
         system=_get_agent_system(cloudify_agent),

--- a/cloudify_rest_client/agents.py
+++ b/cloudify_rest_client/agents.py
@@ -176,16 +176,18 @@ class AgentsClient(object):
         return self._wrapper_cls(response)
 
     def create(self, name, node_instance_id, state=AgentState.CREATING,
-               **kwargs):
+               create_rabbitmq_user=True, **kwargs):
         """Create an agent in the DB.
 
          :param name: The name of the agent
          :param node_instance_id: The node_instance_id of the agent
          :param state: The state of the agent
+         :param create_rabbitmq_user: Should create the rabbitmq user or not
          :return: The details of the agent
          """
         data = {'node_instance_id': node_instance_id,
-                'state': state}
+                'state': state,
+                'create_rabbitmq_user': create_rabbitmq_user}
         data.update(kwargs)
         response = self.api.put('/{0}/{1}'.format(self._uri_prefix, name),
                                 data=data)


### PR DESCRIPTION
* While restoring agents, it will create the agent record in the DB but
  will not creare the rabbitmq user.

* Later in the restore we run the restore_amqp script and rabbitmq users
  will be created.