### PR TITLE
Use the AGENT_NAME envvar instead of CLOUDIFY_DAEMON_NAME

### DIFF
--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -173,7 +173,7 @@ def format_exception(e):
 
 def get_daemon_name():
     """Name of the currently running agent."""
-    return os.environ['CLOUDIFY_DAEMON_NAME']
+    return os.environ['AGENT_NAME']
 
 
 def get_manager_name():


### PR DESCRIPTION
We used to use both randomly, let's standardize to this one,
and forget about the other one.