### PR TITLE
CY-1881 Add include_metrics as a default param to snapshot client

### DIFF
--- a/cloudify_rest_client/snapshots.py
+++ b/cloudify_rest_client/snapshots.py
@@ -112,11 +112,13 @@ class SnapshotsClient(object):
                include_credentials,
                include_logs=True,
                include_events=True,
-               queue=False):
+               queue=False,
+               include_metrics=None):
         """
         Creates a new snapshot.
 
         :param snapshot_id: Snapshot id of the snapshot that will be created.
+        :param include_metrics: Deprecated parameter, should not be used.
         :return: The created snapshot.
         """
         assert snapshot_id


### PR DESCRIPTION
* The parameter include_metrics was removed from `client.snapshot.create`
  and from the unit tests that uses this parameter when creating a snapshot.

* Unit tests of old client versions were broken

* We now add include_metrics as a default param to snapshot create.
  This is a deprecated parameter, which is kept only for old client versions unit tests.