### PR TITLE
response.sort: stop supporting cmp=

### DIFF
--- a/cloudify_rest_client/responses.py
+++ b/cloudify_rest_client/responses.py
@@ -73,4 +73,6 @@ class ListResponse(object):
         return len(self.items)
 
     def sort(self, cmp=None, key=None, reverse=False):
-        return self.items.sort(cmp, key, reverse)
+        if cmp is not None:
+            raise TypeError('cmp is not supported. Use key instead.')
+        return self.items.sort(key=key, reverse=reverse)


### PR DESCRIPTION
It's not there in py3 anymore, and we don't use it

We could just as well use functools.cmp_to_key but it's rare enough
that I don't want to pay the performance cost without alerting the
caller. But I'm open to having my mind changed on this later.

It needs to be a typerror like that, and not just removing the arg,
because cmp is the first arg, so a call like `.sort(f) would then
silently change f from being cmp to being key :(

To be dropped entirely in 5.2