### PR TITLE
CY-3015 Install plugins on first use

### DIFF
--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -543,9 +543,14 @@ class Internal(object):
     @staticmethod
     def _get_package_version(plugins_dir, package_name):
         # get all plugin dirs
-        subdirs = next(os.walk(plugins_dir))[1]
+        try:
+            subdirs = next(os.walk(plugins_dir))[1]
+        except StopIteration:
+            return
         # filter by package name
         package_dirs = [dir for dir in subdirs if dir.startswith(package_name)]
+        if not package_dirs:
+            return
         # cut package name prefix
         versions = [dir[len(package_name) + 1:] for dir in package_dirs]
         # return the latest version

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -620,7 +620,8 @@ class _WorkflowContextBase(object):
                 'package_name': plugin.get('package_name'),
                 'package_version': plugin.get('package_version'),
                 'visibility': plugin.get('visibility'),
-                'tenant_name': plugin.get('tenant_name')
+                'tenant_name': plugin.get('tenant_name'),
+                'source': plugin.get('source')
             },
             'operation': {
                 'name': operation,


### PR DESCRIPTION
When running an operation, check if the plugin is installed,
and if it's not - install it then.

This is as opposed to the previous approach of always installing
plugins up-front.

Also, pass through the plugin source to operations.