### PR TITLE
CY-1071: deal with case when event/log message is not valid text

### DIFF
--- a/cloudify/event.py
+++ b/cloudify/event.py
@@ -75,7 +75,12 @@ class Event(object):
 
     @property
     def text(self):
-        message = self._event['message']['text'].encode('utf-8')
+        message = self._event['message']['text']
+        try:
+            message = message.encode('utf-8')
+        except UnicodeDecodeError as ex:
+            message = "<Unable to encode as UTF-8; error message: {0}>".format(
+                ex)
         if self.is_log_message:
             message = '{0}: {1}'.format(self.log_level, message)
         elif (self.event_type in ('task_rescheduled', 'task_failed')):

--- a/cloudify/exceptions.py
+++ b/cloudify/exceptions.py
@@ -118,13 +118,17 @@ class CommandExecutionException(Exception):
         Exception.__init__(self, self.__str__())
 
     def __str__(self):
-        return "Command '{0}' executed with an error." \
-               "\ncode: {1}" \
-               "\nerror: {2}" \
-               "\noutput: {3}" \
-            .format(self.command, self.code,
-                    self.error or None,
-                    self.output or None)
+        return "Command '{0}' executed with error code {1}.\n" \
+               "stderr:\n" \
+               "-------\n" \
+               "{2}\n" \
+               "-------\n" \
+               "stdout:\n" \
+               "-------\n" \
+               "{3}\n" \
+               "-------".format(self.command, self.code,
+                                self.error or '<none>',
+                                self.output or '<none>')
 
 
 class TimeoutException(Exception):

--- a/cloudify/logs.py
+++ b/cloudify/logs.py
@@ -108,6 +108,14 @@ class CloudifyBaseLoggingHandler(logging.Handler):
 
     def emit(self, record):
         message = self.format(record)
+
+        if not isinstance(message, unicode):
+            try:
+                message = message.decode('utf-8')
+            except UnicodeDecodeError as ex:
+                message = "<Unable to decode as UTF-8; error message: " \
+                          "{0}>".format(ex)
+
         log = {
             'context': self.context,
             'logger': record.name,

--- a/cloudify/tests/test_event.py
+++ b/cloudify/tests/test_event.py
@@ -91,6 +91,10 @@ class TestEvent(testtools.TestCase):
         self.assertIn('Causes (most recent cause last):', text)
         self.assertEqual(2, text.count(causes[0]['traceback']))
 
+    def test_event_non_utf8(self):
+        event = _event('cloudify_log', message='\x80abc', level='INFO')
+        self.assertIn("Unable to encode", event.text)
+
 
 def _event(type, event_type=None, level=None, message=None,
            causes=None, verbosity_level=None):

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -374,8 +374,12 @@ class LocalCommandRunner(object):
 
         :param command: The command to execute.
         :param exit_on_failure: False to ignore failures.
-        :param stdout_pipe: False to not pipe the standard output.
-        :param stderr_pipe: False to not pipe the standard error.
+        :param stdout_pipe: False to not pipe the standard output. In this
+                            case, the response object (or raised exception)
+                            will have 'None' for the std_out/output field.
+        :param stderr_pipe: False to not pipe the standard error. In this
+                            case, the response object (or raised exception)
+                            will have 'None' for the std_err/error field.
         :param cwd: the working directory the command will run from.
         :param execution_env: dictionary of environment variables that will
                               be present in the command scope.


### PR DESCRIPTION
A better approach would be to log the exception somewhere, but for that we need a Python logger configured, and we currently don't have it in that context.