### PR TITLE
ctx.tenant: return full tenant if available

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -714,8 +714,14 @@ class CloudifyContext(CommonContext):
 
     @property
     def tenant(self):
-        """Cloudify tenant"""
-        return self._context.get('tenant', {})
+        """Full Cloudify tenant.
+
+        This will go out to the REST API and fetch all the tenant details
+        that the current user is allowed to obtain.
+        """
+        tenant = self._context.get('tenant', {}).copy()
+        tenant.update(utils.get_tenant())
+        return tenant
 
     @property
     def task_id(self):

--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -555,6 +555,7 @@ class CloudifyContext(CommonContext):
         self._target = None
         self._operation = OperationContext(self._context.get('operation', {}))
         self._agent = CloudifyAgentContext(self)
+        self._tenant = None
 
         capabilities_node_instance = None
         if 'related' in self._context:
@@ -719,9 +720,10 @@ class CloudifyContext(CommonContext):
         This will go out to the REST API and fetch all the tenant details
         that the current user is allowed to obtain.
         """
-        tenant = self._context.get('tenant', {}).copy()
-        tenant.update(utils.get_tenant())
-        return tenant
+        if self._tenant is None:
+            self._tenant = self._context.get('tenant', {}).copy()
+            self._tenant.update(utils.get_tenant())
+        return self._tenant
 
     @property
     def task_id(self):

--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -710,7 +710,7 @@ class CloudifyContext(CommonContext):
     @property
     def tenant_name(self):
         """Cloudify tenant name"""
-        return self.tenant.get('name')
+        return self._context.get('tenant', {}).get('name')
 
     @property
     def tenant(self):

--- a/cloudify/logs.py
+++ b/cloudify/logs.py
@@ -49,7 +49,7 @@ def message_context_from_cloudify_context(ctx):
         'task_target': ctx.task_target,
         'operation': ctx.operation.name,
         'plugin': ctx.plugin,
-        'tenant': ctx.tenant,
+        'tenant': {'name': ctx.tenant_name},
     }
     if ctx.type == constants.NODE_INSTANCE:
         context['node_id'] = ctx.instance.id
@@ -70,7 +70,7 @@ def message_context_from_workflow_context(ctx):
         'deployment_id': ctx.deployment.id,
         'execution_id': ctx.execution_id,
         'workflow_id': ctx.workflow_id,
-        'tenant': ctx.tenant,
+        'tenant': {'name': ctx.tenant_name},
     }
 
 
@@ -81,7 +81,7 @@ def message_context_from_sys_wide_wf_context(ctx):
         'deployment_id': None,
         'execution_id': ctx.execution_id,
         'workflow_id': ctx.workflow_id,
-        'tenant': ctx.tenant,
+        'tenant': {'name': ctx.tenant_name},
     }
 
 


### PR DESCRIPTION
For backwards compatibility, ctx.tenant must return the whole tenant
and not just the name.
