### PR TITLE
CY-2698 Allow Unicode in Cloudify logs

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -477,7 +477,7 @@ class SendHandler(object):
         log_func = getattr(self.logger, level, self.logger.info)
         exec_id = message.get('context', {}).get('execution_id')
         text = message['message']['text']
-        msg = '[{0}] {1}'.format(exec_id, text) if exec_id else text
+        msg = u'[{0}] {1}'.format(exec_id, text) if exec_id else text
         log_func(msg)
 
     def publish(self, message, **kwargs):

--- a/cloudify/event.py
+++ b/cloudify/event.py
@@ -37,7 +37,7 @@ class Event(object):
         if info:  # spacing in between of the info and the message
             info += ' '
 
-        return '{0}  {1} {2} {3}{4}'.format(
+        return u'{0}  {1} {2} {3}{4}'.format(
             printable_timestamp,
             event_type_indicator,
             deployment_id,
@@ -77,7 +77,7 @@ class Event(object):
     def text(self):
         message = self._event['message']['text']
         if self.is_log_message:
-            message = '{0}: {1}'.format(self.log_level, message)
+            message = u'{0}: {1}'.format(self.log_level, message)
         elif (self.event_type in ('task_rescheduled', 'task_failed')):
             causes = self._event['context'].get('task_error_causes', [])
             if causes:
@@ -90,7 +90,7 @@ class Event(object):
                         causes_out.write('{0}\n'.format('-' * 32))
                     causes_out.write(cause.get('traceback', ''))
 
-                message = '{0}\n{1}'.format(message, causes_out.getvalue())
+                message = u'{0}\n{1}'.format(message, causes_out.getvalue())
         return message
 
     @property

--- a/cloudify/logs.py
+++ b/cloudify/logs.py
@@ -30,6 +30,7 @@ from cloudify.utils import (is_management_environment,
                             ENV_AGENT_LOG_MAX_BYTES,
                             ENV_AGENT_LOG_MAX_HISTORY)
 from cloudify.exceptions import ClosedAMQPClientException
+from cloudify._compat import text_type
 
 EVENT_CLASS = _event.Event
 EVENT_VERBOSITY_LEVEL = _event.NO_VERBOSE
@@ -346,7 +347,7 @@ def create_event_message_prefix(event):
     event_obj = EVENT_CLASS(event, verbosity_level=EVENT_VERBOSITY_LEVEL)
     if not event_obj.has_output:
         return None
-    return str(event_obj)
+    return text_type(event_obj)
 
 
 def with_amqp_client(func):

--- a/cloudify/tests/test_event.py
+++ b/cloudify/tests/test_event.py
@@ -1,3 +1,4 @@
+# This Python file uses the following encoding: utf-8
 ########
 # Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
 #
@@ -19,6 +20,7 @@ import testtools
 
 from cloudify import utils
 from cloudify import event
+from cloudify._compat import text_type
 
 
 class TestEvent(testtools.TestCase):
@@ -91,10 +93,27 @@ class TestEvent(testtools.TestCase):
         self.assertIn('Causes (most recent cause last):', text)
         self.assertEqual(2, text.count(causes[0]['traceback']))
 
+    def test_event_unicode_event(self):
+        test_event = _event('cloudify_event', level='INFO',
+                            message=u'אני אבחן אותך ביסודיות',
+                            deployment_id='b44a008f-a8fa-4790-xyz',
+                            timestamp='NOW')
+        self.assertIn(u'אני אבחן אותך ביסודיות', text_type(test_event))
+
+    def test_event_unicode_log(self):
+        test_event = _event('cloudify_log', level='DEBUG',
+                            message=u'אני אבחן אותך ביסודיות',
+                            deployment_id='64be2ce0-93c5-453e-qwe',
+                            timestamp='THEN')
+        self.assertIn(u'אני אבחן אותך ביסודיות', text_type(test_event))
+
 
 def _event(type, event_type=None, level=None, message=None,
-           causes=None, verbosity_level=event.NO_VERBOSE):
+           causes=None, verbosity_level=event.NO_VERBOSE, deployment_id=None,
+           timestamp=None):
     result = {'type': type, 'context': {}}
+    if deployment_id:
+        result['context']['deployment_id'] = deployment_id
     if event_type:
         result['event_type'] = event_type
     if level:
@@ -103,4 +122,6 @@ def _event(type, event_type=None, level=None, message=None,
         result['message'] = {'text': message}
     if causes:
         result['context']['task_error_causes'] = causes
+    if timestamp:
+        result['timestamp'] = timestamp
     return event.Event(result, verbosity_level=verbosity_level)

--- a/cloudify/tests/test_logs.py
+++ b/cloudify/tests/test_logs.py
@@ -1,3 +1,4 @@
+# This Python file uses the following encoding: utf-8
 ########
 # Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
 #
@@ -27,5 +28,16 @@ class TestLogs(testtools.TestCase):
                       'timestamp': '',
                       'message': {'text': 'message'}}
         self.assertIn('message', logs.create_event_message_prefix(test_event))
+        test_event['level'] = 'DEBUG'
+        self.assertIsNone(logs.create_event_message_prefix(test_event))
+
+    def test_create_event_message_prefix_unicode(self):
+        test_event = {'type': 'cloudify_log',
+                      'level': 'INFO',
+                      'context': {'deployment_id': ''},
+                      'timestamp': '',
+                      'message': {'text': u'Zażółć gęślą jaźń'}}
+        self.assertIn(u'Zażółć gęślą jaźń',
+                      logs.create_event_message_prefix(test_event))
         test_event['level'] = 'DEBUG'
         self.assertIsNone(logs.create_event_message_prefix(test_event))


### PR DESCRIPTION
Both database (amqp) and console logs can now handle Unicode messages.