### PR TITLE
CY-1732 Functions evaluation: pass a single storage object

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -69,7 +69,8 @@ class RecursionLimit(object):
             msg = "The recursion limit ({0}) has been reached while " \
                   "evaluating the deployment. ".format(self.limit)
             if self.args_to_str_func and (self.last_args or self.last_kwargs):
-                msg += self.args_to_str_func(self.last_args, self.last_kwargs)
+                msg += self.args_to_str_func(
+                    *self.last_args, **self.last_kwargs)
             raise exceptions.EvaluationRecursionLimitReached(msg)
 
     def __exit__(self, tp, value, tb):
@@ -819,20 +820,13 @@ def evaluate_outputs(outputs_def, storage):
         storage=storage)
 
 
-def _args_to_str_func(args, kwargs):
+def _args_to_str_func(handler, v, scope, context, path):
     """Used to display extra information when recursion limit is reached.
+    This is the message-creating function used with an _EvaluationHandler,
+    so it takes the same arguments as that.
 
-    :param args: arguments that the function has been called with lastly.
-    :param kwargs: keyword arguments that the function has been called with
-        lastly.
-    :return: relevant string containing information about the arguments.
     """
-    msg = "Limit was reached with the following path - {0}"
-    if args and len(args) == 5:
-        return msg.format(args[4])
-    if kwargs and 'path' in kwargs:
-        return msg.format(kwargs['path'])
-    return ""
+    return "Limit was reached with the following path - {0}".format(path)
 
 
 class _EvaluationHandler(object):

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -44,8 +44,8 @@ class RecursionLimit(object):
 
         :param limit: recursion limit (inclusive).
         :param args_to_str_func: function that returns a string containing
-            information about the last arguments used. It's signature should
-            be func(args, kwargs).
+            information about the last arguments used. Its signature should
+            be the same as the signature of the limited function.
         """
         self.limit = limit
         self.args_to_str_func = args_to_str_func

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -772,28 +772,15 @@ def parse(raw_function, scope=None, context=None, path=None):
     return raw_function
 
 
-def evaluate_functions(payload, context,
-                       get_node_instances_method,
-                       get_node_instance_method,
-                       get_node_method,
-                       get_secret_method,
-                       get_capability_method):
+def evaluate_functions(payload, context, storage):
     """Evaluate functions in payload.
 
     :param payload: The payload to evaluate.
     :param context: Context used during evaluation.
-    :param get_node_instances_method: A method for getting node instances.
-    :param get_node_instance_method: A method for getting a node instance.
-    :param get_node_method: A method for getting a node.
-    :param get_secret_method: A method for getting a secret.
-    :param get_capability_method: A method for getting a capability.
+    :param storage: Storage backend for runtime function evaluation
     :return: payload.
     """
-    handler = runtime_evaluation_handler(get_node_instances_method,
-                                         get_node_instance_method,
-                                         get_node_method,
-                                         get_secret_method,
-                                         get_capability_method)
+    handler = runtime_evaluation_handler(storage)
     scan.scan_properties(payload,
                          handler,
                          scope=None,
@@ -803,58 +790,32 @@ def evaluate_functions(payload, context,
     return payload
 
 
-def evaluate_capabilities(capabilities,
-                          get_node_instances_method,
-                          get_node_instance_method,
-                          get_node_method,
-                          get_secret_method,
-                          get_capability_method):
+def evaluate_capabilities(capabilities, storage):
     """Evaluates capabilities definition containing intrinsic functions.
 
     :param capabilities: The dict of capabilities to evaluate
-    :param get_node_instances_method: A method for getting node instances.
-    :param get_node_instance_method: A method for getting a node instance.
-    :param get_node_method: A method for getting a node.
-    :param get_secret_method: A method for getting a secret.
-    :param get_capability_method: A method for getting a capability.
+    :param storage: Storage backend for runtime function evaluation
     :return: Capabilities dict.
     """
     capabilities = dict((k, v['value']) for k, v in capabilities.items())
     return evaluate_functions(
         payload=capabilities,
         context={},
-        get_node_instances_method=get_node_instances_method,
-        get_node_instance_method=get_node_instance_method,
-        get_node_method=get_node_method,
-        get_secret_method=get_secret_method,
-        get_capability_method=get_capability_method)
+        storage=storage)
 
 
-def evaluate_outputs(outputs_def,
-                     get_node_instances_method,
-                     get_node_instance_method,
-                     get_node_method,
-                     get_secret_method,
-                     get_capability_method):
+def evaluate_outputs(outputs_def, storage):
     """Evaluates an outputs definition containing intrinsic functions.
 
     :param outputs_def: Outputs definition.
-    :param get_node_instances_method: A method for getting node instances.
-    :param get_node_instance_method: A method for getting a node instance.
-    :param get_node_method: A method for getting a node.
-    :param get_secret_method: A method for getting a secret.
-    :param get_capability_method: A method for getting a capability.
+    :param storage: Storage backend for runtime function evaluation
     :return: Outputs dict.
     """
     outputs = dict((k, v['value']) for k, v in outputs_def.iteritems())
     return evaluate_functions(
         payload=outputs,
         context={'evaluate_outputs': True},
-        get_node_instances_method=get_node_instances_method,
-        get_node_instance_method=get_node_instance_method,
-        get_node_method=get_node_method,
-        get_secret_method=get_secret_method,
-        get_capability_method=get_capability_method)
+        storage=storage)
 
 
 def _handler(evaluator, **evaluator_kwargs):

--- a/dsl_parser/tests/namespace/test_functions.py
+++ b/dsl_parser/tests/namespace/test_functions.py
@@ -570,8 +570,7 @@ outputs:
         value: { get_property: [test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             'value',
             plan[constants.OUTPUTS]['port']['value'])
@@ -606,8 +605,7 @@ outputs:
         value: { get_property: [test--middle_test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             'value',
             plan[constants.OUTPUTS]['port']['value'])
@@ -746,8 +744,7 @@ outputs:
         value: { get_attribute: [test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             {'get_attribute': ['test--node', 'key']},
             plan[constants.OUTPUTS]['port']['value'])
@@ -782,8 +779,7 @@ outputs:
         value: { get_attribute: [test--middle_test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             {'get_attribute': ['test--middle_test--node', 'key']},
             plan[constants.OUTPUTS]['port']['value'])
@@ -982,8 +978,7 @@ imports:
     -   {0}--{1}
 """.format('test', import_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             {'get_secret': 'secret'},
             plan[constants.OUTPUTS]['test--port']['value'])
@@ -1002,8 +997,7 @@ imports:
     -   {0}--{1}
 """.format('test', import_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             {'get_capability': ['dep_1', 'cap_a']},
             plan[constants.OUTPUTS]['test--port']['value'])
@@ -1027,8 +1021,7 @@ imports:
     -   {0}--{1}
 """.format('test', import_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             8080,
             plan[constants.OUTPUTS]['test--port']['value'])
@@ -1056,8 +1049,7 @@ imports:
     -   {0}--{1}
 """.format('test', layer2_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml),
-                                       self._get_secret_mock)
+        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
         self.assertEqual(
             8080,
             plan[constants.OUTPUTS]['test--middle_test--port']['value'])

--- a/dsl_parser/tests/test_get_capability.py
+++ b/dsl_parser/tests/test_get_capability.py
@@ -106,13 +106,8 @@ node_templates:
             ]}
         }
 
-        functions.evaluate_functions(payload,
-                                     {},
-                                     None,
-                                     None,
-                                     None,
-                                     None,
-                                     self._get_capability_mock)
+        functions.evaluate_functions(
+            payload, {}, self._mock_evaluation_storage())
 
         self.assertEqual(payload['a'], 'value_a_1')
         self.assertEqual(payload['b'], 'value_a_2')
@@ -136,14 +131,7 @@ node_templates:
                          node['properties']['property'])
 
         functions.evaluate_functions(
-            parsed,
-            {},
-            None,
-            None,
-            None,
-            None,
-            self._get_capability_mock,
-        )
+            parsed, {}, self._mock_evaluation_storage())
         self.assertEqual(node['properties']['property'], 'value_a_1')
 
     def test_capabilities_in_outputs(self):
@@ -163,14 +151,7 @@ outputs:
                          outputs['output']['value'])
 
         functions.evaluate_functions(
-            parsed,
-            {},
-            None,
-            None,
-            None,
-            None,
-            self._get_capability_mock,
-        )
+            parsed, {}, self._mock_evaluation_storage())
         self.assertEqual(outputs['output']['value'], 'value_a_1')
 
     def test_capabilities_in_inputs(self):
@@ -196,14 +177,7 @@ outputs:
                          outputs['output']['value'])
 
         functions.evaluate_functions(
-            parsed,
-            {},
-            None,
-            None,
-            None,
-            None,
-            self._get_capability_mock,
-        )
+            parsed, {}, self._mock_evaluation_storage())
         self.assertEqual(outputs['output']['value'], 'value_a_1')
 
     def _assert_raises_with_message(self,

--- a/dsl_parser/tests/test_get_secret.py
+++ b/dsl_parser/tests/test_get_secret.py
@@ -144,7 +144,7 @@ node_templates:
                                 a: { get_secret: target_op_secret_id }
 """
         parsed = prepare_deployment_plan(self.parse(yaml),
-                                         self._get_secret_mock)
+                                         self.get_secret)
         webserver_node = None
         for node in parsed.node_templates:
             if node['id'] == 'webserver':
@@ -255,7 +255,6 @@ class NotFoundException(Exception):
 
 
 class TestEvaluateFunctions(AbstractTestParser):
-
     def test_evaluate_functions(self):
 
         payload = {
@@ -271,13 +270,8 @@ class TestEvaluateFunctions(AbstractTestParser):
             ]}
         }
 
-        functions.evaluate_functions(payload,
-                                     {},
-                                     None,
-                                     None,
-                                     None,
-                                     self._get_secret_mock,
-                                     None)
+        functions.evaluate_functions(
+            payload, {}, self._mock_evaluation_storage())
 
         self.assertEqual(payload['a'], 'id_a_value')
         self.assertEqual(payload['b'], 'id_b_value')
@@ -299,18 +293,11 @@ node_templates:
             property: { get_secret: secret }
 """
         parsed = prepare_deployment_plan(self.parse_1_3(yaml),
-                                         self._get_secret_mock)
+                                         self.get_secret)
         node = self.get_node_by_name(parsed, 'node')
         self.assertEqual({'get_secret': 'secret'},
                          node['properties']['property'])
 
         functions.evaluate_functions(
-            parsed,
-            {},
-            None,
-            None,
-            None,
-            self._get_secret_mock,
-            None
-        )
+            parsed, {}, self._mock_evaluation_storage())
         self.assertEqual(node['properties']['property'], 'secret_value')


### PR DESCRIPTION
Instead of passing all the methods in separately, pass a single "Storage"
object.

This is factored out of #356 