### PR TITLE
REST Client: handle 204 responses

### DIFF
--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -118,6 +118,8 @@ class HTTPClient(object):
         return any(header in self.headers for header in auth_headers)
 
     def _raise_client_error(self, response, url=None):
+        if response.status_code == 204:
+            return None
         try:
             result = response.json()
         except Exception:


### PR DESCRIPTION
204 means no content, so no reason to try and json-decode it.
There's no content. Don't even try.