### PR TITLE
CY-2900 start deployment modification: refresh node instances

### DIFF
--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -416,9 +416,6 @@ def scale_entity(ctx,
             # 'removed_ids_include_hint': []
         }
     })
-    # refresh node instances so that workflow_ctx.get_node_instance() can
-    # return the new node instance that were just created
-    ctx.refresh_node_instances()
     graph = ctx.graph_mode()
     try:
         ctx.logger.info('Deployment modification started. '

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1718,7 +1718,9 @@ class WorkflowDeploymentContext(context.DeploymentContext):
         :rtype: Modification
         """
         handler = self.workflow_ctx.internal.handler
-        return handler.start_deployment_modification(nodes)
+        modification = handler.start_deployment_modification(nodes)
+        self.workflow_ctx.refresh_node_instances()
+        return modification
 
     def list_started_modifications(self):
         """List modifications already started (and not finished)


### PR DESCRIPTION
In scale-like workflows (which can be custom workflows written
by the user!), it is always required to refresh node instances
after starting the scale, so that the local process gets the
newly-created node instances.

Without refreshing, it doesn't have them, and so it can't install
them.

Since it is always required, let's just make it happen automatically.