### PR TITLE
CY-1411 Make start/stop/restart workflows resumable.

### DIFF
--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -554,6 +554,7 @@ def install_new_agents(ctx, **kwargs):
     graph.execute()
 
 
+@workflow(resumable=True)
 def start(ctx, operation_parms, run_by_dependency_order, type_names, node_ids,
           node_instance_ids, **kwargs):
     execute_operation(ctx, 'cloudify.interfaces.lifecycle.start',
@@ -561,6 +562,7 @@ def start(ctx, operation_parms, run_by_dependency_order, type_names, node_ids,
                       type_names, node_ids, node_instance_ids, **kwargs)
 
 
+@workflow(resumable=True)
 def stop(ctx, operation_parms, run_by_dependency_order, type_names, node_ids,
          node_instance_ids, **kwargs):
     execute_operation(ctx, 'cloudify.interfaces.lifecycle.stop',
@@ -568,6 +570,7 @@ def stop(ctx, operation_parms, run_by_dependency_order, type_names, node_ids,
                       type_names, node_ids, node_instance_ids, **kwargs)
 
 
+@workflow(resumable=True)
 def restart(ctx, stop_parms, start_parms, run_by_dependency_order, type_names,
             node_ids, node_instance_ids, **kwargs):
     stop(ctx, stop_parms, run_by_dependency_order, type_names,


### PR DESCRIPTION
Those workflows use a tasks graph and so they are resumable.

(of course, the operations inside of them may still not be resumable,
but the workflow itself is)

This requires #341