### PR TITLE
CY-1525 execute_operation: add operation name to the graph name

### DIFF
--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -643,11 +643,11 @@ def _make_execute_operation_graph(ctx, operation, operation_kwargs,
 
 
 @workflow(resumable=True)
-def execute_operation(ctx, *args, **kwargs):
+def execute_operation(ctx, operation, *args, **kwargs):
     """ A generic workflow for executing arbitrary operations on nodes """
-
+    name = 'execute_operation_{0}'.format(operation)
     graph = _make_execute_operation_graph(
-        ctx, name='execute_operation', *args, **kwargs)
+        ctx, operation, name=name, *args, **kwargs)
     graph.execute()
 
 

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -39,7 +39,7 @@ class GlobalCounter(object):
 global_counter = GlobalCounter()
 
 
-class TestInstallUninstallWorkflows(testtools.TestCase):
+class TestWorkflowLifecycleOperations(testtools.TestCase):
     lifecycle_blueprint_path = path.join('resources', 'blueprints',
                                          'test-lifecycle.yaml')
 
@@ -65,6 +65,14 @@ class TestInstallUninstallWorkflows(testtools.TestCase):
              'cloudify.interfaces.lifecycle.stop',
              'cloudify.interfaces.lifecycle.delete',
              'cloudify.interfaces.lifecycle.postdelete'])
+
+    @workflow_test(lifecycle_blueprint_path)
+    def test_restart(self, cfy_local):
+        cfy_local.execute('restart')
+        self._make_assertions(
+            cfy_local,
+            ['cloudify.interfaces.lifecycle.stop',
+             'cloudify.interfaces.lifecycle.start'])
 
     def _make_assertions(self, cfy_local, expected_ops):
         instances = cfy_local.storage.get_node_instances()

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -23,6 +23,7 @@ import networkx as nx
 from cloudify.workflows import api
 from cloudify.workflows import tasks
 from cloudify.state import workflow_ctx
+from cloudify.exceptions import NonRecoverableError
 
 
 def make_or_get_graph(f):
@@ -68,11 +69,13 @@ class TaskDependencyGraph(object):
             if op.containing_subgraph:
                 subgraph_id = op.containing_subgraph
                 op.containing_subgraph = None
-                # subgraph can be missing if the operation was failed but
-                # the subgraph was suceeded (which happens only if an
-                # operation runs twice at the same time, which shouldn't
-                # happen, but let's not break in that case)
-                subgraph = ops.get(subgraph_id, graph)
+                if subgraph_id not in ops:
+                    raise NonRecoverableError(
+                        'Cannot resume task {0} - containing subgraph {1} is '
+                        'already finished. The execution might have not been '
+                        'cancelled properly (some tasks are still running?)'
+                        .format(op.id, subgraph_id))
+                subgraph = ops[subgraph_id]
                 subgraph.add_task(op)
             else:
                 graph.add_task(op)

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -68,7 +68,11 @@ class TaskDependencyGraph(object):
             if op.containing_subgraph:
                 subgraph_id = op.containing_subgraph
                 op.containing_subgraph = None
-                subgraph = ops[subgraph_id]
+                # subgraph can be missing if the operation was failed but
+                # the subgraph was suceeded (which happens only if an
+                # operation runs twice at the same time, which shouldn't
+                # happen, but let's not break in that case)
+                subgraph = ops.get(subgraph_id, graph)
                 subgraph.add_task(op)
             else:
                 graph.add_task(op)


### PR DESCRIPTION
This means that usages of execute_operation (in the restart workflow)
will have distinct names by default, because they run different
operations.

This doesn't change anything for other usages of execute_workflow,
because the name is just an opaque identifier, nothing really cares
if it's "execute_operation" or "execute_operation_cloudify.lifecycle.create"

Additionally, that means that looking at the operations table in the
db will be nicer, with this info in the name