### PR TITLE
dsl_parser error handling: don't die on None start_line

### DIFF
--- a/dsl_parser/framework/elements.py
+++ b/dsl_parser/framework/elements.py
@@ -106,7 +106,7 @@ class Element(object):
             message.write('\n  in line: {0}, column: {1}'
                           .format(self.name_start_line + 1,
                                   self.name_start_column))
-        elif self.start_line >= 0:
+        elif self.start_line is not None and self.start_line >= 0:
             message.write('\n  in line {0}, column {1}'
                           .format(self.start_line + 1, self.start_column))
         message.write('\n  path: {0}'.format(self.path))


### PR DESCRIPTION
start_line is None in case of a very malformed blueprint, and in that case,
we can't compare that to 0