### PR TITLE
CY-3552 Use b64encode for creating credentials.

### DIFF
--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -17,7 +17,7 @@ import json
 import logging
 
 import requests
-from base64 import urlsafe_b64encode
+from base64 import b64encode
 from requests.packages import urllib3
 
 from cloudify import constants
@@ -343,7 +343,7 @@ class HTTPClient(object):
         if not username or not password:
             return None
         credentials = '{0}:{1}'.format(username, password).encode('utf-8')
-        encoded_credentials = urlsafe_b64encode(credentials).decode('utf-8')
+        encoded_credentials = b64encode(credentials).decode('utf-8')
         return BASIC_AUTH_PREFIX + ' ' + encoded_credentials
 
     def _set_header(self, key, value, log_value=True):


### PR DESCRIPTION
As opposed to urlsafe_b64encode.

No reason for this to be urlsafe. At all.

Also, urlsafe breaks, because flask uses the non-urlsafe version
when decoding: https://github.com/pallets/werkzeug/blob/bbc5cbb8390d8d9de4fff42456cab3d91b85b584/src/werkzeug/http.py#L622
(this is for making `request.authorization`, which we then use).
Also, the basic auth rfc (RFC 7617) talks about using the plain version
of base64, not an urlsafe variant.

It needs to be encoded the same way it's going to be decoded.