### PR TITLE
When checking for plugin dir, check for the marker file as well

### DIFF
--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -291,6 +291,8 @@ class PluginContextTests(testtools.TestCase):
             '{0}-{1}'.format(self.plugin_pacakge_name,
                              self.plugin_pacakge_version))
         os.makedirs(expected_prefix)
+        with open(os.path.join(expected_prefix, 'plugin.id'), 'w') as f:
+            f.write('plugin id')
         with patch('sys.prefix', self.test_prefix):
             self.assertEqual(self.ctx.plugin.prefix, expected_prefix)
 
@@ -302,6 +304,8 @@ class PluginContextTests(testtools.TestCase):
             '{0}-{1}'.format(self.deployment_id,
                              self.plugin_name))
         os.makedirs(expected_prefix)
+        with open(os.path.join(expected_prefix, 'plugin.id'), 'w') as f:
+            f.write('plugin id')
         with patch('sys.prefix', self.test_prefix):
             self.assertEqual(self.ctx.plugin.prefix, expected_prefix)
 

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -561,6 +561,12 @@ class Internal(object):
         return newest
 
     @staticmethod
+    def _is_plugin_dir(path):
+        """Is the given path a directory containing a plugin?"""
+        return (os.path.isdir(path) and
+                os.path.exists(os.path.join(path, 'plugin.id')))
+
+    @staticmethod
     def plugin_prefix(package_name=None, package_version=None,
                       deployment_id=None, plugin_name=None, tenant_name=None,
                       sys_prefix_fallback=True):
@@ -572,12 +578,12 @@ class Internal(object):
                 plugins_dir, package_name)
             wagon_dir = os.path.join(
                 plugins_dir, '{0}-{1}'.format(package_name, package_version))
-            if os.path.isdir(wagon_dir):
+            if Internal._is_plugin_dir(wagon_dir):
                 prefix = wagon_dir
         if prefix is None and deployment_id and plugin_name:
             source_dir = os.path.join(
                 plugins_dir, '{0}-{1}'.format(deployment_id, plugin_name))
-            if os.path.isdir(source_dir):
+            if Internal._is_plugin_dir(source_dir):
                 prefix = source_dir
         if prefix is None and sys_prefix_fallback:
             prefix = sys.prefix


### PR DESCRIPTION
Instead of just checking .isdir, also look for the plugin.id file.
Otherwise it will be just a directory and not a directory containing
a plugin.

In practice, it will be a plugin that is not fully installed yet,
so we should go to the installer, which will do the locking-and-waiting
dance.