### PR TITLE
CY-3584 Hide the 'workflow failed' traceback

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -638,8 +638,8 @@ class WorkflowHandler(TaskHandler):
             else:
                 self._workflow_succeeded()
             return result
-        except exceptions.ProcessExecutionError as e:
-            self._workflow_failed(e, e.traceback)
+        except exceptions.WorkflowFailed as e:
+            self._workflow_failed(e)
             raise
         except BaseException as e:
             self._workflow_failed(e, traceback.format_exc())
@@ -712,12 +712,12 @@ class WorkflowHandler(TaskHandler):
             additional_context=self._get_hook_params()
         )
 
-    def _workflow_failed(self, exception, error_traceback):
+    def _workflow_failed(self, exception, error_traceback=None):
         try:
             self.ctx.internal.send_workflow_event(
                 event_type='workflow_failed',
                 message="'{0}' workflow execution failed: {1}".format(
-                    self.ctx.workflow_id, str(exception)),
+                    self.ctx.workflow_id, exception),
                 args={'error': error_traceback},
                 additional_context=self._get_hook_params()
             )

--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -590,11 +590,7 @@ class WorkflowHandler(TaskHandler):
                         break
                     else:
                         # error occurred in child thread
-                        error = data['error']
-                        raise exceptions.ProcessExecutionError(
-                            error['message'],
-                            error['type'],
-                            error['traceback'])
+                        raise data['error']
                 except queue.Empty:
                     pass
 
@@ -658,14 +654,7 @@ class WorkflowHandler(TaskHandler):
             except api.ExecutionCancelled:
                 queue.put({'result': api.EXECUTION_CANCELLED_RESULT})
             except BaseException as workflow_ex:
-                tb = StringIO()
-                traceback.print_exc(file=tb)
-                err = {
-                    'type': type(workflow_ex).__name__,
-                    'message': str(workflow_ex),
-                    'traceback': tb.getvalue()
-                }
-                queue.put({'error': err})
+                queue.put({'error': workflow_ex})
 
     def _handle_local_workflow(self):
         try:

--- a/cloudify/error_handling.py
+++ b/cloudify/error_handling.py
@@ -35,11 +35,7 @@ def serialize_known_exception(e):
     # Convert exception to a know exception type that can be deserialized
     # by the calling process
     known_exception_type_args = []
-    if isinstance(e, exceptions.ProcessExecutionError):
-        known_exception_type = exceptions.ProcessExecutionError
-        known_exception_type_args = [e.error_type, e.traceback]
-        trace_out = e.traceback
-    elif isinstance(e, exceptions.HttpException):
+    if isinstance(e, exceptions.HttpException):
         known_exception_type = exceptions.HttpException
         known_exception_type_args = [e.url, e.code]
         append_message = True

--- a/cloudify/error_handling.py
+++ b/cloudify/error_handling.py
@@ -54,6 +54,9 @@ def serialize_known_exception(e):
         known_exception_type_args = [e.retry_after]
     elif isinstance(e, exceptions.StopAgent):
         known_exception_type = exceptions.StopAgent
+    elif isinstance(e, exceptions.WorkflowFailed):
+        known_exception_type = exceptions.WorkflowFailed
+        trace_out = None
     else:
         # convert pure user exceptions to a RecoverableError
         known_exception_type = exceptions.RecoverableError

--- a/cloudify/exceptions.py
+++ b/cloudify/exceptions.py
@@ -179,3 +179,10 @@ class StopAgent(Exception):
     def __init__(self, *args, **kwargs):
         self.causes = kwargs.pop('causes', []) or []
         super(StopAgent, self).__init__(*args, **kwargs)
+
+
+class WorkflowFailed(RuntimeError):
+    """A workflow has failed."""
+    def __init__(self, *args, **kwargs):
+        self.causes = kwargs.pop('causes', []) or []
+        super(WorkflowFailed, self).__init__(*args, **kwargs)

--- a/cloudify/exceptions.py
+++ b/cloudify/exceptions.py
@@ -148,23 +148,6 @@ class ProcessKillCancelled(NonRecoverableError):
     """
 
 
-class ProcessExecutionError(RuntimeError):
-    """Raised by the workflow engine when workflow execution fails."""
-
-    def __init__(self, message, error_type=None, traceback=None, causes=None,
-                 **kwargs):
-        super(ProcessExecutionError, self).__init__(message, **kwargs)
-        self._message = message
-        self.error_type = error_type
-        self.traceback = traceback
-        self.causes = causes
-
-    def __str__(self):
-        if self.error_type:
-            return '{0}: {1}'.format(self.error_type, self._message)
-        return self.message
-
-
 class ClosedAMQPClientException(Exception):
     """Raised when attempting to use a closed AMQP client"""
     pass

--- a/cloudify/tests/test_dispatch.py
+++ b/cloudify/tests/test_dispatch.py
@@ -99,8 +99,6 @@ class TestDispatchTaskHandler(testtools.TestCase):
             (exceptions.RecoverableError, ('message', 'retry_after')),
             (exceptions.OperationRetry, ('message', 'retry_after')),
             (exceptions.HttpException, ('url', 'code', 'message')),
-            (exceptions.ProcessExecutionError, ('message', 'error_type',
-                                                'traceback')),
             ((UserException, exceptions.RecoverableError), ('message',)),
             ((RecoverableUserException, exceptions.RecoverableError),
              ('message', 'retry_after')),

--- a/cloudify/tests/test_install_new_agents_workflow.py
+++ b/cloudify/tests/test_install_new_agents_workflow.py
@@ -19,7 +19,7 @@ import testtools
 
 from cloudify.constants import COMPUTE_NODE_TYPE
 from cloudify.decorators import operation
-from cloudify.exceptions import NonRecoverableError
+from cloudify.exceptions import NonRecoverableError, WorkflowFailed
 from cloudify.test_utils import workflow_test
 
 
@@ -79,8 +79,7 @@ class TestInstallNewAgentsWorkflow(testtools.TestCase):
         'host_b_validation_result': _VALIDATION_FAIL})
     def test_failed_validation(self, cfy_local):
         cfy_local.execute('install')
-        with testtools.ExpectedException(RuntimeError,
-                                         ".*Task failed.*validate_amqp.*"):
+        with self.assertRaisesRegex(WorkflowFailed, 'validate_amqp'):
             cfy_local.execute('install_new_agents')
         self._assert_all_computes_created(cfy_local, created=False)
 

--- a/cloudify/tests/test_tasks_graph.py
+++ b/cloudify/tests/test_tasks_graph.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 
 from cloudify_rest_client.operations import Operation
 
+from cloudify.exceptions import WorkflowFailed
 from cloudify.workflows import api
 from cloudify.workflows import tasks
 from cloudify.workflows.tasks_graph import TaskDependencyGraph
@@ -93,7 +94,7 @@ class TestTasksGraphExecute(testtools.TestCase):
         seq.add(task1, task2)
 
         with limited_sleep_mock():
-            self.assertRaisesRegex(RuntimeError, 'Workflow failed', g.execute)
+            self.assertRaisesRegex(WorkflowFailed, 'failtask', g.execute)
         self.assertTrue(task1.is_terminated)
         self.assertFalse(task2.apply_async.called)
 
@@ -128,7 +129,7 @@ class TestTasksGraphExecute(testtools.TestCase):
         seq.add(task1, task2)
         with limited_sleep_mock():
             start_time = time.time()
-            self.assertRaisesRegex(RuntimeError, 'Workflow failed', g.execute)
+            self.assertRaisesRegex(WorkflowFailed, 'failtask', g.execute)
 
         # even though the workflow failed 1 second in, the other task was
         # still waited for and completed

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -20,6 +20,7 @@ from functools import wraps
 
 import networkx as nx
 
+from cloudify.exceptions import WorkflowFailed
 from cloudify.workflows import api
 from cloudify.workflows import tasks
 from cloudify.state import workflow_ctx
@@ -340,11 +341,11 @@ class TaskDependencyGraph(object):
         if handler_result.action == tasks.HandlerResult.HANDLER_FAIL:
             if isinstance(task, SubgraphTask) and task.failed_task:
                 task = task.failed_task
-            message = "Workflow failed: Task failed '{0}'".format(task.name)
+            message = "Task failed '{0}'".format(task.name)
             if task.error:
                 message = '{0} -> {1}'.format(message, task.error)
             if self._error is None:
-                self._error = RuntimeError(message)
+                self._error = WorkflowFailed(message)
         elif handler_result.action == tasks.HandlerResult.HANDLER_RETRY:
             new_task = handler_result.retried_task
             if self.id is not None:


### PR DESCRIPTION
- specialcase the exception
- hide its traceback
- stop wrapping the exception in a dict + another exception kind