### PR TITLE
crypto_utils: work with unicode

### DIFF
--- a/cloudify/cryptography_utils.py
+++ b/cloudify/cryptography_utils.py
@@ -24,26 +24,45 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from cloudify.constants import SECURITY_FILE_LOCATION
 
+# encryption-related functions work in terms of accepting and returning
+# unicode. Returning encrypted data as unicode is not very "pure", but
+# it is more useful to handle; fernet returns base64-encoded data, so
+# it is always possible to decode it
+
 
 def encrypt(data, key=None):
+    """Encrypt the data using the given key.
+
+    :param data: unicode string to be encrypted
+    :param key: encryption key - 64 url-safe base64-encoded bytes; if
+                not provided, use the restservice config key
+    :return: ciphertext, as unicode string
+    """
     key = key or _get_encryption_key()
-    fernet = Fernet256(str(key))
-    return fernet.encrypt(bytes(data))
+    fernet = Fernet256(key)
+    return fernet.encrypt(data.encode('utf-8')).decode('utf-8')
 
 
 def decrypt(encrypted_data, key=None):
+    """Decrypt the ciphertext using the given key.
+
+    :param data: ciphertext, as unicode string
+    :param key: encryption key - 64 url-safe base64-encoded bytes; if
+                not provided, use the restservice config key
+    :return: decrypted data, as unicode script
+    """
     key = key or _get_encryption_key()
     try:
-        fernet = Fernet256(str(key))
+        fernet = Fernet256(key)
     except ValueError:
         return decrypt128(encrypted_data, key)
-    return fernet.decrypt(bytes(encrypted_data))
+    return fernet.decrypt(encrypted_data.encode('utf-8')).decode('utf-8')
 
 
 def decrypt128(encrypted_data, key=None):
     key = key or _get_encryption_key()
-    fernet = Fernet(str(key))
-    return fernet.decrypt(bytes(encrypted_data))
+    fernet = Fernet(key)
+    return fernet.decrypt(encrypted_data.encode('utf-8')).decode('utf-8')
 
 
 def _get_encryption_key():
@@ -53,10 +72,10 @@ def _get_encryption_key():
     # solution until we will have dynamic configuration mechanism
     with open(SECURITY_FILE_LOCATION) as security_conf_file:
         rest_security_conf = json.load(security_conf_file)
-        return rest_security_conf['encryption_key']
+    return rest_security_conf['encryption_key'].encode('utf-8')
 
 
-def generate_key_using_password(password, salt='salt_'):
+def generate_key_using_password(password, salt=b'salt_'):
     password = password.encode()
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),


### PR DESCRIPTION
It would be more pure to use bytes, but examining usage sites,
they all want to deal with unicode, so it's more useful to do it
like this