### PR TITLE
CY-875 Disallow importing from outside the resources directory

### DIFF
--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -164,9 +164,14 @@ def _get_resource_location(resource_name,
             return candidate_url
 
     if resources_base_path:
-        full_path = os.path.join(resources_base_path, resource_name)
-        return 'file:{0}'.format(
-            urllib.pathname2url(os.path.abspath(full_path)))
+        full_path = os.path.normpath(
+            os.path.join(resources_base_path, resource_name))
+        full_path = os.path.abspath(full_path)
+        if not full_path.startswith(os.path.join(resources_base_path, '')):
+            raise exceptions.DSLParsingLogicException(
+                13, 'Unable to import {0} - '
+                    'location outside the resources directory')
+        return 'file:{0}'.format(urllib.pathname2url(full_path))
 
     return None
 


### PR DESCRIPTION
If you try to import `../../../etc/passwd`, this will stop you once
you leave the resources directory (/opt/manager/resources)