### PR TITLE
CY-2435 Restore scheduled tasks from snapshot

### DIFF
--- a/cloudify_rest_client/executions.py
+++ b/cloudify_rest_client/executions.py
@@ -306,3 +306,16 @@ class ExecutionsClient(object):
                                  data={'action': action},
                                  expected_status_code=200)
         return self._wrapper_cls(response)
+
+    def requeue(self, execution_id):
+        """
+        Requeue an execution (e.g. after snapshot restore).
+
+        :param execution_id: Id of the execution to be requeued.
+        :return: Requeued execution.
+        """
+        uri = '/{self._uri_prefix}/{id}'.format(self=self, id=execution_id)
+        response = self.api.post(uri,
+                                 data={'action': 'requeue'},
+                                 expected_status_code=200)
+        return self._wrapper_cls(response)


### PR DESCRIPTION
Properly restore scheduled executions from snapshots.  Add `requeue`
action for reinserting executions to execution queue after snapshot
restoration.