### PR TITLE
test-reqs: pin testtools version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 mock>=1.0.1
-testtools
+testtools==2.3.0
 pytest
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
march 14 2020, testtools 2.4.0 was released, which drops py2.6 compat
pin to 2.3.0 which is the last 2.6-compatible version
