### PR TITLE
CY-3589 ClusterClient: copy the hosts list

### DIFF
--- a/cloudify/cluster.py
+++ b/cloudify/cluster.py
@@ -31,7 +31,8 @@ class ClusterHTTPClient(HTTPClient):
         # from outside, we get self.host passed in as a list (optionally).
         # But we still need self.host to be the currently-used manager,
         # and we can store the list as self.hosts
-        hosts = self.host if isinstance(self.host, list) else [self.host]
+        # (copy the list so that outside mutations don't affect us)
+        hosts = list(self.host) if isinstance(self.host, list) else [self.host]
         random.shuffle(hosts)
         self.hosts = itertools.cycle(hosts)
         self.host = hosts[0]


### PR DESCRIPTION
We need to isolate ourselves from outside changes to the hosts list,
that's why we can copy it.

Main reason of the "outside changes" is another ClusterClient
running concurrently, and doing the shuffle() as well.

This can lead to the client contacting the same manager multiple
times, and skipping over some managers, depending on the shuffle luck.