### PR TITLE
blueprint upload: dereference links

### DIFF
--- a/cloudify_rest_client/utils.py
+++ b/cloudify_rest_client/utils.py
@@ -45,7 +45,7 @@ def tar_file(file_to_tar, destination_dir, tar_name=''):
 
     tar_name = tar_name or os.path.basename(file_to_tar)
     tar_path = os.path.join(destination_dir, '{0}.tar.gz'.format(tar_name))
-    with tarfile.open(tar_path, "w:gz") as tar:
+    with tarfile.open(tar_path, "w:gz", dereference=True) as tar:
         tar.add(file_to_tar, arcname=tar_name, filter=_reset_tarinfo)
     return tar_path
 


### PR DESCRIPTION
When creating a tar archive for a blueprint, add the files pointed-to by links,
instead of adding links