### PR TITLE
CY-3237 Amqp client: reconnect on channel close

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -210,6 +210,7 @@ class AMQPConnection(object):
                 self._process_publish(out_channel)
             except (pika.exceptions.ConnectionClosed,
                     pika.exceptions.ChannelClosed) as e:
+                logger.error('Reconnecting due to: %s', e)
                 if isinstance(e, pika.exceptions.ChannelClosed):
                     self._pika_connection.close()
                 self.connect_wait.clear()


### PR DESCRIPTION
The "queue doesn't exist" would be a programming error and it
doesn't happen in normal operation. What does happen, is getting
a channel close on rabbitmq failovers, and we should just resume
operation then. By reconnecting.