### PR TITLE
Allow storing a graph multiple times

### DIFF
--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -90,8 +90,6 @@ class TaskDependencyGraph(object):
         self.id = graph_id
 
     def store(self, name):
-        if self.id is not None:
-            raise RuntimeError('Graph already stored')
         serialized_tasks = []
         for task in self.tasks_iter():
             serialized = task.dump()


### PR DESCRIPTION
A single graph might be stored multiple times in case it is reused
in a workflow. It will then be stored with different names.