### PR TITLE
Add cause to determine workflow failing event

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -299,16 +299,16 @@ class WorkflowTask(object):
                     causes.append({
                         'type': exceptions.NonRecoverableError.__name__,
                         'message': 'RecoverableError has occurred '
-                        'at last retry'
-                            .format([c['message'] for c in causes]),
+                        'at last retry'.format(
+                            [c['message'] for c in causes]),
                         'traceback': ''
                     })
             if isinstance(exception, exceptions.NonRecoverableError):
                 causes = exception.causes or []
                 causes.append({
                     'type': exceptions.NonRecoverableError.__name__,
-                    'message': 'NonRecoverableError has occurred'
-                        .format([c['message'] for c in causes]),
+                    'message': 'NonRecoverableError has occurred'.format(
+                        [c['message'] for c in causes]),
                     'traceback': ''
                 })
             if isinstance(self, LocalWorkflowTask):

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -299,16 +299,14 @@ class WorkflowTask(object):
                     causes.append({
                         'type': exceptions.NonRecoverableError.__name__,
                         'message': 'RecoverableError has occurred '
-                        'at last retry'.format(
-                            [c['message'] for c in causes]),
+                        'at last retry',
                         'traceback': ''
                     })
             if isinstance(exception, exceptions.NonRecoverableError):
                 causes = exception.causes or []
                 causes.append({
                     'type': exceptions.NonRecoverableError.__name__,
-                    'message': 'NonRecoverableError has occurred'.format(
-                        [c['message'] for c in causes]),
+                    'message': 'NonRecoverableError has occurred',
                     'traceback': ''
                 })
             if isinstance(self, LocalWorkflowTask):

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -299,7 +299,7 @@ class WorkflowTask(object):
                     causes.append({
                         'type': exceptions.NonRecoverableError.__name__,
                         'message': 'RecoverableError has occurred '
-                        'at last retry. Causes {}'
+                        'at last retry'
                             .format([c['message'] for c in causes]),
                         'traceback': ''
                     })
@@ -307,7 +307,7 @@ class WorkflowTask(object):
                 causes = exception.causes or []
                 causes.append({
                     'type': exceptions.NonRecoverableError.__name__,
-                    'message': 'NonRecoverableError has occurred. Causes: {}'
+                    'message': 'NonRecoverableError has occurred'
                         .format([c['message'] for c in causes]),
                     'traceback': ''
                 })


### PR DESCRIPTION
Extra cause will be appended to the causes list
for the failed task in case of workflow terminating failure.
The type will always be NonRecoverable error (regardles of type
of the original exception)