### PR TITLE
CY-1321 Update remote operation state on the dispatch side

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -818,8 +818,14 @@ class CloudifyContext(CommonContext):
             self._provider_context = self._endpoint.get_provider_context()
         return self._provider_context
 
-    def get_resource(self,
-                     resource_path):
+    def update_operation(self, state):
+        """Update current operation state.
+
+        :param state: New operation state
+        """
+        self._endpoint.update_operation(self.task_id, state)
+
+    def get_resource(self, resource_path):
         """
         Retrieves a resource bundled with the blueprint as a string.
 

--- a/cloudify/endpoint.py
+++ b/cloudify/endpoint.py
@@ -256,6 +256,10 @@ class ManagerEndpoint(Endpoint):
         client = manager.get_rest_client()
         return client.manager.get_config(name=name, scope=scope)
 
+    def update_operation(self, operation_id, state):
+        client = manager.get_rest_client()
+        client.operations.update(operation_id, state=state)
+
 
 class LocalEndpoint(Endpoint):
 
@@ -365,3 +369,7 @@ class LocalEndpoint(Endpoint):
     def get_config(self, name=None, scope=None):
         # TODO implement stored config for cfy local
         return []
+
+    def update_operation(self, operation_id, state):
+        # operation storage is not supported for local
+        return None

--- a/cloudify/tests/mocks/mock_rest_client.py
+++ b/cloudify/tests/mocks/mock_rest_client.py
@@ -58,6 +58,10 @@ class MockRestclient(CloudifyClient):
     def agents(self):
         return MockAgentsClient()
 
+    @property
+    def operations(self):
+        return MockOperationsClient()
+
 
 class MockNodesClient(object):
 
@@ -120,3 +124,8 @@ class MockAgentsClient(object):
             'state': state,
             'create_rabbitmq_user': create_rabbitmq_user
         })
+
+
+class MockOperationsClient(object):
+    def update(self, operation_id, state):
+        pass

--- a/cloudify/tests/test_dispatch.py
+++ b/cloudify/tests/test_dispatch.py
@@ -38,7 +38,7 @@ class TestDispatchTaskHandler(testtools.TestCase):
     def test_handle_or_dispatch_to_subprocess(self):
         expected_result = 'the result'
         local_op_handler = self._operation(
-            func1, args=[expected_result], local=True)
+            func1, args=[expected_result])
         subprocess_op_handler = self._operation(
             func1, task_target='stub', args=[expected_result])
         for handler in [local_op_handler, subprocess_op_handler]:
@@ -299,7 +299,7 @@ class TestDispatchTaskHandler(testtools.TestCase):
             execution_env=None,
             socket_url=None,
             deployment_id=None,
-            local=False,
+            local=True,
             process_registry=None):
         module = __name__
         if not local:
@@ -309,6 +309,7 @@ class TestDispatchTaskHandler(testtools.TestCase):
         execution_env['PYTHONPATH'] = os.path.dirname(__file__)
         return dispatch.OperationHandler(cloudify_context={
             'no_ctx_kwarg': True,
+            'local': local,
             'task_id': 'test',
             'task_name': '{0}.{1}'.format(module, func.__name__),
             'task_target': task_target,

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -427,6 +427,9 @@ class RemoteWorkflowTask(WorkflowTask):
         # can safely be rerun
         if state == TASK_SENDING:
             return
+        # final states are set by the agent side
+        if state in TERMINATED_STATES:
+            return
         return super(RemoteWorkflowTask, self)._update_stored_state(state)
 
     def apply_async(self):
@@ -460,7 +463,6 @@ class RemoteWorkflowTask(WorkflowTask):
             self.async_result = RemoteWorkflowTaskResult(self, async_result)
         except (exceptions.NonRecoverableError,
                 exceptions.RecoverableError) as e:
-            self.set_state(TASK_FAILED)
             self.async_result = RemoteWorkflowErrorTaskResult(self, e)
         return self.async_result
 


### PR DESCRIPTION
For remote tasks, it is the agent that is updating the operation
state. This way, the state will be updated even if the workflow
was cancelled.
Additionally, TASK_STARTED state now makes sense as well!