### PR TITLE
add agent_installer to PREINSTALLED_PLUGINS

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -76,6 +76,7 @@ PREINSTALLED_PLUGINS = [
     'default_workflows',
     'worker_installer',
     'cloudify_system_workflows',
+    'agent_installer',
 ]
 
 


### PR DESCRIPTION
That's a 3.2 (!) back-compat thing. Because that's what this was called back then.