### PR TITLE
CY-933 Fix input validations

### DIFF
--- a/dsl_parser/constraints.py
+++ b/dsl_parser/constraints.py
@@ -206,7 +206,7 @@ class Pattern(Constraint):
     # E.g. if self.args = 'abc' then calling `predicate` will only return True
     # when value = "abc".
     def predicate(self, value):
-        if not isinstance(value, str):
+        if not isinstance(value, basestring):
             raise exceptions.ConstraintException(
                 "Value must be of type string, got type "
                 "'{}'".format(type(value)))
@@ -232,7 +232,7 @@ def is_valid_sequence(args):
 
 @register_validation_func(constraint_data_type=_REGEX)
 def is_valid_regex(arg):
-    if not isinstance(arg, str):
+    if not isinstance(arg, basestring):
         return False
     try:
         re.compile(arg)

--- a/dsl_parser/tasks.py
+++ b/dsl_parser/tasks.py
@@ -73,27 +73,24 @@ def _set_plan_inputs(plan, inputs=None):
         if not input_is_missing:
             constraints.validate_input_value(
                 input_name, input_constraints, inputs[input_name])
-            data_type = input_def.get(TYPE, None)
-            if data_type and DATA_TYPES in plan \
-                    and data_type in plan[DATA_TYPES]:
-                try:
-                    utils.parse_value(
-                        value=inputs[input_name],
-                        type_name=data_type,
-                        data_types=plan[DATA_TYPES],
-                        undefined_property_error_message="Undefined property "
-                                                         "{1} in value of "
-                                                         "input {0}.",
-                        missing_property_error_message="Value of input {0} "
-                                                       "is missing property "
-                                                       "{1}.",
-                        node_name=input_name,
-                        path=[],
-                        raise_on_missing_property=True)
-                except exceptions.DSLParsingLogicException as e:
-                    raise exceptions.DSLParsingException(
-                        exceptions.ERROR_INPUT_VIOLATES_DATA_TYPE_SCHEMA,
-                        e.message)
+            try:
+                utils.parse_value(
+                    value=inputs[input_name],
+                    type_name=input_def.get(TYPE, None),
+                    data_types=plan.get(DATA_TYPES, {}),
+                    undefined_property_error_message="Undefined property "
+                                                     "{1} in value of "
+                                                     "input {0}.",
+                    missing_property_error_message="Value of input {0} "
+                                                   "is missing property "
+                                                   "{1}.",
+                    node_name=input_name,
+                    path=[],
+                    raise_on_missing_property=True)
+            except exceptions.DSLParsingLogicException as e:
+                raise exceptions.DSLParsingException(
+                    exceptions.ERROR_INPUT_VIOLATES_DATA_TYPE_SCHEMA,
+                    e.message)
 
     if missing_inputs:
         raise exceptions.MissingRequiredInputError(

--- a/dsl_parser/utils.py
+++ b/dsl_parser/utils.py
@@ -232,15 +232,21 @@ def parse_value(
                 _property_description(path),
                 type_name))
 
+    prop_path = _property_description(path)
+    if not prop_path:
+        err_msg = "Property type validation failed in '{0}': the defined " \
+                  "type is '{1}', yet it was assigned with the " \
+                  "value '{2}'".format(node_name, type_name, value)
+    else:
+        err_msg = "Property type validation failed in '{0}': property " \
+                  "'{1}' type is '{2}', yet it was assigned with the " \
+                  "value '{3}'".format(node_name,
+                                       _property_description(path),
+                                       type_name,
+                                       value)
+
     raise exceptions.DSLParsingLogicException(
-        exceptions.ERROR_VALUE_DOES_NOT_MATCH_TYPE,
-        "Property type validation failed in '{0}': property "
-        "'{1}' type is '{2}', yet it was assigned with the "
-        "value '{3}'".format(
-            node_name,
-            _property_description(path),
-            type_name,
-            value))
+        exceptions.ERROR_VALUE_DOES_NOT_MATCH_TYPE, err_msg)
 
 
 def load_yaml(raw_yaml, error_message, filename=None):


### PR DESCRIPTION
- Fixes regex string validation: it now uses basestring and not str.
- Fixes basic data types not validated during deployment creation.