### PR TITLE
CY-3456 NOP tasks: pass through the id, keep them in the graph

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -773,8 +773,10 @@ class LocalWorkflowTask(WorkflowTask):
 class NOPLocalWorkflowTask(LocalWorkflowTask):
 
     def __init__(self, workflow_context, **kwargs):
-        super(NOPLocalWorkflowTask, self).__init__(lambda: None,
-                                                   workflow_context)
+        kwargs.update(
+            workflow_context=workflow_context,
+            local_task=lambda: None)
+        super(NOPLocalWorkflowTask, self).__init__(**kwargs)
 
     @property
     def name(self):
@@ -782,12 +784,12 @@ class NOPLocalWorkflowTask(LocalWorkflowTask):
         return 'NOP'
 
     def _update_stored_state(self, state):
-        # the task is always stored as succeeded - nothing to update
+        # the task is always stored as pending - nothing to update
         pass
 
     def dump(self):
         stored = super(NOPLocalWorkflowTask, self).dump()
-        stored['state'] = TASK_SUCCEEDED
+        stored['state'] = TASK_PENDING
         stored['parameters'].update({
             'info': None,
             'error': None


### PR DESCRIPTION
In the various workflow graphs, there are still NOP tasks
used for structuring the graph and keeping dependencies.

During graph restore, we key the dicts by task id, and so the
task id must be passed through and set. Hence making sure the
kwargs are passed.

Since the NOP tasks are used for structuring, they must go into
the restored graph as well. Hence storing them as pending after all.
They will always go into the graph, and possibly be executed
immediately after restoring. But they will always be there and will
influence the ordering of other operations as they should.