### PR TITLE
CY-1259: removing un-needed check for input types

### DIFF
--- a/dsl_parser/interfaces/utils.py
+++ b/dsl_parser/interfaces/utils.py
@@ -14,8 +14,7 @@
 #    * limitations under the License.
 
 
-from dsl_parser import (functions,
-                        utils)
+from dsl_parser import utils
 from dsl_parser.exceptions import (ERROR_MISSING_PROPERTY,
                                    DSLParsingLogicException)
 

--- a/dsl_parser/interfaces/utils.py
+++ b/dsl_parser/interfaces/utils.py
@@ -36,43 +36,6 @@ def validate_missing_inputs(inputs, schema_inputs):
         raise DSLParsingLogicException(ERROR_MISSING_PROPERTY, message)
 
 
-def validate_inputs_types(inputs, schema_inputs):
-    for input_key, _input in schema_inputs.iteritems():
-        input_type = _input.get('type')
-        if input_type is None:
-            # no type defined - no validation
-            continue
-        input_val = inputs[input_key]
-
-        if functions.parse(input_val) != input_val:
-            # intrinsic function - not validated at the moment
-            continue
-
-        if input_type == 'integer':
-            if isinstance(input_val, (int, long)) and not \
-                    isinstance(input_val, bool):
-                continue
-        elif input_type == 'float':
-            if isinstance(input_val, (int, float, long)) and not \
-                    isinstance(input_val, bool):
-                continue
-        elif input_type == 'boolean':
-            if isinstance(input_val, bool):
-                continue
-        elif input_type == 'string':
-            continue
-        else:
-            raise DSLParsingLogicException(
-                    80, "Unexpected type defined in inputs schema "
-                        "for input '{0}' - unknown type is {1}"
-                        .format(input_key, input_type))
-
-        raise DSLParsingLogicException(
-                50, "Input type validation failed: Input '{0}' type "
-                    "is '{1}', yet it was assigned with the value '{2}'"
-                    .format(input_key, input_type, input_val))
-
-
 def merge_schema_and_instance_inputs(schema_inputs,
                                      instance_inputs):
 
@@ -82,7 +45,6 @@ def merge_schema_and_instance_inputs(schema_inputs,
             instance_inputs.items())
 
     validate_missing_inputs(merged_inputs, schema_inputs)
-    validate_inputs_types(merged_inputs, schema_inputs)
     return merged_inputs
 
 

--- a/dsl_parser/tests/test_relationships.py
+++ b/dsl_parser/tests/test_relationships.py
@@ -1163,3 +1163,52 @@ node_templates:
               operation: not_existing
 """
         self.assertRaises(DSLParsingLogicException, self.parse, yaml)
+
+
+class TestRelationshipInputValidation(BaseParserApiTest):
+    def test_valid_input_types(self):
+        yaml = """
+relationships:
+    test_relationship:
+        properties:
+            integer:
+                type: integer
+                default: 1
+            list:
+                type: list
+                default: [1, 2]
+            float:
+                type: float
+                default: 1.5
+            string:
+                type: string
+                default: test
+            regex:
+                type: regex
+                default: ^.$
+            boolean:
+                type: boolean
+                default: false
+        """
+        parsed = self.parse(yaml)
+        relationships = parsed['relationships']
+        self.assertEquals(1, len(relationships))
+        test_relationship = relationships['test_relationship']
+        properties = test_relationship['properties']
+        self.assertEqual(1, properties['integer']['default'])
+        self.assertEqual([1, 2], properties['list']['default'])
+        self.assertEqual(1.5, properties['float']['default'])
+        self.assertEqual('test', properties['string']['default'])
+        self.assertEqual('^.$', properties['regex']['default'])
+        self.assertEqual(False, properties['boolean']['default'])
+
+    def test_not_valid_input_type(self):
+        yaml = """
+relationships:
+    test_relationship:
+        properties:
+            not_valid:
+                type: test
+                default: 1
+        """
+        self.assertRaises(DSLParsingLogicException, self.parse, yaml)


### PR DESCRIPTION
- which was already validated in the parsing process by the parse_value util