### PR TITLE
get_is_bypass_maintenance: default to False

### DIFF
--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -327,7 +327,7 @@ def get_is_bypass_maintenance():
     Returns true if workflow should run in maintenance mode.
     """
     try:
-        return _get_current_context()._context.get('bypass_maintenance')
+        return _get_current_context()._context.get('bypass_maintenance', False)
     except RuntimeError:    # not in context
         return False
 


### PR DESCRIPTION
default to False, not to None. It's false in case of a missing context, why would
it not be false in case of a missing attr?

in practice, this cases many agent tests to fail, because they assert
on this being false. Which is not very smart of them, but eh.