### PR TITLE
CY-3534 Manage plugin state in plugin_installer

### DIFF
--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -171,6 +171,11 @@ def format_exception(e):
             return repr(e)
 
 
+def get_daemon_name(cls):
+    """Name of the currently running agent."""
+    return os.environ['CLOUDIFY_DAEMON_NAME']
+
+
 def get_manager_name():
     """Hostname/id of the current manager.
 


### PR DESCRIPTION
Moving the plugin state updates to here, from
cloudify_agent.operations, because implicit (on-first-use) calls
to install/uninstall also need to update the plugin state.

Packaged the state-updating part into a decorator, too.