### PR TITLE
ClusterClient: no read timeout

### DIFF
--- a/cloudify/cluster.py
+++ b/cloudify/cluster.py
@@ -25,7 +25,7 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 
 
 class ClusterHTTPClient(HTTPClient):
-    default_timeout_sec = 5
+    default_timeout_sec = (5, None)
     retries = 30
     retry_interval = 3
 


### PR DESCRIPTION
We have a connect timeout so that if a manager node is down, other
can be tried.
However, there's no reason to have a read timeout. Once we connected,
wait for the response as long as it takes.
(This is also what the CLI does)