### PR TITLE
CY-1013 Expose TMPDIR to the script

### DIFF
--- a/cloudify/cluster.py
+++ b/cloudify/cluster.py
@@ -183,7 +183,7 @@ class ClusterHTTPClient(HTTPClient):
                 return super(ClusterHTTPClient, self).do_request(*args,
                                                                  **kwargs)
             except (NotClusterMaster, requests.exceptions.ConnectionError):
-                    continue
+                continue
 
         raise CloudifyClientError('No active node in the cluster!')
 

--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -184,7 +184,7 @@ def _extract_import_parts(import_url,
     namespace_op_location = utils.find_namespace_location(import_url)
     namespace = None
 
-    if namespace_op_location is not -1:
+    if namespace_op_location != -1:
         namespace = import_url[:namespace_op_location]
         import_url = import_url[namespace_op_location + 2:]
 
@@ -544,8 +544,8 @@ def _merge_node_templates_relationships(
             # If the current parsed yaml contains only relationships element,
             # the user can only extend with more relationships or merge it
             # with required field to a set a node template.
-                _extend_node_template(from_dict_holder, to_dict_holder)
-                return
+            _extend_node_template(from_dict_holder, to_dict_holder)
+            return
         elif only_relationships_in_source:
             _extend_list_with_namespaced_values(
                 from_dict_holder[constants.RELATIONSHIPS].namespace,

--- a/script_runner/tasks.py
+++ b/script_runner/tasks.py
@@ -280,9 +280,9 @@ def execute(script_path, ctx, process):
         raise NonRecoverableError(str(ctx._return_value))
     elif return_code != 0:
         if not (ctx.is_script_exception_defined and
-           isinstance(ctx._return_value, ScriptException)):
-                raise ProcessException(command,
-                                       return_code)
+                isinstance(ctx._return_value, ScriptException)):
+            raise ProcessException(command,
+                                   return_code)
 
 
 def start_ctx_proxy(ctx, process):

--- a/script_runner/tasks.py
+++ b/script_runner/tasks.py
@@ -27,7 +27,7 @@ from contextlib import contextmanager
 import requests
 
 from cloudify import ctx as operation_ctx
-from cloudify.utils import create_temp_folder
+from cloudify.utils import create_temp_folder, get_exec_tempdir
 from cloudify.workflows import ctx as workflows_ctx
 from cloudify.decorators import operation, workflow
 from cloudify.exceptions import NonRecoverableError
@@ -337,6 +337,7 @@ def _get_process_environment(process, proxy):
     the current executable.
     """
     env = os.environ.copy()
+    env.setdefault('TMPDIR', get_exec_tempdir())
     process_env = process.get('env', {})
     env.update(process_env)
 


### PR DESCRIPTION
By default, expose the exec temp directory to the script, so that
`mktemp` calls inside the script use it