### PR TITLE
Plugin uninstall: don't break on missing directories

### DIFF
--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -249,9 +249,14 @@ def uninstall(plugin, deployment_id=None):
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
+
     parent_dir = os.path.dirname(dst_dir)
-    if not os.listdir(parent_dir):
-        shutil.rmtree(parent_dir, ignore_errors=True)
+    try:
+        if not os.listdir(parent_dir):
+            shutil.rmtree(parent_dir, ignore_errors=True)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
 
 
 @contextmanager


### PR DESCRIPTION
All of this code has some kind of "ignore errors" except for the
os.listdir call. Which will break when the directory doesn't exist,
when trying to uninstall a plugin which isn't installed.

Let's not break, and instead add a try/except around that listdir
as well.