### PR TITLE
CY-3534 manage_plugin_state fixes

### DIFF
--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -109,9 +109,7 @@ def install(plugin, deployment_id=None, blueprint_id=None):
     managed_plugin = get_managed_plugin(plugin)
     args = get_plugin_args(plugin)
     if managed_plugin:
-        _install_managed_plugin(
-            managed_plugin=managed_plugin,
-            args=args)
+        _install_managed_plugin(managed_plugin, args=args)
         return
 
     source = get_plugin_source(plugin, blueprint_id)
@@ -180,33 +178,33 @@ def _get_plugin_description(managed_plugin):
         for field in fields if managed_plugin.get(field))
 
 
-def _install_managed_plugin(managed_plugin, args):
+def _install_managed_plugin(plugin, args):
     dst_dir = target_plugin_prefix(
-        name=managed_plugin.package_name,
+        name=plugin.package_name,
         tenant_name=ctx.tenant_name,
-        version=managed_plugin.package_version
+        version=plugin.package_version
     )
     with _lock(dst_dir):
-        if is_already_installed(dst_dir, managed_plugin.id):
+        if is_already_installed(dst_dir, plugin.id):
             ctx.logger.info(
                 'Using existing installation of managed plugin: %s [%s]',
-                managed_plugin.id, _get_plugin_description(managed_plugin))
+                plugin.id, _get_plugin_description(plugin))
             return
 
         ctx.logger.info(
             'Installing managed plugin: %s [%s]',
-            managed_plugin.id, _get_plugin_description(managed_plugin))
+            plugin.id, _get_plugin_description(plugin))
         _make_virtualenv(dst_dir)
         try:
-            _wagon_install(plugin=managed_plugin, venv=dst_dir, args=args)
+            _wagon_install(plugin, venv=dst_dir, args=args)
             with open(os.path.join(dst_dir, 'plugin.id'), 'w') as f:
-                f.write(managed_plugin.id)
+                f.write(plugin.id)
         except Exception as e:
             shutil.rmtree(dst_dir, ignore_errors=True)
             tpe, value, tb = sys.exc_info()
             exc = NonRecoverableError(
                 'Failed installing managed plugin: {0} [{1}][{2}]'
-                .format(managed_plugin.id, managed_plugin, e))
+                .format(plugin.id, plugin, e))
             reraise(NonRecoverableError, exc, tb)
 
 

--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -93,8 +93,6 @@ def _manage_plugin_state(pre_state, post_state, allow_missing=False):
     return _decorator
 
 
-@_manage_plugin_state(pre_state=PluginInstallationState.INSTALLING,
-                      post_state=PluginInstallationState.INSTALLED)
 def install(plugin, deployment_id=None, blueprint_id=None):
     """Install the plugin to the current virtualenv.
 
@@ -178,6 +176,8 @@ def _get_plugin_description(managed_plugin):
         for field in fields if managed_plugin.get(field))
 
 
+@_manage_plugin_state(pre_state=PluginInstallationState.INSTALLING,
+                      post_state=PluginInstallationState.INSTALLED)
 def _install_managed_plugin(plugin, args):
     dst_dir = target_plugin_prefix(
         name=plugin.package_name,

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -171,7 +171,7 @@ def format_exception(e):
             return repr(e)
 
 
-def get_daemon_name(cls):
+def get_daemon_name():
     """Name of the currently running agent."""
     return os.environ['CLOUDIFY_DAEMON_NAME']
 


### PR DESCRIPTION
The main point is running this on _managed_ plugins because only
they have an id, so it can only be run on them anyway.

See each commit for details.