### PR TITLE
CY-2314 Rollback started dep-mods on scale_entity

### DIFF
--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -493,7 +493,7 @@ def _abort_started_deployment_modifications(ctx, ignore_failure):
     graph = ctx.graph_mode()
     for modification in started_modifications:
         ctx.logger.info('Rolling back deployment modification. '
-                        '[modification_id={0}]'.format(modification.id))
+                        '[modification_id=%s]', modification.id)
         added_and_related = set(modification.added.node_instances)
         added = set(i for i in added_and_related
                     if i.modification == 'added')

--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -287,6 +287,7 @@ def scale_entity(ctx,
                  include_instances=None,
                  exclude_instances=None,
                  rollback_if_failed=True,
+                 abort_started=False,
                  **kwargs):
     """Scales in/out the subgraph of node_or_group_name.
 
@@ -314,7 +315,10 @@ def scale_entity(ctx,
     :param include_instances: Instances to include when scaling down
     :param exclude_instances: Instances to exclude when scaling down
     :param rollback_if_failed: when False, no rollback will be triggered.
+    :param abort_started: Remove any started deployment modifications
+                          created prior to this scaling workflow
     """
+
     include_instances = include_instances or []
     exclude_instances = exclude_instances or []
     if not isinstance(include_instances, list):
@@ -381,6 +385,10 @@ def scale_entity(ctx,
                          .format(delta,
                                  scalable_entity_name,
                                  curr_num_instances))
+
+    if abort_started:
+        _abort_started_deployment_modifications(ctx, ignore_failure)
+
     modification = ctx.deployment.start_modification({
         scale_id: {
             'instances': planned_num_instances,
@@ -474,6 +482,30 @@ def scale_entity(ctx,
                             '[modification_id={0}]'.format(modification.id))
             raise
 
+
+def _abort_started_deployment_modifications(ctx, ignore_failure):
+    """Aborts any started deployment modifications running in this context.
+
+    :param ctx: cloudify context
+    :param ignore_failure: ignore operations failures in uninstall workflow
+    """
+    started_modifications = ctx.deployment.list_started_modifications()
+    graph = ctx.graph_mode()
+    for modification in started_modifications:
+        ctx.logger.info('Rolling back deployment modification. '
+                        '[modification_id={0}]'.format(modification.id))
+        added_and_related = set(modification.added.node_instances)
+        added = set(i for i in added_and_related
+                    if i.modification == 'added')
+        related = added_and_related - added
+        if added:
+            lifecycle.uninstall_node_instances(
+                graph=graph,
+                node_instances=added,
+                ignore_failure=ignore_failure,
+                related_nodes=related,
+            )
+        modification.rollback()
 
 # Kept for backward compatibility with older versions of types.yaml
 @workflow

--- a/cloudify/tests/resources/blueprints/test-scale-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/test-scale-blueprint.yaml
@@ -21,6 +21,8 @@ workflows:
         default: 1
       scale_compute:
         default: false
+      abort_started:
+        default: false
 
   scale_old:
     mapping: plugin.cloudify.plugins.workflows.scale

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -25,7 +25,8 @@ from cloudify import exceptions
 from cloudify.plugins import lifecycle
 from cloudify.decorators import operation
 from cloudify.test_utils import workflow_test
-from cloudify.workflows.workflow_context import WorkflowDeploymentContext
+from cloudify.workflows.workflow_context import (Modification,
+                                                 WorkflowDeploymentContext)
 
 
 class GlobalCounter(object):
@@ -412,12 +413,8 @@ class TestScale(testtools.TestCase):
 
     @workflow_test(scale_blueprint_path)
     def test_valid_delta(self, cfy_local):
-        modification = mock.MagicMock(
-            'cloudify.workflows.workflow_context.Modification')
+        modification = mock.MagicMock(Modification)
         modification.id = 'dd8aa09e-035e-4f38-84df-bb2361d55efb'
-        modification.rollback = mock.MagicMock()
-        modification.finish = mock.MagicMock()
-        modification.added = mock.MagicMock()
         with mock.patch.object(WorkflowDeploymentContext,
                                'list_started_modifications',
                                return_value=None) as list_mock:
@@ -440,12 +437,8 @@ class TestScale(testtools.TestCase):
 
     @workflow_test(scale_blueprint_path)
     def test_abort_started(self, cfy_local):
-        modification = mock.MagicMock(
-            'cloudify.workflows.workflow_context.Modification')
+        modification = mock.MagicMock(Modification)
         modification.id = 'dd8aa09e-035e-4f38-84df-bb2361d55efb'
-        modification.rollback = mock.MagicMock()
-        modification.finish = mock.MagicMock()
-        modification.added = mock.MagicMock()
         with mock.patch.object(WorkflowDeploymentContext,
                                'list_started_modifications',
                                return_value=[modification]) as list_mock:

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -57,6 +57,7 @@ from cloudify.logs import (CloudifyWorkflowLoggingHandler,
                            init_cloudify_logger,
                            send_workflow_event,
                            send_sys_wide_wf_event)
+from cloudify.models_states import DeploymentModificationState
 
 from cloudify.utils import is_agent_alive
 
@@ -1223,6 +1224,9 @@ class CloudifyWorkflowContextHandler(object):
     def rollback_deployment_modification(self, modification):
         raise NotImplementedError('Implemented by subclasses')
 
+    def list_deployment_modifications(self, status):
+        raise NotImplementedError('Implemented by subclasses')
+
     def scaling_groups(self):
         raise NotImplementedError('Implemented by subclasses')
 
@@ -1514,6 +1518,14 @@ class RemoteCloudifyWorkflowContextHandler(RemoteContextHandler):
         client = get_rest_client()
         client.deployment_modifications.rollback(modification.id)
 
+    def list_deployment_modifications(self, status):
+        deployment_id = self.workflow_ctx.deployment.id
+        client = get_rest_client()
+        modifications = client.deployment_modifications.list(
+            deployment_id=deployment_id,
+            status=status)
+        return [Modification(self.workflow_ctx, m) for m in modifications]
+
     def send_workflow_event(self, event_type, message=None, args=None,
                             additional_context=None):
         send_workflow_event(self.workflow_ctx,
@@ -1708,6 +1720,16 @@ class WorkflowDeploymentContext(context.DeploymentContext):
         """
         handler = self.workflow_ctx.internal.handler
         return handler.start_deployment_modification(nodes)
+
+    def list_started_modifications(self):
+        """List modifications already started (and not finished)
+
+        :return: A list of workflow modification wrappers
+        :rtype: list of Modification
+        """
+        handler = self.workflow_ctx.internal.handler
+        return handler.list_deployment_modifications(
+            DeploymentModificationState.STARTED)
 
     @property
     def scaling_groups(self):


### PR DESCRIPTION
Enable rollback of started (stalled) deployment modifications before
scaling workflow