### PR TITLE
restclient: dep-update: pass json mime-encoded body

### DIFF
--- a/cloudify_rest_client/deployment_updates.py
+++ b/cloudify_rest_client/deployment_updates.py
@@ -142,10 +142,7 @@ class DeploymentUpdatesClient(object):
         params = {}
         # all the inputs are passed through the query
         if inputs:
-            inputs_file = tempfile.TemporaryFile()
-            json.dump(inputs, inputs_file)
-            inputs_file.seek(0)
-            data_form['inputs'] = ('inputs', inputs_file, 'text/plain')
+            data_form['inputs'] = ('inputs', json.dumps(inputs), 'text/plain')
 
         if application_file_name:
             params['application_file_name'] = urlquote(application_file_name)


### PR DESCRIPTION
TemporaryFile() by default takes bytes, so we can't json.dump()
into it, because that tries to write unicode.
We can't make it a unicode-kind file, because requests, if it gets
a file, wants a binary file.
Instead, we can just pass the json-encoded string directly, without
a file.

This fixes the integration test:
`integration_tests/tests/agentless_tests/test_runtime_functions.py::TestRuntimeFunctionEvaluation::test_change_flag_update`