### PR TITLE
CY-1028 : fixing the validation of remote resource scripts

### DIFF
--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -181,12 +181,12 @@ def _extract_import_parts(import_url,
             namespaced, the returned namespace will be
             None.
     """
-    namespace_op_location = utils.find_namespace_location(import_url)
-    namespace = None
+    namespace, _, import_url = \
+        import_url.rpartition(constants.NAMESPACE_DELIMITER)
 
-    if namespace_op_location != -1:
-        namespace = import_url[:namespace_op_location]
-        import_url = import_url[namespace_op_location + 2:]
+    if namespace == '':
+        # The mark of no namespace is None, so we need to use that value.
+        namespace = None
 
     return namespace, _get_resource_location(import_url,
                                              resources_base_path,

--- a/dsl_parser/elements/relationships.py
+++ b/dsl_parser/elements/relationships.py
@@ -16,12 +16,13 @@
 from dsl_parser import (constants,
                         utils)
 from dsl_parser.interfaces import interfaces_parser
+from dsl_parser.framework.elements import Dict
+from dsl_parser.framework.requirements import Value, Requirement
 from dsl_parser.elements import (data_types as _data_types,
                                  operation,
                                  plugins as _plugins,
-                                 types)
-from dsl_parser.framework.requirements import Value, Requirement
-from dsl_parser.framework.elements import Dict
+                                 types,
+                                 misc)
 
 
 class Relationship(types.Type):
@@ -38,10 +39,12 @@ class Relationship(types.Type):
         'self': [Value('super_type',
                        predicate=types.derived_from_predicate,
                        required=False)],
-        _data_types.DataTypes: [Value('data_types')]
+        _data_types.DataTypes: [Value('data_types')],
+        misc.NamespacesMapping: [Value(constants.NAMESPACES_MAPPING)]
     }
 
-    def parse(self, super_type, plugins, resource_base, data_types):
+    def parse(self, super_type, plugins, resource_base, data_types,
+              namespaces_mapping):
         relationship_type = self.build_dict_result()
         if not relationship_type.get('derived_from'):
             relationship_type.pop('derived_from', None)
@@ -63,7 +66,8 @@ class Relationship(types.Type):
             rel_obj=relationship_type,
             plugins=plugins,
             rel_name=relationship_type_name,
-            resource_base=resource_base)
+            resource_base=resource_base,
+            remote_resources_namespaces=namespaces_mapping)
         relationship_type['name'] = relationship_type_name
         relationship_type[
             constants.TYPE_HIERARCHY] = self.create_type_hierarchy(super_type)
@@ -76,7 +80,8 @@ class Relationships(types.Types):
     schema = Dict(type=Relationship)
 
 
-def _validate_relationship_fields(rel_obj, plugins, rel_name, resource_base):
+def _validate_relationship_fields(rel_obj, plugins, rel_name, resource_base,
+                                  remote_resources_namespaces):
     for interfaces in [constants.SOURCE_INTERFACES,
                        constants.TARGET_INTERFACES]:
         for interface_name, interface in rel_obj[interfaces].items():
@@ -85,4 +90,5 @@ def _validate_relationship_fields(rel_obj, plugins, rel_name, resource_base):
                 plugins=plugins,
                 error_code=19,
                 partial_error_message="Relationship '{0}'".format(rel_name),
-                resource_bases=resource_base)
+                resource_bases=resource_base,
+                remote_resources_namespaces=remote_resources_namespaces)

--- a/dsl_parser/elements/workflows.py
+++ b/dsl_parser/elements/workflows.py
@@ -13,9 +13,11 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+from dsl_parser import constants
 from dsl_parser.elements import (data_types,
                                  plugins as _plugins,
-                                 operation)
+                                 operation,
+                                 misc)
 from dsl_parser.framework.requirements import Value, Requirement
 from dsl_parser.framework.elements import (DictElement,
                                            Element,
@@ -45,10 +47,11 @@ class Workflow(Element):
     ]
     requires = {
         'inputs': [Requirement('resource_base', required=False)],
-        _plugins.Plugins: [Value('plugins')]
+        _plugins.Plugins: [Value('plugins')],
+        misc.NamespacesMapping: [Value(constants.NAMESPACES_MAPPING)]
     }
 
-    def parse(self, plugins, resource_base):
+    def parse(self, plugins, resource_base, namespaces_mapping):
         if isinstance(self.initial_value, str):
             operation_content = {'mapping': self.initial_value,
                                  'parameters': {}}
@@ -61,6 +64,7 @@ class Workflow(Element):
             error_code=21,
             partial_error_message='',
             resource_bases=resource_base,
+            remote_resources_namespaces=namespaces_mapping,
             is_workflows=True)
 
 

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -208,8 +208,13 @@ imports:"""
                           dsl_version=self.BASIC_VERSION_SECTION_DSL_1_3,
                           resolver=resolver)
 
-    def parse_from_path(self, dsl_path, resources_base_path=None):
-        return dsl_parse_from_path(dsl_path, resources_base_path)
+    def parse_from_path(self,
+                        dsl_path,
+                        resources_base_path=None,
+                        resolver=None):
+        return dsl_parse_from_path(dsl_path,
+                                   resources_base_path,
+                                   resolver=resolver)
 
     def parse_multi(self, yaml):
         return create_deployment_plan(self.parse_1_3(yaml))

--- a/dsl_parser/utils.py
+++ b/dsl_parser/utils.py
@@ -348,3 +348,7 @@ def is_blueprint_import(import_url):
 
 def remove_blueprint_import_prefix(import_url):
     return import_url.replace(constants.BLUEPRINT_IMPORT, '')
+
+
+def find_suffix_matches_in_list(sub_str, items):
+    return [item for item in items if item.endswith(sub_str)]


### PR DESCRIPTION
* Remote resource (blueprint import) can have scripts, but in the current
  parsed script there is no need to verify those exists.
* Adding fix for namespced script plugin name in workflows
* Clearing up the error msg if there is no plugin or script resource in not
  found for an operation.