### PR TITLE
Plugin uninstall: remove parent dir if empty

### DIFF
--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -249,6 +249,9 @@ def uninstall(plugin, deployment_id=None):
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
+    parent_dir = os.path.dirname(dst_dir)
+    if not os.listdir(parent_dir):
+        shutil.rmtree(parent_dir, ignore_errors=True)
 
 
 @contextmanager


### PR DESCRIPTION
Plugin dirs are `/opt/mgmtworker/env/plugins/<tenant>/<plugin>/<version>`
When the `<version>` dir is deleted, if this was the last one for that
plugin, also delete the `<plugin>` dir as well