### PR TITLE
Set task state to SENDING when sending it not from a tasks-graph

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -762,6 +762,7 @@ class WorkflowTaskResult(object):
             self.task = handler_result.retried_task
             task_graph.add_task(self.task)
             self._check_execution_cancelled()
+            self.task.set_state(TASK_SENDING)
             self.task.apply_async()
             self._refresh_state()
 

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -33,6 +33,7 @@ from cloudify.manager import (get_node_instance,
                               get_rest_client,
                               download_resource)
 from cloudify.workflows.tasks import (TASK_FAILED,
+                                      TASK_SENDING,
                                       TASK_STARTED,
                                       TASK_SUCCEEDED,
                                       TASK_RESCHEDULED,
@@ -824,6 +825,7 @@ class _WorkflowContextBase(object):
             return task
         else:
             self.internal.task_graph.add_task(task)
+            task.set_state(TASK_SENDING)
             return task.apply_async()
 
     def get_operations(self, graph_id):


### PR DESCRIPTION
Places that send a task must do the same as the tasks graph and set
the state correctly.
Those non-tasks-graph places don't support resuming.