### PR TITLE
CY-3419 Restore operations belonging to finished subgraphs

### DIFF
--- a/cloudify/tests/test_tasks_graph.py
+++ b/cloudify/tests/test_tasks_graph.py
@@ -18,6 +18,8 @@ import time
 import testtools
 from contextlib import contextmanager
 
+from cloudify_rest_client.operations import Operation
+
 from cloudify.workflows import api
 from cloudify.workflows import tasks
 from cloudify.workflows.tasks_graph import TaskDependencyGraph
@@ -173,3 +175,98 @@ class TestTasksGraphExecute(testtools.TestCase):
 
         self.assertFalse(task.apply_async.called)
         self.assertFalse(task.cancel.called)
+
+
+class TestTaskGraphRestore(testtools.TestCase):
+    def _remote_task(self):
+        """Make a RemoteWorkflowTask mock for use in tests"""
+        return {
+            'type': 'RemoteWorkflowTask',
+            'dependencies': [],
+            'parameters': {
+                'info': {},
+                'current_retries': 0,
+                'send_task_events': False,
+                'containing_subgraph': None,
+                'task_kwargs': {
+                    'kwargs': {
+                        '__cloudify_context': {}
+                    }
+                }
+            }
+        }
+
+    def _subgraph(self):
+        """Make a SubgraphTask mock for use in tests"""
+        return {
+            'type': 'SubgraphTask',
+            'id': 0,
+            'dependencies': [],
+            'parameters': {
+                'info': {},
+                'current_retries': 0,
+                'send_task_events': False,
+                'containing_subgraph': None,
+                'task_kwargs': {}
+            }
+        }
+
+    def _restore_graph(self, operations):
+        mock_wf_ctx = mock.Mock()
+        mock_wf_ctx.get_operations.return_value = [
+            Operation(op) for op in operations]
+        mock_retrieved_graph = mock.Mock(id=0)
+        return TaskDependencyGraph.restore(mock_wf_ctx, mock_retrieved_graph)
+
+    def test_restore_empty(self):
+        """Restoring an empty list of operations results in an empty graph"""
+        graph = self._restore_graph([])
+        operations = list(graph.tasks_iter())
+        assert operations == []
+
+    def test_restore_single(self):
+        """A single operation is restored into the graph"""
+        graph = self._restore_graph([self._remote_task()])
+        operations = list(graph.tasks_iter())
+        assert len(operations)
+        assert isinstance(operations[0], tasks.RemoteWorkflowTask)
+
+    def test_restore_finished(self):
+        """Finished tasks are not restored into the graph"""
+        task = self._remote_task()
+        task['state'] = tasks.TASK_SUCCEEDED
+        graph = self._restore_graph([task])
+        operations = list(graph.tasks_iter())
+        assert operations == []
+
+    def test_restore_with_subgraph(self):
+        """Restoring operations keeps subgraph structure"""
+        subgraph = self._subgraph()
+        task = self._remote_task()
+        subgraph['id'] = 15
+        task['parameters']['containing_subgraph'] = 15
+
+        graph = self._restore_graph([subgraph, task])
+        operations = list(graph.tasks_iter())
+        assert len(operations) == 2
+        subgraphs = [op for op in operations if op.is_subgraph]
+        remote_tasks = [op for op in operations if not op.is_subgraph]
+
+        assert len(subgraphs) == 1
+        assert len(remote_tasks) == 1
+
+        assert len(subgraphs[0].tasks) == 1
+        assert remote_tasks[0].containing_subgraph is subgraphs[0]
+
+    def test_restore_with_dependencies(self):
+        """Restoring operations keeps the dependency structure"""
+        task1 = self._remote_task()
+        task1['id'] = 1
+        task2 = self._remote_task()
+        task2['id'] = 2
+        task2['dependencies'] = [1]
+
+        graph = self._restore_graph([task1, task2])
+        operations = list(graph.tasks_iter())
+        assert len(operations) == 2
+        assert graph.graph.predecessors(1) == [2]

--- a/cloudify/tests/test_tasks_graph.py
+++ b/cloudify/tests/test_tasks_graph.py
@@ -228,7 +228,7 @@ class TestTaskGraphRestore(testtools.TestCase):
         """A single operation is restored into the graph"""
         graph = self._restore_graph([self._remote_task()])
         operations = list(graph.tasks_iter())
-        assert len(operations)
+        assert len(operations) == 1
         assert isinstance(operations[0], tasks.RemoteWorkflowTask)
 
     def test_restore_finished(self):


### PR DESCRIPTION
We have the logic that if a task is already finished, we don't restore it to the graph.

However, if the task was failed, the subgraph would've been failed as well. And when we
resumed that failed task with reset-operations, the subgraph wouldn't be part of
the graph.
This makes it so that a subgraph to which a resumed task belongs, is also going to
be resumed. Its state is reset to STARTED.

Also added a few unittests.

Note that commit 2 implements the idea, but commit 3 refactors it, so it probably
doesn't make sense to read too much into commit 2 on its own.