### PR TITLE
CY-3419 Restore graph: only restore each subgraph once

### DIFF
--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -121,7 +121,14 @@ class TaskDependencyGraph(object):
             self.add_task(op)
 
     def _restore_operation(self, op_descr):
-        """Create a Task object from a rest-client Operation object."""
+        """Create a Task object from a rest-client Operation object.
+
+        If the task was already restored before, return a reference to the
+        same object.
+        """
+        restored = self.get_task(op_descr.id)
+        if restored is not None:
+            return restored
         return OP_TYPES[op_descr.type].restore(
             self.ctx._get_current_object(), self, op_descr)
 


### PR DESCRIPTION
Every task belonging to a subgraph will go into the
`while op_descr.containing_subgraph` loop. Multiple tasks
in the same subgraph will each go there, and we must make
sure that they all get the _same_ subgraph object, as opposed
to each getting a new subgraph, which would only contain
that one task.

Putting the `if` inside of `_restore_operation` instead of
in the caller, because that function is called twice there,
so I'd have to `if` twice there.

This fixes the integration test:
agentless_tests/test_resume.py::TestResumeMgmtworker::test_nonresumable_mgmtworker_op