### PR TITLE
CY-1083

### DIFF
--- a/packaging/plugins/Vagrantfile
+++ b/packaging/plugins/Vagrantfile
@@ -91,7 +91,7 @@ Vagrant.configure('2') do |config|
     redhat_maipo.vm.provider :aws do |aws, override|
       aws.access_key_id = AWS_ACCESS_KEY_ID
       aws.secret_access_key = AWS_ACCESS_KEY
-      aws.ami = "ami-c1c699a7"
+      aws.ami = "ami-0e12cbde3e77cbb98"
       aws.region = "eu-west-1"
       aws.instance_type = "m3.medium"
       aws.keypair_name = "vagrant_build"


### PR DESCRIPTION
I am not sure if this is the right AMI. The old AMI was ami-c1c699a7. Now it is no longer available. Currently this region offers me an ARM and an x86 version. I'm guessing we need the x86 version since that's what we apparently used according to the old wagon names, but I'm not sure. I'm also not sure if this API is available in the account Jenkins uses. I guess we will need to change this and run the build again and see if it gets fixed.