### PR TITLE
contexts: make bypass_maintenance a public attribute

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -734,6 +734,11 @@ class CloudifyContext(CommonContext):
         return self._rest_ssl_cert
 
     @property
+    def bypass_maintenance(self):
+        """If true, all requests sent bypass maintenance mode."""
+        return self._context.get('bypass_maintenance', False)
+
+    @property
     def tenant_name(self):
         """Cloudify tenant name"""
         return self._context.get('tenant', {}).get('name')

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -327,7 +327,7 @@ def get_is_bypass_maintenance():
     Returns true if workflow should run in maintenance mode.
     """
     try:
-        return _get_current_context()._context.get('bypass_maintenance', False)
+        return _get_current_context().bypass_maintenance
     except RuntimeError:    # not in context
         return False
 

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -513,6 +513,11 @@ class _WorkflowContextBase(object):
         return self._context.get('execution_token')
 
     @property
+    def bypass_maintenance(self):
+        """If true, all requests sent bypass maintenance mode."""
+        return self._context.get('bypass_maintenance', False)
+
+    @property
     def tenant_name(self):
         """Cloudify tenant name"""
         return self.tenant.get('name')


### PR DESCRIPTION
Make this a real attribute, so that 'external' methods
(the one in utils.py) use a public attribute on the context,
instead of touching the internal ._context

This matters because quasi-contexts such as the CancelCloudifyContext
(which is used for kill-canceling) or the PluginInstallContext
(plugin force-installing) declare some attributes, and ._context
is not one of them. I want to make those quasi-contexts declare
.bypass_maintenance, I don't want to make them declare an
'internal' .context