### PR TITLE
CY-3584 Hide OperationRetry traceback

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -293,7 +293,7 @@ class TaskHandler(object):
                 error.causes.append({
                     'message': e['message'],
                     'type': e['exception_type'],
-                    'traceback': e['traceback']
+                    'traceback': e.get('traceback')
                 })
                 raise error
             else:
@@ -812,7 +812,7 @@ def main():
         logger.error('Task {0}[{1}] raised:\n{2}'.format(
             handler.cloudify_context['task_name'],
             handler.cloudify_context.get('task_id', '<no-id>'),
-            payload['traceback']))
+            payload.get('traceback')))
 
     with open(os.path.join(dispatch_dir, 'output.json'), 'w') as f:
         json.dump({

--- a/cloudify/error_handling.py
+++ b/cloudify/error_handling.py
@@ -48,6 +48,7 @@ def serialize_known_exception(e):
     elif isinstance(e, exceptions.OperationRetry):
         known_exception_type = exceptions.OperationRetry
         known_exception_type_args = [e.retry_after]
+        trace_out = None
     elif isinstance(e, exceptions.RecoverableError):
         known_exception_type = exceptions.RecoverableError
         known_exception_type_args = [e.retry_after]

--- a/cloudify/error_handling.py
+++ b/cloudify/error_handling.py
@@ -64,7 +64,6 @@ def serialize_known_exception(e):
         causes = []
 
     payload = {
-        'traceback': trace_out,
         'exception_type': type(e).__name__,
         'message': format_exception(e),
         'known_exception_type': known_exception_type.__name__,
@@ -72,6 +71,8 @@ def serialize_known_exception(e):
         'known_exception_type_kwargs': {'causes': causes or []},
         'append_message': append_message,
     }
+    if trace_out:
+        payload['traceback'] = trace_out
     return payload
 
 

--- a/cloudify/event.py
+++ b/cloudify/event.py
@@ -88,9 +88,13 @@ class Event(object):
                 for cause in causes:
                     if multiple_causes:
                         causes_out.write('{0}\n'.format('-' * 32))
-                    causes_out.write(cause.get('traceback', ''))
+                    tb = cause.get('traceback')
+                    if tb:
+                        causes_out.write(tb)
 
-                message = u'{0}\n{1}'.format(message, causes_out.getvalue())
+                causes = causes_out.getvalue()
+                if causes:
+                    message = u'{0}\n{1}'.format(message, causes)
         return message
 
     @property

--- a/cloudify/tests/test_dispatch.py
+++ b/cloudify/tests/test_dispatch.py
@@ -124,7 +124,11 @@ class TestDispatchTaskHandler(testtools.TestCase):
             self.assertIn('message', cause['message'])
             self.assertEqual(raised_exception_type.__name__,
                              cause['type'])
-            self.assertIsNotNone(cause.get('traceback'))
+
+            if raised_exception_type is not exceptions.OperationRetry:
+                # retries have no tracebacks
+                self.assertIsNotNone(cause.get('traceback'))
+
             for arg in args:
                 if arg == 'message':
                     self.assertIn('message', str(e))


### PR DESCRIPTION
Retry tracebacks are uninteresting. No need to display them ever.