### PR TITLE
Bump bottle version to 0.12.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,8 @@ commands:
         default: py27
     steps:
       - restore_cache:
-          keys: 
+          keys:
             - << parameters.cache_prefix >>-dependencies-{{ checksum "dev-requirements.txt" }}-{{ checksum "test-requirements.txt" }}-{{ checksum "setup.py" }}
-            - << parameters.cache_prefix >>-dependencies-
       - run: pip install -r dev-requirements.txt --user
       - run: pip install -r test-requirements.txt --user
       - run: pip install -e . --user
@@ -277,7 +276,7 @@ workflows:
           filters:
             branches:
               only: 5.0.5-build
-    
+
   build_and_test:
     jobs:
       - py3_compat

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
     'retrying==1.3.3',
     'pika==0.11.2',
     'proxy_tools==0.1.0',
-    'bottle==0.12.7',
+    'bottle==0.12.18',
     'jinja2==2.10',
     'requests_toolbelt==0.8.0',
     'pysnmp==4.4.5'


### PR DESCRIPTION
0.12.7 uses some deprecated syntax which results in warnings