### PR TITLE
CY-2313 Use blueprint detatype default values

### DIFF
--- a/dsl_parser/tasks.py
+++ b/dsl_parser/tasks.py
@@ -73,8 +73,9 @@ def _set_plan_inputs(plan, inputs=None):
         if not input_is_missing:
             constraints.validate_input_value(
                 input_name, input_constraints, inputs[input_name])
+            inputs_complete = inputs[input_name]
             try:
-                utils.parse_value(
+                inputs_complete = utils.parse_value(
                     value=inputs[input_name],
                     type_name=input_def.get(TYPE, None),
                     data_types=plan.get(DATA_TYPES, {}),
@@ -91,6 +92,7 @@ def _set_plan_inputs(plan, inputs=None):
                 raise exceptions.DSLParsingException(
                     exceptions.ERROR_INPUT_VIOLATES_DATA_TYPE_SCHEMA,
                     str(e))
+            inputs[input_name] = inputs_complete
 
     if missing_inputs:
         raise exceptions.MissingRequiredInputError(

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -1098,6 +1098,54 @@ inputs:
             ERROR_UNKNOWN_TYPE,
             message_regex='Illegal type name')
 
+    def test_input_type_default_value(self):
+        yaml = """
+inputs:
+  inp1:
+    type: dtype1
+
+data_types:
+  dtype1:
+    properties:
+      p1:
+        type: string
+        default: default_p1
+      p2:
+        type: string
+"""
+        parsed = self.parse_1_3(yaml)
+        self.assertEqual(1, len(parsed[consts.INPUTS]))
+        plan = prepare_deployment_plan(
+            parsed,
+            inputs={'inp1': {'p2': 'b'}})
+        self.assertEqual(2, len(plan[consts.INPUTS]['inp1']))
+        self.assertEqual('default_p1', plan[consts.INPUTS]['inp1']['p1'])
+        self.assertEqual('b', plan[consts.INPUTS]['inp1']['p2'])
+
+    def test_input_type_default_value_overwrite(self):
+        yaml = """
+inputs:
+  inp1:
+    type: dtype1
+
+data_types:
+  dtype1:
+    properties:
+      p1:
+        type: string
+        default: default_p1
+      p2:
+        type: string
+"""
+        parsed = self.parse_1_3(yaml)
+        self.assertEqual(1, len(parsed[consts.INPUTS]))
+        plan = prepare_deployment_plan(
+            parsed,
+            inputs={'inp1': {'p1': 'a', 'p2': 'b'}})
+        self.assertEqual(2, len(plan[consts.INPUTS]['inp1']))
+        self.assertEqual('a', plan[consts.INPUTS]['inp1']['p1'])
+        self.assertEqual('b', plan[consts.INPUTS]['inp1']['p2'])
+
     def test_validate_regex_value_successful(self):
         self._test_validate_value_successful(
             'regex', '^$', '^.$', self.assertEqual)


### PR DESCRIPTION
When using datatype that has default values, in a blueprint and overwriting
only part of the properties in an input file, the other properties were
missing from the node properties.

This patch fixes that issue by using parsed input's value instead of
original one.