### PR TITLE
Send no response when a task is kill-cancelled

### DIFF
--- a/cloudify/exceptions.py
+++ b/cloudify/exceptions.py
@@ -132,6 +132,14 @@ class TimeoutException(Exception):
     pass
 
 
+class ProcessKillCancelled(NonRecoverableError):
+    """The execution subprocess was kill-cancelled.
+
+    This exception should never be shown to the user, but instead it's
+    used to notify the taskhandler to not send a response.
+    """
+
+
 class ProcessExecutionError(RuntimeError):
     """Raised by the workflow engine when workflow execution fails."""
 


### PR DESCRIPTION
When a task is kill-cancelled, the other side is killed as well,
so there's nobody who can receive the "error: process was killed"
response, and that response is stuck in the queue.
If then a resume is called, that response is pulled, and the resume
immediately fails due to it.

With these changes, processes that are kill-cancelled are going to
send no response at all, and are going to delete the response queue
right away.