### PR TITLE
CY-3456 Smart resume for the install workflow

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -109,6 +109,8 @@ class LifecycleProcessor(object):
             name=self._name_prefix + 'install',
             node_instance_subgraph_func=install_node_instance_subgraph,
             graph_finisher_func=self._finish_install)
+        if workflow_ctx.resume:
+            self._update_resumed_install(graph)
         graph.execute()
 
     def uninstall(self):
@@ -118,6 +120,42 @@ class LifecycleProcessor(object):
             node_instance_subgraph_func=uninstall_node_instance_subgraph,
             graph_finisher_func=self._finish_uninstall)
         graph.execute()
+
+    def _update_resumed_install(self, graph):
+        """Update a resumed install graph to cleanup first.
+
+        When an install is resumed:
+         - if we are going to re-send the create operation, send delete first
+         - if we are going to re-send the start operation, send stop first
+        """
+        install_subgraphs = _find_install_subgraphs(graph)
+        for instance in self.node_instances:
+            install_subgraph = install_subgraphs.get(instance.id)
+            if not install_subgraph:
+                continue
+
+            tasks = []
+            if instance.state in ['starting'] and _would_resend(
+                    install_subgraph, 'cloudify.interfaces.lifecycle.start'):
+                tasks += _pre_resume_stop(instance)
+            if instance.state in ['creating'] and _would_resend(
+                    install_subgraph, 'cloudify.interfaces.lifecycle.create'):
+                tasks += _pre_resume_uninstall(instance)
+            if not tasks:
+                continue
+            tasks = [
+                instance.send_event('Rolling back prior to resuming install')
+            ] + tasks + [
+                instance.send_event(
+                    'Finished rolling back, now resuming install')
+            ]
+
+            uninstall_subgraph = graph.subgraph(
+                'resume_cleanup_{0}'.format(instance.id))
+            sequence = uninstall_subgraph.sequence()
+            sequence.add(*tasks)
+            ignore_subgraph_on_task_failure(uninstall_subgraph, instance)
+            _run_subgraph_before(uninstall_subgraph, install_subgraph)
 
     @make_or_get_graph
     def _process_node_instances(self,
@@ -239,6 +277,113 @@ class LifecycleProcessor(object):
                     if on_dependency_added:
                         task_sequence = subgraph_sequences[instance.id]
                         on_dependency_added(instance, rel, task_sequence)
+
+
+def _find_install_subgraphs(graph):
+    """In the install graph, find subgraphs that install a node instance.
+
+    Make a dict of {instance id: subgraph}, based on the subgraph name.
+    """
+    install_subgraphs = {}
+    for task in graph.tasks_iter():
+        if task.is_subgraph and task.name.startswith('install_'):
+            instance_name = task.name[len('install_'):]
+            install_subgraphs[instance_name] = task
+    return install_subgraphs
+
+
+def _would_resend(subgraph, operation):
+    """Would the subgraph send the operation again?
+
+    Find the task named by operation, and check its state.
+    """
+    found_task = None
+    for task in subgraph.tasks.values():
+        if task.task_type != 'RemoteWorkflowTask':
+            continue
+        try:
+            if task.cloudify_context['operation']['name'] == operation:
+                found_task = task
+                break
+        except KeyError:
+            pass
+    else:
+        return False
+    return found_task.get_state() == workflow_tasks.TASK_PENDING
+
+
+def _pre_resume_uninstall(instance):
+    """Run these uninstall tasks before resuming/resending a create."""
+    delete = _skip_nop_operations(
+        pre=instance.send_event('Deleting node instance'),
+        task=instance.execute_operation(
+            'cloudify.interfaces.lifecycle.delete'),
+        post=instance.send_event('Deleted node instance')
+    )
+    if 'cloudify.interfaces.lifecycle.postdelete'\
+            in instance.node.operations:
+        postdelete = _skip_nop_operations(
+            pre=instance.send_event('Postdeleting node instance'),
+            task=instance.execute_operation(
+                'cloudify.interfaces.lifecycle.postdelete'),
+            post=instance.send_event('Node instance postdeleted'))
+    else:
+        postdelete = []
+
+    return delete + postdelete
+
+
+def _pre_resume_stop(instance):
+    """Run these stop tasks before resuming/resending a start."""
+    if 'cloudify.interfaces.lifecycle.prestop' in instance.node.operations:
+        prestop = _skip_nop_operations(
+            pre=instance.send_event('Prestopping node instance'),
+            task=instance.execute_operation(
+                'cloudify.interfaces.lifecycle.prestop'),
+            post=instance.send_event('Node instance prestopped'))
+    else:
+        prestop = []
+
+    if is_host_node(instance):
+        host_pre_stop = _host_pre_stop(instance)
+    else:
+        host_pre_stop = []
+
+    stop = _skip_nop_operations(
+        task=instance.execute_operation(
+            'cloudify.interfaces.lifecycle.stop'),
+        post=instance.send_event('Stopped node instance'))
+    return prestop + host_pre_stop + stop
+
+
+def _run_subgraph_before(subgraph_before, subgraph_after):
+    """Hook up dependencies so that subgraph_before runs before subgraph_after.
+
+    "before" will depend on everything that "after" depends, and "after" will
+    also depend on the "before".
+    """
+    if subgraph_before.graph is not subgraph_after.graph:
+        raise RuntimeError('{0} and {1} belog to different graphs'
+                           .format(subgraph_before, subgraph_after))
+    graph = subgraph_before.graph
+    for dependency_id in graph.graph.successors(subgraph_after.id):
+        graph.add_dependency(subgraph_before.id, graph.get_task(dependency_id))
+    graph.add_dependency(subgraph_after, subgraph_before)
+
+
+def ignore_subgraph_on_task_failure(task, instance):
+    """If the subgraph fails, just ignore it.
+
+    This is to be used in the pre-resume uninstall graphs, so that
+    the uninstall failing doesn't block the install from being resumed.
+    """
+    def _ignore_subgraph_failure(tsk):
+        workflow_ctx.logger.info('Ignoring failure in uninstall')
+        for t in tsk.tasks.values():
+            if t.get_state() == workflow_tasks.TASK_PENDING:
+                tsk.remove_task(t)
+        return workflow_tasks.HandlerResult.ignore()
+    task.on_failure = _ignore_subgraph_failure
 
 
 def set_send_node_event_on_error_handler(task, instance):


### PR DESCRIPTION
When the install workflow is resumed, if we are to re-send
the create operation, send a delete first. If we are to re-send
the stop operation, send stop first.