### PR TITLE
CY-1711 Don't duplicate context in serialized tasks

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -414,12 +414,17 @@ class RemoteWorkflowTask(WorkflowTask):
         self._cloudify_context = cloudify_context
         self._cloudify_agent = None
 
+    @classmethod
+    def restore(cls, ctx, graph, task_descr):
+        params = task_descr.parameters
+        context = params['task_kwargs']['kwargs']['__cloudify_context']
+        # RemoteWorkflowTask requires the context dict to be passed in
+        params['task_kwargs']['cloudify_context'] = context
+        return super(RemoteWorkflowTask, cls).restore(ctx, graph, task_descr)
+
     def dump(self):
         task = super(RemoteWorkflowTask, self).dump()
-        task['parameters']['task_kwargs'] = {
-            'cloudify_context': self.cloudify_context,
-            'kwargs': self._kwargs
-        }
+        task['parameters']['task_kwargs'] = {'kwargs': self._kwargs}
         return task
 
     def _update_stored_state(self, state):


### PR DESCRIPTION
cloudify_context is already present in the task kwargs, so no need
to store it there twice.
However it is required as a parameter to __init__, and so in restore
we must make sure to pass it there.