### PR TITLE
Make pysnmp optional

### DIFF
--- a/cloudify/snmp/snmp_trap.py
+++ b/cloudify/snmp/snmp_trap.py
@@ -16,18 +16,22 @@
 import time
 import json
 from calendar import timegm
-
-from pysnmp.hlapi import (SnmpEngine,
-                          ContextData,
-                          CommunityData,
-                          ObjectIdentity,
-                          NotificationType,
-                          sendNotification,
-                          UdpTransportTarget,
-                          OctetString,
-                          Counter64)
-
 from cloudify.utils import setup_logger
+
+try:
+    from pysnmp.hlapi import (SnmpEngine,
+                              ContextData,
+                              CommunityData,
+                              ObjectIdentity,
+                              NotificationType,
+                              sendNotification,
+                              UdpTransportTarget,
+                              OctetString,
+                              Counter64)
+except ImportError:
+    SNMP_AVAILABLE = False
+else:
+    SNMP_AVAILABLE = True
 
 
 # The name of our mib
@@ -61,6 +65,8 @@ notification_types = {
 
 
 def send_snmp_trap(event_context, **kwargs):
+    if not SNMP_AVAILABLE:
+        raise RuntimeError('pysnmp not available')
     notification_type = _create_notification_type(event_context)
     destination_address = kwargs['destination_address']
     destination_port = kwargs['destination_port']

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ install_requires = [
     'proxy_tools==0.1.0',
     'bottle==0.12.18',
     'jinja2>=2.10,<2.11',
-    'requests_toolbelt==0.8.0',
-    'pysnmp==4.4.5'
+    'requests_toolbelt==0.8.0'
 ]
 
 try:
@@ -69,6 +68,9 @@ setup(
         'dispatcher': [
             'PyYAML==3.12',
             'networkx==1.9.1',
+        ],
+        'snmp': [
+            'pysnmp==4.4.5'
         ]
     }
 )


### PR DESCRIPTION
It's only needed in the mgmtworker, for custom hook-called functions