### PR TITLE
CY-2460 scheduled tasks snapshot restore

### DIFF
--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -273,11 +273,11 @@ def get_resource_from_manager(resource_path,
     verify = utils.get_local_rest_certificate()
     headers = {}
     try:
-        headers[constants.CLOUDIFY_TOKEN_AUTHENTICATION_HEADER] = \
-            ctx.rest_token
+        headers[constants.CLOUDIFY_EXECUTION_TOKEN_HEADER] = \
+            ctx.execution_token
     except NotInContext:
-        headers[constants.CLOUDIFY_TOKEN_AUTHENTICATION_HEADER] = \
-            workflow_ctx.rest_token
+        headers[constants.CLOUDIFY_EXECUTION_TOKEN_HEADER] = \
+            workflow_ctx.execution_token
 
     for next_url in base_urls:
         url = '{0}/{1}'.format(next_url.rstrip('/'), resource_path.lstrip('/'))

--- a/cloudify_rest_client/executions.py
+++ b/cloudify_rest_client/executions.py
@@ -306,3 +306,16 @@ class ExecutionsClient(object):
                                  data={'action': action},
                                  expected_status_code=200)
         return self._wrapper_cls(response)
+
+    def requeue(self, execution_id):
+        """
+        Requeue an execution (e.g. after snapshot restore).
+
+        :param execution_id: Id of the execution to be requeued.
+        :return: Requeued execution.
+        """
+        uri = '/{self._uri_prefix}/{id}'.format(self=self, id=execution_id)
+        response = self.api.post(uri,
+                                 data={'action': 'requeue'},
+                                 expected_status_code=200)
+        return self._wrapper_cls(response)


### PR DESCRIPTION
Properly restore scheduled executions from snapshots.  Add `requeue` action for reinserting executions to execution queue after snapshot restoration.

This is a dc9fa569 commit cherry-picked for `5.0.5-ms` branch.