### PR TITLE
CY-1959 If operation was started before, mark it as a resume

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -835,6 +835,10 @@ class CloudifyContext(CommonContext):
             self._provider_context = self._endpoint.get_provider_context()
         return self._provider_context
 
+    def get_operation(self):
+        """Get the operation object for the currently-executed task."""
+        return self._endpoint.get_operation(self.task_id)
+
     def update_operation(self, state):
         """Update current operation state.
 

--- a/cloudify/endpoint.py
+++ b/cloudify/endpoint.py
@@ -254,6 +254,10 @@ class ManagerEndpoint(Endpoint):
         client = manager.get_rest_client()
         return client.manager.get_config(name=name, scope=scope)
 
+    def get_operation(self, operation_id):
+        client = manager.get_rest_client()
+        return client.operations.get(operation_id)
+
     def update_operation(self, operation_id, state):
         client = manager.get_rest_client()
         client.operations.update(operation_id, state=state)
@@ -370,4 +374,7 @@ class LocalEndpoint(Endpoint):
 
     def update_operation(self, operation_id, state):
         # operation storage is not supported for local
+        return None
+
+    def get_operation(self, operation_id):
         return None

--- a/cloudify/tests/mocks/mock_rest_client.py
+++ b/cloudify/tests/mocks/mock_rest_client.py
@@ -15,6 +15,7 @@ from cloudify_rest_client.agents import Agent
 from cloudify_rest_client import CloudifyClient
 from cloudify_rest_client.evaluate import EvaluatedFunctions
 from cloudify_rest_client.executions import Execution
+from cloudify_rest_client.operations import Operation
 from cloudify_rest_client.node_instances import NodeInstance
 
 
@@ -144,5 +145,8 @@ class MockAgentsClient(object):
 
 
 class MockOperationsClient(object):
+    def get(self, operation_id):
+        return Operation({'id': operation_id})
+
     def update(self, operation_id, state):
         pass

--- a/cloudify_rest_client/operations.py
+++ b/cloudify_rest_client/operations.py
@@ -56,6 +56,11 @@ class OperationsClient(object):
             [self._wrapper_cls(item) for item in response['items']],
             response['metadata'])
 
+    def get(self, operation_id):
+        response = self.api.get('/{self._uri_prefix}/{id}'
+                                .format(self=self, id=operation_id))
+        return Operation(response)
+
     def create(self, operation_id, graph_id, name, type, parameters,
                dependencies):
         data = {


### PR DESCRIPTION
When setting operation state to "started", we might learn that the
operation was already started before. In that case, we know it's a
resume, so we can set it as one.