### PR TITLE
CY-894 : fixing auto-init description fields with None

### DIFF
--- a/dsl_parser/elements/misc.py
+++ b/dsl_parser/elements/misc.py
@@ -18,6 +18,7 @@ from dsl_parser.elements import (
     data_types,
     version as element_version)
 from dsl_parser.framework.elements import (DictElement,
+                                           DictNoDefaultElement,
                                            Element,
                                            Leaf,
                                            List,
@@ -36,7 +37,7 @@ class OutputValue(Element):
     schema = Leaf(type=elements.PRIMITIVE_TYPES)
 
 
-class Output(DictElement):
+class Output(DictNoDefaultElement):
 
     schema = {
         'description': OutputDescription,
@@ -61,7 +62,7 @@ class CapabilityValue(Element):
     schema = Leaf(type=elements.PRIMITIVE_TYPES)
 
 
-class Capability(DictElement):
+class Capability(DictNoDefaultElement):
 
     schema = {
         'description': CapabilityDescription,

--- a/dsl_parser/framework/elements.py
+++ b/dsl_parser/framework/elements.py
@@ -190,9 +190,10 @@ class Element(object):
                 "Multiple matches found for '{0}'".format(element_type))
         return matches[0]
 
-    def build_dict_result(self):
+    def build_dict_result(self, with_default=True):
         return dict((child.name, child.value)
-                    for child in self.context.child_elements_iter(self))
+                    for child in self.context.child_elements_iter(self)
+                    if with_default or child.defined)
 
     def children(self):
         return list(self.context.child_elements_iter(self))
@@ -214,8 +215,16 @@ class Element(object):
 
 class DictElement(Element):
 
+    # If turned off will not initialize undefined fields
+    # by user.
+    with_default = True
+
     def parse(self, **kwargs):
-        return self.build_dict_result()
+        return self.build_dict_result(self.with_default)
+
+
+class DictNoDefaultElement(DictElement):
+    with_default = False
 
 
 class UnknownSchema(object):

--- a/dsl_parser/tests/test_capabilities.py
+++ b/dsl_parser/tests/test_capabilities.py
@@ -1,0 +1,44 @@
+########
+# Copyright (c) 2018 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+from dsl_parser import constants
+from dsl_parser.tests.abstract_test_parser import AbstractTestParser
+
+
+class TestCapabilities(AbstractTestParser):
+
+    def test_capabilities_definition(self):
+        yaml = """
+capabilities: {}
+"""
+        parsed = self.parse(yaml)
+        self.assertEqual(0, len(parsed[constants.CAPABILITIES]))
+
+    def test_capability_definition(self):
+        yaml = """
+capabilities:
+    cap1:
+        description: cap1
+        value: 1
+    cap2:
+        value: 2
+"""
+        parsed = self.parse(yaml)
+        capabilities = parsed[constants.CAPABILITIES]
+        self.assertEqual(2, len(capabilities))
+        self.assertEqual(1, capabilities['cap1']['value'])
+        self.assertEqual('cap1', capabilities['cap1']['description'])
+        self.assertEqual(2, capabilities['cap2']['value'])
+        self.assertNotIn('description', capabilities['cap2'])

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -1,5 +1,5 @@
 ########
-# Copyright (c) 2014 GigaSpaces Technologies Ltd. All rights reserved
+# Copyright (c) 2018 Cloudify Platform Ltd. All rights reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+from dsl_parser import constants
 from dsl_parser.tasks import prepare_deployment_plan
 from dsl_parser.exceptions import (MissingRequiredInputError,
                                    UnknownInputError,
@@ -24,10 +25,9 @@ from dsl_parser.tests.abstract_test_parser import AbstractTestParser
 
 class TestInputs(AbstractTestParser):
 
-    def test_inputs_definition(self):
+    def test_empty_inputs(self):
         yaml = """
 inputs: {}
-node_templates: {}
 """
         parsed = self.parse(yaml)
         self.assertEqual(0, len(parsed['inputs']))
@@ -45,20 +45,25 @@ node_templates: {}
         self.assertEqual(8080, parsed['inputs']['port']['default'])
         self.assertEqual('the port', parsed['inputs']['port']['description'])
 
-    def test_two_inputs(self):
+    def test_inputs_definition(self):
         yaml = """
 inputs:
     port:
         description: the port
         default: 8080
+    port2:
+        default: 9090
     ip: {}
 node_templates: {}
 """
         parsed = self.parse(yaml)
-        self.assertEqual(2, len(parsed['inputs']))
-        self.assertEqual(8080, parsed['inputs']['port']['default'])
-        self.assertEqual('the port', parsed['inputs']['port']['description'])
-        self.assertEqual(0, len(parsed['inputs']['ip']))
+        inputs = parsed[constants.INPUTS]
+        self.assertEqual(3, len(inputs))
+        self.assertEqual(8080, inputs['port']['default'])
+        self.assertEqual('the port', inputs['port']['description'])
+        self.assertEqual(9090, inputs['port2']['default'])
+        self.assertNotIn('description', inputs['port2'])
+        self.assertEqual(0, len(inputs['ip']))
 
     def test_verify_get_input_in_properties(self):
         yaml = """

--- a/dsl_parser/tests/test_outputs.py
+++ b/dsl_parser/tests/test_outputs.py
@@ -1,5 +1,5 @@
 ########
-# Copyright (c) 2014 GigaSpaces Technologies Ltd. All rights reserved
+# Copyright (c) 2018 Cloudify Platform Ltd. All rights reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ outputs:
         description: p3
         value: []
     port4:
-        description: p4
         value: false
 """
         parsed = self.parse(yaml)
@@ -60,7 +59,7 @@ outputs:
         self.assertEqual({}, outputs['port2']['value'])
         self.assertEqual('p3', outputs['port3']['description'])
         self.assertEqual([], outputs['port3']['value'])
-        self.assertEqual('p4', outputs['port4']['description'])
+        self.assertNotIn('description', outputs['port4'])
         self.assertFalse(outputs['port4']['value'])
         prepared = prepare_deployment_plan(parsed)
         self.assertEqual(parsed['outputs'], prepared['outputs'])


### PR DESCRIPTION
- An element of type DictElement will be parsed to Dict always, which is needed feature so the parser could always read the content of the element. But DictElement init all fields with the user input or None, which can be not desired behaviour for the element. So an element flag was added to enable that ability.