### PR TITLE
Set TASK_STARTED in remote tasks

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -448,6 +448,7 @@ class OperationHandler(TaskHandler):
             # should be single `with` and comma-separate ctxmanagers,
             # but has to be nested for python 2.6 compat
             with self._amqp_client():
+                ctx.update_operation(tasks.TASK_STARTED)
                 try:
                     result = self._run_operation_func(ctx, kwargs)
                 except Exception:


### PR DESCRIPTION
That state was unused, but now we have a way to actually set it,
so that we can differentiate sent and started tasks