### PR TITLE
plugin_prefix: only return valid plugin dirs

### DIFF
--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -845,9 +845,8 @@ def _find_versioned_plugin_dir(base_dir, version):
             return
         newest = max(available_versions, key=lambda pair: pair[1])[0]
         found = os.path.join(base_dir, newest)
-    if not _is_plugin_dir(found):
-        return
-    return found
+    if _is_plugin_dir(found):
+        return found
 
 
 def plugin_prefix(name, tenant_name, version=None, deployment_id=None):

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -845,7 +845,7 @@ def _find_versioned_plugin_dir(base_dir, version):
             return
         newest = max(available_versions, key=lambda pair: pair[1])[0]
         found = os.path.join(base_dir, newest)
-    if _is_plugin_dir(found):
+    if not _is_plugin_dir(found):
         return
     return found
 

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -810,6 +810,12 @@ def _get_formatted_version(version):
         return None
 
 
+def _is_plugin_dir(path):
+    """Is the given path a directory containing a plugin?"""
+    return (os.path.isdir(path) and
+            os.path.exists(os.path.join(path, 'plugin.id')))
+
+
 def _find_versioned_plugin_dir(base_dir, version):
     """In base_dir, find a subdirectory containing the version, or the newest.
 
@@ -839,7 +845,7 @@ def _find_versioned_plugin_dir(base_dir, version):
             return
         newest = max(available_versions, key=lambda pair: pair[1])[0]
         found = os.path.join(base_dir, newest)
-    if not os.path.isdir(found):
+    if _is_plugin_dir(found):
         return
     return found
 


### PR DESCRIPTION
This restores _is_plugin_dir to as it was before #512

Just checking if the dir exists is not enough because maybe the
plugin is currently being installed by another process(/thread)

The id file is created after installation is done, so only when that
exists, the plugin is done and ready to use