### PR TITLE
Refactor utils.plugin_prefix

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -1109,13 +1109,11 @@ class PluginContext(str):
     @property
     def prefix(self):
         """The plugin prefix."""
-        return utils.internal.plugin_prefix(
-            package_name=self.package_name,
-            package_version=self.package_version,
+        return utils.plugin_prefix(
+            name=self.package_name,
+            version=self.package_version,
             deployment_id=self._deployment_id,
-            plugin_name=self.name,
-            tenant_name=self._tenant_name,
-            sys_prefix_fallback=True)
+            tenant_name=self._tenant_name)
 
     @property
     def workdir(self):

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -259,8 +259,8 @@ class PluginContextTests(testtools.TestCase):
     def setUp(self):
         super(PluginContextTests, self).setUp()
         self.plugin_name = 'test_plugin'
-        self.plugin_pacakge_name = 'test-plugin'
-        self.plugin_pacakge_version = '0.1.1'
+        self.plugin_package_name = 'test-plugin'
+        self.plugin_package_version = '0.1.1'
         self.deployment_id = 'test_deployment'
         self.tenant_name = 'default_tenant'
         self.ctx = context.CloudifyContext({
@@ -268,8 +268,8 @@ class PluginContextTests(testtools.TestCase):
             'tenant': {'name': self.tenant_name},
             'plugin': {
                 'name': self.plugin_name,
-                'package_name': self.plugin_pacakge_name,
-                'package_version': self.plugin_pacakge_version
+                'package_name': self.plugin_package_name,
+                'package_version': self.plugin_package_version
             }
         })
         self.test_prefix = tempfile.mkdtemp(prefix='context-plugin-test-')
@@ -279,17 +279,17 @@ class PluginContextTests(testtools.TestCase):
     def test_attributes(self):
         self.assertEqual(self.ctx.plugin.name, self.plugin_name)
         self.assertEqual(self.ctx.plugin.package_name,
-                         self.plugin_pacakge_name)
+                         self.plugin_package_name)
         self.assertEqual(self.ctx.plugin.package_version,
-                         self.plugin_pacakge_version)
+                         self.plugin_package_version)
 
     def test_prefix_from_wagon(self):
         expected_prefix = os.path.join(
             self.test_prefix,
             'plugins',
             self.tenant_name,
-            self.plugin_pacakge_name,
-            self.plugin_pacakge_version)
+            self.plugin_package_name,
+            self.plugin_package_version)
         os.makedirs(expected_prefix)
         with open(os.path.join(expected_prefix, 'plugin.id'), 'w') as f:
             f.write('plugin id')
@@ -302,8 +302,8 @@ class PluginContextTests(testtools.TestCase):
             'source_plugins',
             self.tenant_name,
             self.deployment_id,
-            self.plugin_pacakge_name,
-            self.plugin_pacakge_version)
+            self.plugin_package_name,
+            self.plugin_package_version)
         os.makedirs(expected_prefix)
         with open(os.path.join(expected_prefix, 'plugin.id'), 'w') as f:
             f.write('plugin id')

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -288,8 +288,8 @@ class PluginContextTests(testtools.TestCase):
             self.test_prefix,
             'plugins',
             self.tenant_name,
-            '{0}-{1}'.format(self.plugin_pacakge_name,
-                             self.plugin_pacakge_version))
+            self.plugin_pacakge_name,
+            self.plugin_pacakge_version)
         os.makedirs(expected_prefix)
         with open(os.path.join(expected_prefix, 'plugin.id'), 'w') as f:
             f.write('plugin id')
@@ -299,18 +299,16 @@ class PluginContextTests(testtools.TestCase):
     def test_prefix_from_source(self):
         expected_prefix = os.path.join(
             self.test_prefix,
-            'plugins',
+            'source_plugins',
             self.tenant_name,
-            '{0}-{1}'.format(self.deployment_id,
-                             self.plugin_name))
+            self.deployment_id,
+            self.plugin_pacakge_name,
+            self.plugin_pacakge_version)
         os.makedirs(expected_prefix)
         with open(os.path.join(expected_prefix, 'plugin.id'), 'w') as f:
             f.write('plugin id')
         with patch('sys.prefix', self.test_prefix):
             self.assertEqual(self.ctx.plugin.prefix, expected_prefix)
-
-    def test_fallback_prefix(self):
-        self.assertEqual(self.ctx.plugin.prefix, sys.prefix)
 
 
 class GetResourceTemplateTests(testtools.TestCase):

--- a/cloudify/tests/test_local_workflows.py
+++ b/cloudify/tests/test_local_workflows.py
@@ -755,7 +755,6 @@ class LocalWorkflowTest(BaseWorkflowTest):
             self.assertEqual(PLUGIN_PACKAGE_NAME, ctx.plugin.package_name)
             self.assertEqual(PLUGIN_PACKAGE_VERSION,
                              ctx.plugin.package_version)
-            self.assertEqual(sys.prefix, ctx.plugin.prefix)
             self.assertEqual('test.op0', ctx.operation.name)
             self.assertEqual(ctx.node.properties.get('property'), 'value'),
             self.assertEqual(b'content', ctx.get_resource('resource'))

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -535,61 +535,6 @@ class Internal(object):
         return broker_user, broker_pass, broker_vhost
 
     @staticmethod
-    def _get_formatted_version(version):
-        try:
-            return StrictVersion(version)
-        except ValueError:
-            return None
-
-    @staticmethod
-    def _get_package_version(plugins_dir, package_name):
-        # get all plugin dirs
-        try:
-            subdirs = next(os.walk(plugins_dir))[1]
-        except StopIteration:
-            return
-        # filter by package name
-        package_dirs = [dir for dir in subdirs if dir.startswith(package_name)]
-        if not package_dirs:
-            return
-        # cut package name prefix
-        versions = [dir[len(package_name) + 1:] for dir in package_dirs]
-        # return the latest version
-        newest = max(versions, key=Internal._get_formatted_version)
-        if Internal._get_formatted_version(newest) is None:
-            return
-        return newest
-
-    @staticmethod
-    def _is_plugin_dir(path):
-        """Is the given path a directory containing a plugin?"""
-        return (os.path.isdir(path) and
-                os.path.exists(os.path.join(path, 'plugin.id')))
-
-    @staticmethod
-    def plugin_prefix(package_name=None, package_version=None,
-                      deployment_id=None, plugin_name=None, tenant_name=None,
-                      sys_prefix_fallback=True):
-        tenant_name = tenant_name or ''
-        plugins_dir = os.path.join(sys.prefix, 'plugins', tenant_name)
-        prefix = None
-        if package_name:
-            package_version = package_version or Internal._get_package_version(
-                plugins_dir, package_name)
-            wagon_dir = os.path.join(
-                plugins_dir, '{0}-{1}'.format(package_name, package_version))
-            if Internal._is_plugin_dir(wagon_dir):
-                prefix = wagon_dir
-        if prefix is None and deployment_id and plugin_name:
-            source_dir = os.path.join(
-                plugins_dir, '{0}-{1}'.format(deployment_id, plugin_name))
-            if Internal._is_plugin_dir(source_dir):
-                prefix = source_dir
-        if prefix is None and sys_prefix_fallback:
-            prefix = sys.prefix
-        return prefix
-
-    @staticmethod
     @contextmanager
     def _change_tenant(ctx, tenant):
         """
@@ -852,3 +797,61 @@ def get_python_path(venv):
         'python.exe' if os.name == 'nt' else 'python',
         venv=venv
     )
+
+
+def _get_formatted_version(version):
+    """StrictVersion, but None instead of a ValueError"""
+    try:
+        return StrictVersion(version)
+    except ValueError:
+        return None
+
+
+def _find_versioned_plugin_dir(base_dir, version):
+    """In base_dir, find a subdirectory containing the version, or the newest.
+
+    If version is not None, the plugin directory is base_dir+version.
+    If version is None, then the plugin directory is the highest version
+    from base_dir.
+
+    For example, say base_dir contains the subdirectories: 1.0.0, 2.0.0:
+    >>> _find_versioned_plugin_dir('/plugins', None)
+    /plugins/2.0.0
+    >>> _find_versioned_plugin_dir('/plugins', '1.0.0')
+    /plugins/1.0.0
+    >>> _find_versioned_plugin_dir('/plugins', '3.0.0')
+    None
+    """
+    if not os.path.isdir(base_dir):
+        return
+    if version:
+        found = os.path.join(base_dir, version)
+    else:
+        available_versions = [
+            (d, _get_formatted_version(d))
+            for d in os.listdir(base_dir)
+            if _get_formatted_version(d) is not None
+        ]
+        if not available_versions:
+            return
+        newest = max(available_versions, key=lambda pair: pair[1])[0]
+        found = os.path.join(base_dir, newest)
+    if not os.path.isdir(found):
+        return
+    return found
+
+
+def plugin_prefix(name, tenant_name, version=None, deployment_id=None):
+    """Virtualenv for the specified plugin.
+
+    If version is not provided, the highest version is used.
+    """
+    managed_plugin_dir = os.path.join(
+        sys.prefix, 'plugins', tenant_name, name)
+    prefix = _find_versioned_plugin_dir(managed_plugin_dir, version)
+    if prefix is None and deployment_id is not None:
+        source_plugin_dir = os.path.join(
+            sys.prefix, 'source_plugins', tenant_name, deployment_id, name)
+        prefix = _find_versioned_plugin_dir(
+            source_plugin_dir, version)
+    return prefix

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -878,13 +878,15 @@ def plugin_prefix(name, tenant_name, version=None, deployment_id=None):
 # by plugin_prefix
 def target_plugin_prefix(name, tenant_name, version=None, deployment_id=None):
     """Target directory into which the plugin should be installed"""
-    target_dir = os.path.join(
-        sys.prefix, 'source_plugins' if deployment_id else 'plugins')
+    parts = [
+        sys.prefix,
+        'source_plugins' if deployment_id else 'plugins'
+    ]
     if tenant_name:
-        target_dir = os.path.join(target_dir, tenant_name)
+        parts.append(tenant_name)
     if deployment_id:
-        target_dir = os.path.join(target_dir, deployment_id)
+        parts.append(deployment_id)
     # if version is not given, default to 0.0.0 so that version that _are_
     # declared always take precedence
-    target_dir = os.path.join(target_dir, name, version or '0.0.0')
-    return target_dir
+    parts += [name, version or '0.0.0']
+    return os.path.join(*parts)

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -845,13 +845,29 @@ def plugin_prefix(name, tenant_name, version=None, deployment_id=None):
     """Virtualenv for the specified plugin.
 
     If version is not provided, the highest version is used.
+
+    :param name: package name of the plugin
+    :param tenant_name: tenant name, or None for local executions
+    :param version: version of the plugin, or None for the newest version
+    :param deployment_id: deployment id, for source plugins
+    :return: directory containing the plugin virtualenv, or None
     """
-    managed_plugin_dir = os.path.join(
-        sys.prefix, 'plugins', tenant_name, name)
+    managed_plugin_dir = os.path.join(sys.prefix, 'plugins')
+    if tenant_name:
+        managed_plugin_dir = os.path.join(
+            managed_plugin_dir, tenant_name, name)
+    else:
+        managed_plugin_dir = os.path.join(managed_plugin_dir, name)
+
     prefix = _find_versioned_plugin_dir(managed_plugin_dir, version)
     if prefix is None and deployment_id is not None:
-        source_plugin_dir = os.path.join(
-            sys.prefix, 'source_plugins', tenant_name, deployment_id, name)
+        source_plugin_dir = os.path.join(sys.prefix, 'source_plugins')
+        if tenant_name:
+            source_plugin_dir = os.path.join(
+                source_plugin_dir, tenant_name, deployment_id, name)
+        else:
+            source_plugin_dir = os.path.join(
+                source_plugin_dir, deployment_id, name)
         prefix = _find_versioned_plugin_dir(
             source_plugin_dir, version)
     return prefix

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -871,3 +871,20 @@ def plugin_prefix(name, tenant_name, version=None, deployment_id=None):
         prefix = _find_versioned_plugin_dir(
             source_plugin_dir, version)
     return prefix
+
+
+# this function must be kept in sync with the above plugin_prefix,
+# so that the target directory created by this, can be then found
+# by plugin_prefix
+def target_plugin_prefix(name, tenant_name, version=None, deployment_id=None):
+    """Target directory into which the plugin should be installed"""
+    target_dir = os.path.join(
+        sys.prefix, 'source_plugins' if deployment_id else 'plugins')
+    if tenant_name:
+        target_dir = os.path.join(target_dir, tenant_name)
+    if deployment_id:
+        target_dir = os.path.join(target_dir, deployment_id)
+    # if version is not given, default to 0.0.0 so that version that _are_
+    # declared always take precedence
+    target_dir = os.path.join(target_dir, name, version or '0.0.0')
+    return target_dir


### PR DESCRIPTION
This makes getting the plugin directory a bit simpler.

Plugins are now installed in, for managed plugins:
`/opt/mgmtworker/env/plugins/<tenant>/<plugin name>/<version>`
and for source plugins:
`/opt/mgmtworker/env/source_plugins/<tenant>/<plugin name>/<version>`

Also, visibility isn't needed, because plugins are installed for
the _using_ tenant anyway. And if visibility isn't global, then
the plugin can't be downloaded or used anyway.