### PR TITLE
add 0 to wagon version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'bottle==0.12.18',
     'jinja2>=2.10,<2.11',
     'requests_toolbelt==0.8.0',
-    'wagon>0.10',
+    'wagon>0.10.0',
     'fasteners==0.13.0',
 ]
 


### PR DESCRIPTION
Received Error:
```cloudify-common 5.1.0.dev1 requires wagon>0.10, but you'll have wagon 0.10.0 which is incompatible.111```