### PR TITLE
CY-1043 Get rabbitmq credentials from rest when sending tasks

### DIFF
--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -266,10 +266,13 @@ def get_execution_token():
 
 
 def get_tenant():
-    """
-    Returns a dict with the details of the current tenant
-    """
-    return _get_current_context().tenant
+    """Returns a dict with the details of the current tenant"""
+    # this now gets the tenant from REST, however it needs to stay here to
+    # not break backwards compat for users of this function (mainly in
+    # agent), so we have to import from manager into here
+    from cloudify.manager import get_rest_client
+    rest_client = get_rest_client()
+    return rest_client.tenants.get(get_tenant_name())
 
 
 def get_tenant_name():

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1276,8 +1276,7 @@ class _TaskDispatcher(object):
         if task['queue'] == MGMTWORKER_QUEUE:
             client = amqp_client.get_client()
         else:
-            rest_client = get_rest_client()
-            tenant = rest_client.tenants.get(task['tenant']['name'])
+            tenant = utils.get_tenant()
             client = amqp_client.get_client(
                 amqp_user=tenant.rabbitmq_username,
                 amqp_pass=tenant.rabbitmq_password,

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1273,14 +1273,15 @@ class _TaskDispatcher(object):
         return task
 
     def _get_client(self, task):
-        tenant = task['tenant']
         if task['queue'] == MGMTWORKER_QUEUE:
             client = amqp_client.get_client()
         else:
+            rest_client = get_rest_client()
+            tenant = rest_client.tenants.get(task['tenant']['name'])
             client = amqp_client.get_client(
-                amqp_user=tenant['rabbitmq_username'],
-                amqp_pass=tenant['rabbitmq_password'],
-                amqp_vhost=tenant['rabbitmq_vhost']
+                amqp_user=tenant.rabbitmq_username,
+                amqp_pass=tenant.rabbitmq_password,
+                amqp_vhost=tenant.rabbitmq_vhost
             )
         return client
 

--- a/cloudify_rest_client/tenants.py
+++ b/cloudify_rest_client/tenants.py
@@ -61,6 +61,27 @@ class Tenant(dict):
         """
         return self.get('groups')
 
+    @property
+    def rabbitmq_username(self):
+        """
+        :return: Rabbitmq username for this tenant's executions and agents
+        """
+        return self.get('rabbitmq_username')
+
+    @property
+    def rabbitmq_password(self):
+        """
+        :return: Rabbitmq password for this tenant's executions and agents
+        """
+        return self.get('rabbitmq_password')
+
+    @property
+    def rabbitmq_vhost(self):
+        """
+        :return: Rabbitmq vhost for this tenant's executions and agents
+        """
+        return self.get('rabbitmq_vhost')
+
 
 class TenantsClient(object):
 


### PR DESCRIPTION
Instead of storing the credentials in operation context, which
might be stored in places that we don't want to store credentials in
(eg. the operations table), get the credentials via rest when
sending.

Also declare the credential fields on the restclient Tenant object -
they were there before (since CY-599), but undeclared