### PR TITLE
CY-3455 Add workflow_ctx.download_resource

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -556,6 +556,16 @@ class _WorkflowContextBase(object):
         logging_handler = self.internal.handler.get_context_logging_handler()
         return init_cloudify_logger(logging_handler, logger_name)
 
+    def download_resource(self, resource_path, target_path=None):
+        """Downloads a blueprint/deployment resource to target_path.
+
+        This mirrors ctx.download_resource, but for workflow contexts.
+        See CloudifyContext.download_resource.
+        """
+        return self._internal.handler.download_deployment_resource(
+            resource_path=resource_path,
+            target_path=target_path)
+
     def send_event(self, event, event_type='workflow_stage',
                    args=None,
                    additional_context=None):


### PR DESCRIPTION
Similar to ctx.download_resource.

This is because we sometimes _do_ need a download_resource on the
workflow level - specifically, when installing source plugins, we'll
use download_resource, on whichever context we're in - if it's an
operation function, then CloudifyContext, but if we're in a
workflow context, because we're installing a plugin containing the
workflow function, then we'll be using a WorkflowContext. So it
needs to be defined there as well.

But in principle any workflow function code can use download_resource.
And it's surprising this feature hasn't come up before.