### PR TITLE
RD-208 Replace tasks polling with callbacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ commands:
           name: pytest << parameters.target >>
           command: |
             pytest \
+              -sv \
               -n 4 \
               --cov-report term-missing \
               --cov=<< parameters.target >> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,12 @@ executors:
         # staying on old debian image, because buster dropped libssl1.0-dev, which
         # is required to compile py2.6 via pyenv
       - image: circleci/python:2.7-stretch
-      - image: rabbitmq:3.7.4
   py27:
     docker:
       - image: circleci/python:2.7
-      - image: rabbitmq:3.7.4
   py36:
     docker:
       - image: circleci/python:3.6
-      - image: rabbitmq:3.7.4
 
 
   docs_builder:

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -206,7 +206,7 @@ class AMQPConnection(object):
         out_channel = self.connect()
         while not self._closed:
             try:
-                self._pika_connection.process_data_events(0.2)
+                self._pika_connection.process_data_events(0.05)
                 self._process_publish(out_channel)
             except pika.exceptions.ChannelClosed as e:
                 # happens when we attempt to use an exchange/queue that is not

--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -673,8 +673,7 @@ class WorkflowHandler(TaskHandler):
             self.ctx.internal.start_local_tasks_processing()
             result = self.func(*self.args, **self.kwargs)
             if not self.ctx.internal.graph_mode:
-                tasks = list(self.ctx.internal.task_graph.tasks_iter())
-                for workflow_task in tasks:
+                for workflow_task in self.ctx.internal.task_graph.tasks:
                     workflow_task.async_result.get()
             return result
         finally:

--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -614,13 +614,13 @@ class WorkflowHandler(TaskHandler):
                     # deprecated api.EXECUTION_CANCELLED_RESULT as result).
                     # parent thread then goes back to polling for messages from
                     # child thread or possibly 'force-cancelling' requests
-                    api.cancel_request = True
+                    api.set_cancel_request()
 
                 if execution.status == Execution.KILL_CANCELLING:
                     # if a custom workflow function must attempt some cleanup,
                     # it might attempt to catch SIGTERM, and confirm using this
                     # flag that it is being kill-cancelled
-                    api.kill_request = True
+                    api.set_kill_request()
 
                 if execution.status in [
                         Execution.FORCE_CANCELLING,

--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -398,7 +398,9 @@ def ignore_subgraph_on_task_failure(subgraph):
 
 def set_send_node_event_on_error_handler(task, instance):
     def send_node_event_error_handler(tsk):
-        instance.send_event('Ignoring task {0} failure'.format(tsk.name))
+        event = instance.send_event(
+            'Ignoring task {0} failure'.format(tsk.name))
+        event.apply_async()
         return workflow_tasks.HandlerResult.ignore()
     task.on_failure = send_node_event_error_handler
 

--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -218,7 +218,7 @@ class LifecycleProcessor(object):
     def _handle_dependency_creation(source_subgraph, target_subgraph,
                                     operation, target_id, graph):
         if operation:
-            for task_subgraph in target_subgraph.graph.tasks_iter():
+            for task_subgraph in target_subgraph.graph.tasks:
                 # If the task is not an operation task
                 if not task_subgraph.cloudify_context:
                     continue
@@ -285,7 +285,7 @@ def _find_install_subgraphs(graph):
     Make a dict of {instance id: subgraph}, based on the subgraph name.
     """
     install_subgraphs = {}
-    for task in graph.tasks_iter():
+    for task in graph.tasks:
         if task.is_subgraph and task.name.startswith('install_'):
             instance_name = task.name[len('install_'):]
             install_subgraphs[instance_name] = task

--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -436,8 +436,7 @@ def scale_entity(ctx,
                     raise
 
                 ctx.logger.error('Scale out failed, scaling back in.')
-                tasks_list = [task for task in graph.tasks_iter()]
-                for task in tasks_list:
+                for task in graph.tasks:
                     graph.remove_task(task)
                 lifecycle.uninstall_node_instances(
                     graph=graph,

--- a/cloudify/tests/resources/blueprints/execute_operation-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/execute_operation-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+  - minimal_types.yaml
 
 node_templates:
   node1:

--- a/cloudify/tests/resources/blueprints/install-new-agents-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/install-new-agents-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+  - minimal_types.yaml
 
 plugins:
   p:

--- a/cloudify/tests/resources/blueprints/minimal_types.yaml
+++ b/cloudify/tests/resources/blueprints/minimal_types.yaml
@@ -1,0 +1,267 @@
+###
+# this is a minimal version of Cloudify types.yaml, to be used only in
+# cloudify-common unittests.
+###
+
+
+
+plugins:
+  default_workflows:
+    executor: central_deployment_agent
+    install: false
+
+node_types:
+  cloudify.nodes.Root:
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        precreate: {}
+        create: {}
+        configure: {}
+        start: {}
+        poststart: {}
+        prestop: {}
+        stop: {}
+        delete: {}
+        postdelete: {}
+      cloudify.interfaces.validation:
+        create: {}
+        delete: {}
+      cloudify.interfaces.monitoring:
+        start: {}
+        stop: {}
+
+  cloudify.nodes.Compute:
+    derived_from: cloudify.nodes.Root
+    properties:
+      agent_config:
+        default:
+          install_method: remote
+      install_agent:
+        default: ''
+
+    interfaces:
+      cloudify.interfaces.cloudify_agent:
+        create: {}
+        configure: {}
+        start: {}
+        stop: {}
+        stop_amqp: {}
+        delete: {}
+        restart: {}
+        restart_amqp: {}
+        install_plugins: {}
+        uninstall_plugins: {}
+        create_amqp: {}
+        validate_amqp: {}
+
+
+      cloudify.interfaces.host:  # DEPRECATED
+        get_state: {}
+
+      cloudify.interfaces.monitoring_agent:
+        install: {}
+        start: {}
+        stop: {}
+        uninstall: {}
+
+relationships:
+  cloudify.relationships.depends_on:
+    source_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        preconfigure: {}
+        postconfigure: {}
+        establish: {}
+        unlink: {}
+    target_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        preconfigure: {}
+        postconfigure: {}
+        establish: {}
+        unlink: {}
+    properties:
+      connection_type:
+        default: all_to_all
+
+  cloudify.relationships.connected_to:
+    derived_from: cloudify.relationships.depends_on
+
+  cloudify.relationships.contained_in:
+    derived_from: cloudify.relationships.depends_on
+
+workflows:
+  install:
+    mapping: default_workflows.cloudify.plugins.workflows.install
+    is_cascading: false
+
+  uninstall:
+    mapping: default_workflows.cloudify.plugins.workflows.uninstall
+    is_cascading: false
+    parameters:
+      ignore_failure:
+        default: false
+        type: boolean
+
+  start:
+    mapping: default_workflows.cloudify.plugins.workflows.start
+    is_cascading: false
+    parameters:
+      operation_parms:
+        default: {}
+      run_by_dependency_order:
+        default: true
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
+  stop:
+    mapping: default_workflows.cloudify.plugins.workflows.stop
+    is_cascading: false
+    parameters:
+      operation_parms:
+        default: {}
+      run_by_dependency_order:
+        default: true
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
+  restart:
+    mapping: default_workflows.cloudify.plugins.workflows.restart
+    is_cascading: false
+    parameters:
+      stop_parms:
+        default: {}
+      start_parms:
+        default: {}
+      run_by_dependency_order:
+        default: true
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
+  execute_operation:
+    mapping: default_workflows.cloudify.plugins.workflows.execute_operation
+    is_cascading: false
+    parameters:
+      operation: {}
+      operation_kwargs:
+        default: {}
+      allow_kwargs_override:
+        default: null
+      run_by_dependency_order:
+        default: false
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
+  heal:
+    mapping: default_workflows.cloudify.plugins.workflows.auto_heal_reinstall_node_subgraph
+    is_cascading: false
+    parameters:
+      node_instance_id:
+        description: Which node instance has failed
+      diagnose_value:
+        description: Diagnosed reason of failure
+        default: Not provided
+      ignore_failure:
+        default: true
+        type: boolean
+
+  update:
+    mapping: default_workflows.cloudify.plugins.workflows.update
+    is_cascading: false
+    parameters:
+      update_id:
+        default: ''
+      skip_install:
+        default: false
+      skip_uninstall:
+        default: false
+      added_instance_ids:
+        default: []
+        type: list
+      added_target_instances_ids:
+        default: []
+        type: list
+      removed_instance_ids:
+        default: []
+        type: list
+      remove_target_instance_ids:
+        default: []
+        type: list
+      modified_entity_ids:
+        default: []
+        type: list
+      extended_instance_ids:
+        default: []
+        type: list
+      extend_target_instance_ids:
+        default: []
+        type: list
+      reduced_instance_ids:
+        default: []
+        type: list
+      reduce_target_instance_ids:
+        default: []
+        type: list
+      ignore_failure:
+        default: false
+        type: boolean
+      install_first:
+        default: false
+        type: boolean
+      node_instances_to_reinstall:
+        default: []
+        type: list
+      central_plugins_to_install:
+        default: []
+        type: list
+      central_plugins_to_uninstall:
+        default: []
+        type: list
+      update_plugins:
+        default: true
+        type: boolean
+
+  install_new_agents:
+    mapping: default_workflows.cloudify.plugins.workflows.install_new_agents
+    is_cascading: false
+    parameters:
+      install_agent_timeout:
+        default: 300
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+      install_methods:
+        default: null
+      validate:
+        default: True
+        type: boolean
+      install:
+        default: True
+        type: boolean
+      install_script:
+        default: ''
+      manager_ip:
+        description: The private ip of the new manager
+        default: ''
+      manager_certificate:
+        description: The cloudify_internal_ca_cert.pem of the new manager
+        default: ''
+      stop_old_agent:
+        description: Stop the old agent after the new agent is installed
+        default: false
+        type: boolean

--- a/cloudify/tests/resources/blueprints/not_exist_op_workflow-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/not_exist_op_workflow-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+    - minimal_types.yaml
 
 node_templates:
     node1:

--- a/cloudify/tests/resources/blueprints/test-blueprint-ignore-failure.yaml
+++ b/cloudify/tests/resources/blueprints/test-blueprint-ignore-failure.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+  - minimal_types.yaml
 
 plugins:
   p:

--- a/cloudify/tests/resources/blueprints/test-heal-correct-order-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/test-heal-correct-order-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+  - minimal_types.yaml
 
 plugins:
   p:

--- a/cloudify/tests/resources/blueprints/test-lifecycle-retry-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/test-lifecycle-retry-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+    - minimal_types.yaml
 
 dsl_definitions:
   - &op

--- a/cloudify/tests/resources/blueprints/test-lifecycle.yaml
+++ b/cloudify/tests/resources/blueprints/test-lifecycle.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/5.0.0.dev1/types.yaml
+  - minimal_types.yaml
 
 plugins:
   mock:

--- a/cloudify/tests/resources/blueprints/test-relationship-order-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/test-relationship-order-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+  - minimal_types.yaml
 
 node_templates:
 

--- a/cloudify/tests/resources/blueprints/test-subgraph-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/test-subgraph-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+  - minimal_types.yaml
 
 plugins:
   p:

--- a/cloudify/tests/resources/blueprints/test-uninstall-ignore-failure-parameter-blueprint.yaml
+++ b/cloudify/tests/resources/blueprints/test-uninstall-ignore-failure-parameter-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/5.1.1.dev1/types.yaml
+    - minimal_types.yaml
 
 dsl_definitions:
   - &node_interfaces

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -339,9 +339,7 @@ class NodeContextTests(testtools.TestCase):
         os.path.dirname(os.path.realpath(__file__)),
         "resources/blueprints/test-context-node.yaml")
 
-    @workflow_test(blueprint_path=test_blueprint_path,
-                   resources_to_copy=[
-                       'resources/blueprints/execute_operation_workflow.yaml'])
+    @workflow_test(blueprint_path=test_blueprint_path)
     def test_node_type(self, cfy_local):
         cfy_local.execute('execute_operation', parameters={
             'operation': 'test.interface.create',

--- a/cloudify/tests/test_ctx_relationships.py
+++ b/cloudify/tests/test_ctx_relationships.py
@@ -120,10 +120,8 @@ class TestContextRelationship(testtools.TestCase):
         }
 
     def _assert_capabilities(self, cfy_local, rel):
-        with warnings.catch_warnings(record=True) as warns:
+        with warnings.catch_warnings(record=True):
             self._run(cfy_local, 'assert_capabilities', rel)
-        self.assertEqual(len(warns), 1)
-        self.assertIn('capabilities is deprecated', str(warns[0]))
 
         instances = cfy_local.storage.get_node_instances()
         instance1 = [i for i in instances if i.node_id == 'node1'][0]

--- a/cloudify/tests/test_dispatch.py
+++ b/cloudify/tests/test_dispatch.py
@@ -22,7 +22,7 @@ import tempfile
 from mock import patch, MagicMock, Mock
 import testtools
 
-from cloudify import amqp_client
+from cloudify import amqp_client, amqp_client_utils
 from cloudify import dispatch
 from cloudify import exceptions
 from cloudify import utils
@@ -54,7 +54,8 @@ class TestDispatchTaskHandler(testtools.TestCase):
         register_calls = process_registry.register.mock_calls
         self.assertEqual(len(register_calls), 1)
 
-    def test_dispatch_update_operation_resume(self):
+    @patch('cloudify.dispatch.amqp_client_utils')
+    def test_dispatch_update_operation_resume(self, _):
         """When the operation was already started, we set resume=true
 
         (and the function fails because it's not resumable)
@@ -338,6 +339,8 @@ class TestDispatchTaskHandler(testtools.TestCase):
 
 if os.environ.get('CLOUDIFY_DISPATCH'):
     amqp_client.create_client = Mock()
+    amqp_client_utils.init_events_publisher = Mock()
+    amqp_client_utils.close_amqp_client = Mock()
 
 
 def func1(result):

--- a/cloudify/tests/test_operation_retry.py
+++ b/cloudify/tests/test_operation_retry.py
@@ -110,7 +110,7 @@ class OperationRetryWorkflowTests(testtools.TestCase):
     def test_operation_retry(self, cfy_local):
         cfy_local.execute('execute_operation',
                           task_retries=3,
-                          task_retry_interval=1,
+                          task_retry_interval=0,
                           parameters={
                               'operation': 'lifecycle.start'
                           })
@@ -136,7 +136,7 @@ class OperationRetryWorkflowTests(testtools.TestCase):
     def test_ignore_operation_retry(self, cfy_local):
         cfy_local.execute('execute_operation',
                           task_retries=3,
-                          task_retry_interval=1,
+                          task_retry_interval=0,
                           parameters={
                               'operation': 'lifecycle.stop'
                           })

--- a/cloudify/tests/test_task_serialize.py
+++ b/cloudify/tests/test_task_serialize.py
@@ -123,4 +123,4 @@ class TestGraphSerialize(TestCase):
                          deserialized_subgraph.id)
 
         # this checks dependencies
-        self.assertEqual(deserialized.graph.edges(), graph.graph.edges())
+        self.assertEqual(deserialized._dependencies, graph._dependencies)

--- a/cloudify/tests/test_tasks_graph.py
+++ b/cloudify/tests/test_tasks_graph.py
@@ -84,11 +84,11 @@ class TestTasksGraphExecute(testtools.TestCase):
             name = 'failtask'
 
             def apply_async(self):
-                self.async_result.result = tasks.HandlerResult.fail()
+                self.async_result.result = None
                 self.set_state(tasks.TASK_FAILED)
                 return self.async_result
 
-        task1 = FailedTask(mock.Mock())
+        task1 = FailedTask(mock.Mock(), total_retries=0)
         task2 = mock.Mock(execute_after=0)
 
         g = TaskDependencyGraph(MockWorkflowContext())

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -793,6 +793,10 @@ class WorkflowTaskResult(object):
             self.result = api.ExecutionCancelled()
             raise self.result
 
+        ctx = self.task.workflow_context
+        if not ctx.internal.graph_mode:
+            ctx.internal.task_graph.remove_task(self.task)
+
         if self.task.get_state() in (TASK_FAILED, TASK_RESCHEDULED):
             handler_result = self.task.handle_task_terminated()
             if handler_result.retried_task and retry_on_failure:

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -291,8 +291,6 @@ class WorkflowTask(object):
         (i.e. has either failed or been rescheduled)
         """
         result = self.async_result.result
-        if isinstance(result, HandlerResult):
-            return result
 
         if isinstance(result, exceptions.OperationRetry):
             # operation explicitly requested a retry, so we ignore

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -52,11 +52,6 @@ DEFAULT_SEND_TASK_EVENTS = True
 DISPATCH_TASK = 'cloudify.dispatch.dispatch'
 
 
-def retry_failure_handler(task):
-    """Basic on_success/on_failure handler that always returns retry"""
-    return HandlerResult.retry()
-
-
 class WorkflowTask(object):
     """A base class for workflow tasks"""
 
@@ -95,7 +90,7 @@ class WorkflowTask(object):
         """
         self.id = task_id or str(uuid.uuid4())
         self._state = TASK_PENDING
-        self.async_result = None
+        self.async_result = WorkflowTaskResult(self)
         self.on_success = on_success
         self.on_failure = on_failure
         self.info = info
@@ -104,7 +99,6 @@ class WorkflowTask(object):
         self.retry_interval = retry_interval
         self.timeout = timeout
         self.timeout_recoverable = timeout_recoverable
-        self.terminated = queue.Queue(maxsize=1)
         self.is_terminated = False
         self.workflow_context = workflow_context
         self.send_task_events = send_task_events
@@ -114,7 +108,7 @@ class WorkflowTask(object):
         # timestamp for which the task should not be executed
         # by the task graph before reached, overridden by the task
         # graph during retries
-        self.execute_after = time.time()
+        self.execute_after = None
         self.stored = False
 
         # ID of the task that is being retried by this task
@@ -176,6 +170,9 @@ class WorkflowTask(object):
             }
         }
 
+    def apply_async(self):
+        return self.async_result
+
     def is_remote(self):
         """
         :return: Is this a remote task
@@ -221,15 +218,9 @@ class WorkflowTask(object):
         self._state = state
         if state in TERMINATED_STATES:
             self.is_terminated = True
-            self.terminated.put_nowait(True)
 
     def _update_stored_state(self, state):
         self.workflow_context.update_operation(self.id, state=state)
-
-    def wait_for_terminated(self, timeout=None):
-        if self.is_terminated:
-            return
-        self.terminated.get(timeout=timeout)
 
     def handle_task_terminated(self):
         if self.get_state() in (TASK_FAILED, TASK_RESCHEDULED):
@@ -238,9 +229,9 @@ class WorkflowTask(object):
             handler_result = self._handle_task_succeeded()
 
         if handler_result.action == HandlerResult.HANDLER_RETRY:
-            if any([self.total_retries == INFINITE_TOTAL_RETRIES,
-                    self.current_retries < self.total_retries,
-                    handler_result.ignore_total_retries]):
+            if (self.total_retries == INFINITE_TOTAL_RETRIES or
+                    self.current_retries < self.total_retries or
+                    handler_result.ignore_total_retries):
                 if handler_result.retry_after is None:
                     handler_result.retry_after = self.retry_interval
                 if handler_result.retried_task is None:
@@ -259,7 +250,6 @@ class WorkflowTask(object):
                 # we will only consider the first one handled
                 if not subgraph.failed_task:
                     subgraph.failed_task = self
-                    subgraph.set_state(TASK_FAILED)
             elif handler_result.action == HandlerResult.HANDLER_RETRY:
                 retried_task = handler_result.retried_task
             subgraph.task_terminated(task=self, new_task=retried_task)
@@ -274,23 +264,15 @@ class WorkflowTask(object):
             return HandlerResult.cont()
 
     def _handle_task_not_succeeded(self):
-
         """
         Call handler for task which hasn't ended in 'succeeded' state
         (i.e. has either failed or been rescheduled)
         """
+        result = self.async_result.result
+        if isinstance(result, HandlerResult):
+            return result
 
-        try:
-            exception = self.async_result.result
-        except Exception as e:
-            exception = exceptions.NonRecoverableError(
-                'Could not de-serialize '
-                'exception of task {0} --> {1}: {2}'
-                .format(self.name,
-                        type(e).__name__,
-                        str(e)))
-
-        if isinstance(exception, exceptions.OperationRetry):
+        if isinstance(result, exceptions.OperationRetry):
             # operation explicitly requested a retry, so we ignore
             # the handler set on the task.
             handler_result = HandlerResult.retry()
@@ -299,30 +281,25 @@ class WorkflowTask(object):
         else:
             handler_result = HandlerResult.retry()
 
-        if handler_result.action == HandlerResult.HANDLER_RETRY:
-            if isinstance(exception, exceptions.NonRecoverableError):
+            if isinstance(result, exceptions.NonRecoverableError):
                 handler_result = HandlerResult.fail()
-            elif isinstance(exception, exceptions.RecoverableError):
-                handler_result.retry_after = exception.retry_after
+            elif isinstance(result, exceptions.RecoverableError):
+                handler_result.retry_after = result.retry_after
 
         if not self.is_subgraph:
             causes = []
-            if isinstance(exception, (exceptions.RecoverableError,
-                                      exceptions.NonRecoverableError)):
-                causes = exception.causes or []
-            if isinstance(self, LocalWorkflowTask):
-                tb = self.async_result._holder.error[1]
-                causes.append(exception_to_error_cause(exception, tb))
+            if isinstance(result, (exceptions.RecoverableError,
+                                   exceptions.NonRecoverableError)):
+                causes = result.causes or []
             self.workflow_context.internal.send_task_event(
                 state=self.get_state(),
                 task=self,
-                event={'exception': exception, 'causes': causes})
+                event={'exception': result, 'causes': causes})
 
         return handler_result
 
     def __str__(self):
-        suffix = self.info if self.info is not None else ''
-        return '{0}({1})'.format(self.name, suffix)
+        return '{0}({1})'.format(self.name, self.info or '')
 
     def duplicate_for_retry(self, execute_after):
         """
@@ -349,77 +326,29 @@ class WorkflowTask(object):
         """
         :return: The task name
         """
-
         raise NotImplementedError('Implemented by subclasses')
 
     @property
     def is_subgraph(self):
         return False
 
-    def _should_resume(self):
-        """Has this task already been sent and should be resumed?"""
-        return (
-            self._state in (TASK_SENT, TASK_STARTED, TASK_RESPONSE_SENT) and
-            self.async_result is None
-        )
-
 
 class RemoteWorkflowTask(WorkflowTask):
     """A WorkflowTask wrapping an AMQP based task"""
-
-    # cache for registered tasks queries to agent workers
-    cache = {}
-
     def __init__(self,
                  kwargs,
                  cloudify_context,
                  workflow_context,
+                 task_id=None,
                  task_queue=None,
                  task_target=None,
-                 task_id=None,
-                 info=None,
-                 on_success=None,
-                 on_failure=retry_failure_handler,
-                 total_retries=DEFAULT_TOTAL_RETRIES,
-                 retry_interval=DEFAULT_RETRY_INTERVAL,
-                 send_task_events=DEFAULT_SEND_TASK_EVENTS):
-        """
-        :param kwargs: The keyword argument this task will be invoked with
-        :param cloudify_context: the cloudify context dict
-        :param task_queue: the cloudify context dict
-        :param task_target: the cloudify context dict
-        :param task_id: The id of this task (generated if none is provided)
-        :param info: A short description of this task (for logging)
-        :param on_success: A handler called when the task's execution
-                           terminates successfully.
-                           Expected to return one of
-                           [HandlerResult.retry(), HandlerResult.cont()]
-                           to indicate whether this task should be re-executed.
-        :param on_failure: A handler called when the task's execution
-                           fails.
-                           Expected to return one of
-                           [HandlerResult.retry(), HandlerResult.ignore(),
-                            HandlerResult.fail()]
-                           to indicate whether this task should be re-executed,
-                           cause the engine to terminate workflow execution
-                           immediately or simply ignore this task failure and
-                           move on.
-        :param total_retries: Maximum retry attempt for this task, in case
-                              the handlers return a retry attempt.
-        :param retry_interval: Number of seconds to wait between retries
-        :param workflow_context: the CloudifyWorkflowContext instance
-        """
+                 **kw):
         super(RemoteWorkflowTask, self).__init__(
             workflow_context,
             task_id,
-            info=info,
-            on_success=on_success,
-            on_failure=on_failure,
-            total_retries=total_retries,
-            retry_interval=retry_interval,
             timeout=cloudify_context.get('timeout'),
             timeout_recoverable=cloudify_context.get('timeout_recoverable'),
-            send_task_events=send_task_events)
+            **kw)
         self._task_target = task_target
         self._task_queue = task_queue
         self._task_tenant = None
@@ -463,16 +392,10 @@ class RemoteWorkflowTask(WorkflowTask):
         return super(RemoteWorkflowTask, self)._update_stored_state(state)
 
     def apply_async(self):
-        """
-        Call the underlying tasks' apply_async. Verify the worker
-        is alive and send an event before doing so.
+        """Send the task to an agent.
 
-        :return: a RemoteWorkflowTaskResult instance wrapping the async result
+        :return: a WorkflowTaskResult instance wrapping the async result
         """
-        # the task should be sent to the agent if either:
-        # 1) this is the first execution of this task (state=pending)
-        # 2) this is a resume (state=sent|started) and the task is a central
-        #    deployment agent task
         should_send = self._state == TASK_PENDING
         if self._state == TASK_PENDING:
             self.set_state(TASK_SENDING)
@@ -481,18 +404,17 @@ class RemoteWorkflowTask(WorkflowTask):
             task = self.workflow_context.internal.handler.get_task(
                 self, queue=self._task_queue, target=self._task_target,
                 tenant=self._task_tenant)
-            async_result = self.workflow_context.internal.handler\
-                .wait_for_result(self, task)
+            self.workflow_context.internal.handler.wait_for_result(
+                self.async_result, self, task)
             if should_send:
                 self.workflow_context.internal.send_task_event(
                     TASK_SENDING, self)
                 self.set_state(TASK_SENT)
                 self.workflow_context.internal.handler.send_task(self, task)
-            self.async_result = RemoteWorkflowTaskResult(self, async_result)
         except (exceptions.NonRecoverableError,
                 exceptions.RecoverableError) as e:
             self.set_state(TASK_FAILED)
-            self.async_result = RemoteWorkflowErrorTaskResult(self, e)
+            self.async_result.result = e
         return self.async_result
 
     def is_local(self):
@@ -506,8 +428,6 @@ class RemoteWorkflowTask(WorkflowTask):
                                  workflow_context=self.workflow_context,
                                  task_id=None,  # we want a new task id
                                  info=self.info,
-                                 on_success=self.on_success,
-                                 on_failure=self.on_failure,
                                  total_retries=self.total_retries,
                                  retry_interval=self.retry_interval,
                                  send_task_events=self.send_task_events)
@@ -644,8 +564,6 @@ class LocalWorkflowTask(WorkflowTask):
                  workflow_context,
                  node=None,
                  info=None,
-                 on_success=None,
-                 on_failure=retry_failure_handler,
                  total_retries=DEFAULT_TOTAL_RETRIES,
                  retry_interval=DEFAULT_RETRY_INTERVAL,
                  send_task_events=DEFAULT_SEND_TASK_EVENTS,
@@ -657,20 +575,6 @@ class LocalWorkflowTask(WorkflowTask):
         :param workflow_context: the CloudifyWorkflowContext instance
         :param node: The CloudifyWorkflowNode instance (if in node context)
         :param info: A short description of this task (for logging)
-        :param on_success: A handler called when the task's execution
-                           terminates successfully.
-                           Expected to return one of
-                           [HandlerResult.retry(), HandlerResult.cont()]
-                           to indicate whether this task should be re-executed.
-        :param on_failure: A handler called when the task's execution
-                           fails.
-                           Expected to return one of
-                           [HandlerResult.retry(), HandlerResult.ignore(),
-                            HandlerResult.fail()]
-                           to indicate whether this task should be re-executed,
-                           cause the engine to terminate workflow execution
-                           immediately or simply ignore this task failure and
-                           move on.
         :param total_retries: Maximum retry attempt for this task, in case
                               the handlers return a retry attempt.
         :param retry_interval: Number of seconds to wait between retries
@@ -679,8 +583,6 @@ class LocalWorkflowTask(WorkflowTask):
         """
         super(LocalWorkflowTask, self).__init__(
             info=info,
-            on_success=on_success,
-            on_failure=on_failure,
             total_retries=total_retries,
             retry_interval=retry_interval,
             task_id=task_id,
@@ -727,11 +629,10 @@ class LocalWorkflowTask(WorkflowTask):
         return super(LocalWorkflowTask, self)._update_stored_state(state)
 
     def apply_async(self):
-        """
-        Execute the task in the local task thread pool
+        """Execute the task in the local task thread pool
+
         :return: A wrapper for the task result
         """
-
         def local_task_wrapper():
             try:
                 self.workflow_context.internal.send_task_event(TASK_STARTED,
@@ -739,21 +640,17 @@ class LocalWorkflowTask(WorkflowTask):
                 result = self.local_task(**self.kwargs)
                 self.workflow_context.internal.send_task_event(
                     TASK_SUCCEEDED, self, event={'result': str(result)})
-                self.async_result._holder.result = result
+                self.async_result.result = result
                 self.set_state(TASK_SUCCEEDED)
             except BaseException as e:
                 new_task_state = TASK_RESCHEDULED if isinstance(
                     e, exceptions.OperationRetry) else TASK_FAILED
-                exc_type, exception, tb = sys.exc_info()
-                self.async_result._holder.error = (exception, tb)
                 self.set_state(new_task_state)
-
-        self.async_result = LocalWorkflowTaskResult(self)
+                self.async_result.result = e
 
         self.workflow_context.internal.send_task_event(TASK_SENDING, self)
         self.set_state(TASK_SENT)
         self.workflow_context.internal.add_local_task(local_task_wrapper)
-
         return self.async_result
 
     def is_local(self):
@@ -764,8 +661,6 @@ class LocalWorkflowTask(WorkflowTask):
                                 workflow_context=self.workflow_context,
                                 node=self.node,
                                 info=self.info,
-                                on_success=self.on_success,
-                                on_failure=self.on_failure,
                                 total_retries=self.total_retries,
                                 retry_interval=self.retry_interval,
                                 send_task_events=self.send_task_events,
@@ -783,15 +678,7 @@ class LocalWorkflowTask(WorkflowTask):
         return self.kwargs.get('__cloudify_context')
 
 
-# NOP tasks class
-class NOPLocalWorkflowTask(LocalWorkflowTask):
-
-    def __init__(self, workflow_context, **kwargs):
-        kwargs.update(
-            workflow_context=workflow_context,
-            local_task=lambda: None)
-        super(NOPLocalWorkflowTask, self).__init__(**kwargs)
-
+class NOPLocalWorkflowTask(WorkflowTask):
     @property
     def name(self):
         """The task name"""
@@ -810,17 +697,20 @@ class NOPLocalWorkflowTask(LocalWorkflowTask):
         })
         return stored
 
+    @with_execute_after
     def apply_async(self):
         self.set_state(TASK_SUCCEEDED)
-        return LocalWorkflowTaskResult(self)
+        self.async_result.result = None
+        return self.async_result
 
     def is_nop(self):
         return True
 
+    def is_local(self):
+        return True
 
-# Dry run tasks class
+
 class DryRunLocalWorkflowTask(LocalWorkflowTask):
-
     def apply_async(self):
         self.workflow_context.internal.send_task_event(TASK_SENDING, self)
         self.workflow_context.internal.send_task_event(TASK_STARTED, self)
@@ -830,141 +720,63 @@ class DryRunLocalWorkflowTask(LocalWorkflowTask):
             event={'result': 'dry run'}
         )
         self.set_state(TASK_SUCCEEDED)
-        return LocalWorkflowTaskResult(self)
+        self.async_result.result = None
+        return self.async_result
 
 
 class WorkflowTaskResult(object):
-    """A base wrapper for workflow task results"""
+    _NOT_SET = object()
 
     def __init__(self, task):
         self.task = task
+        self._callbacks = []
+        self._result = self._NOT_SET
 
-    def _process(self, retry_on_failure):
-        if self.task.workflow_context.internal.graph_mode:
-            return self._get()
-        task_graph = self.task.workflow_context.internal.task_graph
-        while True:
-            self._wait_for_task_terminated()
-            handler_result = self.task.handle_task_terminated()
-            task_graph.remove_task(self.task)
-            try:
-                result = self._get()
-                if handler_result.action != HandlerResult.HANDLER_RETRY:
-                    return result
-            except Exception:
-                if (not retry_on_failure or
-                        handler_result.action == HandlerResult.HANDLER_FAIL):
-                    raise
-            self._sleep(handler_result.retry_after)
-            self.task = handler_result.retried_task
-            task_graph.add_task(self.task)
-            self._check_execution_cancelled()
-            self.task.apply_async()
-            self._refresh_state()
+    def on_result(self, f, *a, **kw):
+        self._callbacks.append((f, a, kw))
+        if self._result is not self._NOT_SET:
+            f(self._result, *a, **kw)
 
-    @staticmethod
-    def _check_execution_cancelled():
-        if api.has_cancel_request():
-            raise api.ExecutionCancelled()
+    @property
+    def result(self):
+        if self._result is self._NOT_SET:
+            raise RuntimeError('Result not set yet')
+        return self._result
 
-    def _wait_for_task_terminated(self):
-        while True:
-            self._check_execution_cancelled()
-            try:
-                self.task.wait_for_terminated(timeout=1)
-                break
-            except queue.Empty:
-                continue
-
-    def _sleep(self, seconds):
-        while seconds > 0:
-            self._check_execution_cancelled()
-            sleep_time = 1 if seconds > 1 else seconds
-            time.sleep(sleep_time)
-            seconds -= sleep_time
+    @result.setter
+    def result(self, result):
+        if self._result is not self._NOT_SET:
+            raise RuntimeError('Result already set')
+        self._result = result
+        for f, a, kw in self._callbacks:
+            rv = f(self._result, *a, **kw)
+            if rv is not None:
+                self._result = rv
 
     def get(self, retry_on_failure=True):
-        """
-        Get the task result.
-        Will block until the task execution ends.
+        """Get the task result. Will block until the task execution ends.
 
         :return: The task result
         """
-        return self._process(retry_on_failure)
+        done = threading.Event()
 
-    def _get(self):
-        raise NotImplementedError('Implemented by subclasses')
+        api.cancel_callbacks.add(done.set)
+        self.on_result(lambda _result: done.set())
+        done.wait()
+        api.cancel_callbacks.discard(done.set)
 
-    def _refresh_state(self):
-        raise NotImplementedError('Implemented by subclasses')
+        if api.has_cancel_request():
+            self.result = api.ExecutionCancelled()
+            raise self.result
 
-
-class RemoteWorkflowErrorTaskResult(WorkflowTaskResult):
-
-    def __init__(self, task, exception):
-        super(RemoteWorkflowErrorTaskResult, self).__init__(task)
-        self.exception = exception
-
-    def _get(self):
-        raise self.exception
-
-    @property
-    def result(self):
-        return self.exception
-
-
-class RemoteWorkflowTaskResult(WorkflowTaskResult):
-    def __init__(self, task, async_result):
-        super(RemoteWorkflowTaskResult, self).__init__(task)
-        self.async_result = async_result
-
-    def _get(self):
-        return self.async_result.get()
-
-    def _refresh_state(self):
-        self.async_result = self.task.async_result.async_result
-
-    @property
-    def result(self):
-        return self.async_result.result
-
-
-class LocalWorkflowTaskResult(WorkflowTaskResult):
-    """A wrapper for local workflow task results"""
-
-    class ResultHolder(object):
-
-        def __init__(self, result=None, error=None):
-            self.result = result
-            self.error = error
-
-    def __init__(self, task):
-        """
-        :param task: The LocalWorkflowTask instance
-        """
-        super(LocalWorkflowTaskResult, self).__init__(task)
-        self._holder = self.ResultHolder()
-
-    def _get(self):
-        if self._holder.error is not None:
-            exception, traceback = self._holder.error
-            reraise(type(exception), exception, traceback)
-        return self._holder.result
-
-    def _refresh_state(self):
-        self._holder = self.task.async_result._holder
-
-    @property
-    def result(self):
-        if self._holder.error:
-            return self._holder.error[0]
-        else:
-            return self._holder.result
-
-
-class StubAsyncResult(object):
-    """Stub async result that always returns None"""
-    result = None
+        if self.task.get_state() in (TASK_FAILED, TASK_RESCHEDULED):
+            handler_result = self.task.handle_task_terminated()
+            if handler_result.retried_task and retry_on_failure:
+                handler_result.retried_task.apply_async()
+                return handler_result.retried_task.async_result.get()
+            else:
+                raise self.result
+        return self._result
 
 
 class HandlerResult(object):
@@ -986,6 +798,9 @@ class HandlerResult(object):
         # duplicating the task and updating the relevant task fields
         # or by a subgraph on_XXX handler
         self.retried_task = None
+
+    def __repr__(self):
+        return '<HandlerResult: {0}>'.format(self.action)
 
     @classmethod
     def retry(cls, ignore_total_retries=False, retry_after=None):

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -140,6 +140,14 @@ class WorkflowTask(object):
         task.stored = True
         return task
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        if isinstance(other, WorkflowTask):
+            return self.id == other.id
+        return self.id == other
+
     def __repr__(self):
         return '<{0} {1}>'.format(self.task_type, self.id)
 

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -458,6 +458,9 @@ class SubgraphTask(tasks.WorkflowTask):
         if not self.tasks:
             self.set_state(tasks.TASK_SUCCEEDED)
         else:
+            # subgraph started - allow its tasks to run - remove their
+            # dependency on the subgraph, so they don't wait on the
+            # subgraph anymore
             for task_id, task in self.tasks.items():
                 self.graph.remove_dependency(task, self)
             self.set_state(tasks.TASK_STARTED)

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -259,7 +259,7 @@ class TaskDependencyGraph(object):
                 task = self._ready.pop()
                 self._run_task(task)
 
-            self._tasks_wait.wait()
+            self._tasks_wait.wait(1)
 
             while self._finished_tasks:
                 task, result = self._finished_tasks.popitem()

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -15,10 +15,9 @@
 
 
 import time
+import threading
+from collections import defaultdict
 from functools import wraps
-
-
-import networkx as nx
 
 from cloudify.exceptions import WorkflowFailed
 from cloudify.workflows import api
@@ -47,8 +46,7 @@ def make_or_get_graph(f):
 
 
 class TaskDependencyGraph(object):
-    """
-    A task graph builder
+    """A task graph.
 
     :param workflow_context: A WorkflowContext instance (used for logging)
     """
@@ -65,12 +63,20 @@ class TaskDependencyGraph(object):
     def __init__(self, workflow_context, graph_id=None,
                  default_subgraph_task_config=None):
         self.ctx = workflow_context
-        self.graph = nx.DiGraph()
         default_subgraph_task_config = default_subgraph_task_config or {}
         self._default_subgraph_task_config = default_subgraph_task_config
         self._error = None
+        self._wake_after_fail = None
+        self._error_time = None
         self._stored = False
         self.id = graph_id
+        self._tasks = {}
+        self._dependencies = defaultdict(set)
+        self._dependents = defaultdict(set)
+        self._ready = set()
+        self._waiting_for = set()
+        self._tasks_wait = threading.Event()
+        self._finished_tasks = {}
 
     def _restore_dependencies(self, ops):
         """Set dependencies between this graph's tasks according to ops.
@@ -112,6 +118,7 @@ class TaskDependencyGraph(object):
                 subgraph_descr = ops_by_id[subgraph_id]
                 subgraph_descr['state'] = tasks.TASK_STARTED
                 subgraph = self._restore_operation(subgraph_descr)
+                self.add_task(subgraph)
                 restored_ops[subgraph_id] = subgraph
 
                 op.containing_subgraph = subgraph
@@ -135,10 +142,10 @@ class TaskDependencyGraph(object):
 
     def store(self, name):
         serialized_tasks = []
-        for task in self.tasks_iter():
+        for task in self._tasks.values():
             serialized = task.dump()
-            serialized['dependencies'] = list(
-                self.graph.succ.get(task.id, {}).keys())
+            serialized['dependencies'] = [
+                dep.id for dep in self._dependencies.get(task, [])]
             serialized_tasks.append(serialized)
         stored_graph = self.ctx.store_tasks_graph(
             name, operations=serialized_tasks)
@@ -146,12 +153,17 @@ class TaskDependencyGraph(object):
             self.id = stored_graph['id']
             self._stored = True
 
+    @property
+    def tasks(self):
+        return list(self._tasks.values())
+
     def add_task(self, task):
         """Add a WorkflowTask to this graph
 
         :param task: The task
         """
-        self.graph.add_node(task.id, task=task)
+        self._tasks[task.id] = task
+        self._ready.add(task)
 
     def get_task(self, task_id):
         """Get a task instance that was inserted to this graph by its id
@@ -160,8 +172,7 @@ class TaskDependencyGraph(object):
         :return: a WorkflowTask instance for the requested task if found.
                  None, otherwise.
         """
-        data = self.graph.node.get(task_id)
-        return data['task'] if data is not None else None
+        return self._tasks.get(task_id)
 
     def remove_task(self, task):
         """Remove the provided task from the graph
@@ -171,13 +182,19 @@ class TaskDependencyGraph(object):
         if task.is_subgraph:
             for subgraph_task in task.tasks.values():
                 self.remove_task(subgraph_task)
-        if task.id in self.graph:
-            self.graph.remove_node(task.id)
+        if task.id in self._tasks:
+            del self._tasks[task.id]
+            self._ready.discard(task)
+            for dependent in self._dependents.pop(task, []):
+                self._dependencies[dependent].discard(task)
+                if not self._dependencies.get(dependent):
+                    self._ready.add(dependent)
+            for dependency in self._dependencies.pop(task, []):
+                self._dependents[dependency].discard(task)
 
-    # src depends on dst
     def add_dependency(self, src_task, dst_task):
-        """
-        Add a dependency between tasks.
+        """Add a dependency between tasks: src depends on dst.
+
         The source task will only be executed after the target task terminates.
         A task may depend on several tasks, in which case it will only be
         executed after all its 'destination' tasks terminate
@@ -185,13 +202,24 @@ class TaskDependencyGraph(object):
         :param src_task: The source task
         :param dst_task: The target task
         """
-        if not self.graph.has_node(src_task.id):
-            raise RuntimeError('source task {0} is not in graph (task id: '
-                               '{1})'.format(src_task, src_task.id))
-        if not self.graph.has_node(dst_task.id):
-            raise RuntimeError('destination task {0} is not in graph (task '
-                               'id: {1})'.format(dst_task, dst_task.id))
-        self.graph.add_edge(src_task.id, dst_task.id)
+        if src_task.id not in self._tasks:
+            raise RuntimeError('src not in graph: {0!r}'.format(src_task))
+        if dst_task.id not in self._tasks:
+            raise RuntimeError('dst not in graph: {0!r}'.format(dst_task))
+        self._dependencies[src_task].add(dst_task)
+        self._dependents[dst_task].add(src_task)
+        self._ready.discard(src_task)
+
+    def remove_dependency(self, src_task, dst_task):
+        if src_task.id not in self._tasks:
+            raise RuntimeError('src not in graph: {0!r}'.format(src_task))
+        if dst_task.id not in self._tasks:
+            raise RuntimeError('dst not in graph: {0!r}'.format(dst_task))
+        self._dependencies[src_task].discard(dst_task)
+        self._dependents[dst_task].discard(src_task)
+        if not self._dependencies[src_task]:
+            self._ready.add(src_task)
+            self._tasks_wait.set()
 
     def sequence(self):
         """
@@ -206,155 +234,102 @@ class TaskDependencyGraph(object):
         return task
 
     def execute(self):
-        """
-        Start executing the graph based on tasks and dependencies between
-        them.\
-        Calling this method will block until one of the following occurs:\
-            1. all tasks terminated\
-            2. a task failed\
-            3. an unhandled exception is raised\
-            4. the execution is cancelled\
+        """Execute tasks in this graph.
 
-        Note: This method will raise an api.ExecutionCancelled error if the\
-        execution has been cancelled. When catching errors raised from this\
-        method, make sure to re-raise the error if it's\
-        api.ExecutionsCancelled in order to allow the execution to be set in\
-        cancelled mode properly.\
+        Run ready tasks, register callbacks on their result, process
+        results from tasks that did finish.
+        Tasks whose dependencies finished, are marked as ready for
+        the next iteration.
 
-        Also note that for the time being, if such a cancelling event\
-        occurs, the method might return even while there's some operations\
-        still being executed.
+        This main loop is directed by the _tasks_wait event, which
+        is set only when there is something to be done: a task response
+        has been received, some tasks dependencies finished which makes
+        new tasks ready to be run, or the execution was cancelled.
+
+        If a task failed, wait for ctx.wait_after_fail for additional
+        responses to come in anyway.
         """
-        # clear error, in case the tasks graph has been reused
         self._error = None
+        api.cancel_callbacks.add(self._tasks_wait.set)
 
-        while self._error is None:
+        while not self._is_finished():
+            self._tasks_wait.clear()
 
-            if self._is_execution_cancelled():
-                raise api.ExecutionCancelled()
+            while self._ready and not self._error:
+                task = self._ready.pop()
+                self._run_task(task)
 
-            # handle all terminated tasks
-            # it is important this happens before handling
-            # executable tasks so we get to make tasks executable
-            # and then execute them in this iteration (otherwise, it would
-            # be the next one)
-            for task in self._terminated_tasks():
-                self._handle_terminated_task(task)
+            self._tasks_wait.wait()
 
-            # if there was an error when handling terminated tasks, don't
-            # continue on to sending new tasks in handle_executable
-            if self._error:
-                break
+            while self._finished_tasks:
+                task, result = self._finished_tasks.popitem()
+                self._handle_terminated_task(result, task)
 
-            # handle all executable tasks
-            for task in self._executable_tasks():
-                self._handle_executable_task(task)
+        api.cancel_callbacks.discard(self._tasks_wait.set)
+        if self._wake_after_fail:
+            self._wake_after_fail.cancel()
+        if self._error:
+            raise self._error
 
-            # no more tasks to process, time to move on
-            if len(self.graph.node) == 0:
-                if self._error:
-                    raise self._error
-                return
-            # sleep some and do it all over again
+    def _is_finished(self):
+        if api.has_cancel_request():
+            self._error = api.ExecutionCancelled()
+            return True
+
+        if not self._tasks:
+            return True
+
+        if self._error:
+            if not self._waiting_for:
+                return True
+            deadline = self._error_time + self.ctx.wait_after_fail
+            if deadline > time.time():
+                return True
             else:
-                time.sleep(0.1)
+                self._wake_after_fail = threading.Timer(
+                    deadline - time.time(),
+                    self._tasks_wait.set)
+                self._wake_after_fail.daemon = True
+                self._wake_after_fail.start()
+        return False
 
-        # if we got here, we had an error in a task, and we're just waiting
-        # for other tasks to return, but not sending new tasks
-        deadline = time.time() + self.ctx.wait_after_fail
-        while deadline > time.time():
-            if self._is_execution_cancelled():
-                raise api.ExecutionCancelled()
-            for task in self._terminated_tasks():
-                self._handle_terminated_task(task)
-            if not any(self._sent_tasks()):
-                break
-            else:
-                time.sleep(0.1)
-        raise self._error
+    def _run_task(self, task):
+        result = task.apply_async()
+        self._waiting_for.add(task)
+        result.on_result(self._task_finished, task)
 
-    @staticmethod
-    def _is_execution_cancelled():
-        return api.has_cancel_request()
+    def _task_finished(self, result, task):
+        self._finished_tasks[task] = result
+        self._tasks_wait.set()
 
-    def _executable_tasks(self):
-        """
-        A task is executable if it is in pending state
-        , it has no dependencies at the moment (i.e. all of its dependencies
-        already terminated) and its execution timestamp is smaller then the
-        current timestamp
-
-        :return: An iterator for executable tasks
-        """
-        now = time.time()
-        return (task for task in self.tasks_iter()
-                if (task.get_state() == tasks.TASK_PENDING or
-                    task._should_resume()) and
-                task.execute_after <= now and
-                not (task.containing_subgraph and
-                     task.containing_subgraph.get_state() ==
-                     tasks.TASK_FAILED) and
-                not self._task_has_dependencies(task))
-
-    def _terminated_tasks(self):
-        """
-        A task is terminated if it is in 'succeeded' or 'failed' state
-
-        :return: An iterable of terminated tasks
-        """
-        return [task for task in self.tasks_iter()
-                if task.get_state() in tasks.TERMINATED_STATES]
-
-    def _sent_tasks(self):
-        """Tasks that are in the 'sent' state"""
-        return (task for task in self.tasks_iter()
-                if task.get_state() == tasks.TASK_SENT)
-
-    def _task_has_dependencies(self, task):
-        """
-        :param task: The task
-        :return: Does this task have any dependencies
-        """
-        return (len(self.graph.succ.get(task.id, {})) > 0 or
-                (task.containing_subgraph and self._task_has_dependencies(
-                    task.containing_subgraph)))
-
-    def tasks_iter(self):
-        """
-        An iterator on tasks added to the graph
-        """
-        return (data['task'] for _, data in self.graph.nodes_iter(data=True))
-
-    def _handle_executable_task(self, task):
-        """Handle executable task"""
-        task.apply_async()
-
-    def _handle_terminated_task(self, task):
-        """Handle terminated task"""
+    def _handle_terminated_task(self, result, task):
+        self._waiting_for.discard(task)
         handler_result = task.handle_task_terminated()
-
-        dependents = self.graph.predecessors(task.id)
-        removed_edges = [(dependent, task.id)
-                         for dependent in dependents]
-        self.graph.remove_edges_from(removed_edges)
-        self.graph.remove_node(task.id)
         if handler_result.action == tasks.HandlerResult.HANDLER_FAIL:
             if isinstance(task, SubgraphTask) and task.failed_task:
                 task = task.failed_task
             message = "Task failed '{0}'".format(task.name)
-            if task.error:
-                message = '{0} -> {1}'.format(message, task.error)
+            if result and not isinstance(result, tasks.HandlerResult):
+                message = '{0} -> {1}'.format(message, result)
             if self._error is None:
                 self._error = WorkflowFailed(message)
+                self._error_time = time.time()
         elif handler_result.action == tasks.HandlerResult.HANDLER_RETRY:
             new_task = handler_result.retried_task
             if self.id is not None:
-                self.ctx.store_operation(new_task, dependents, self.id)
+                self.ctx.store_operation(
+                    new_task,
+                    [dep.id for dep in self._dependencies[task]],
+                    self.id)
                 new_task.stored = True
             self.add_task(new_task)
-            added_edges = [(dependent, new_task.id)
-                           for dependent in dependents]
-            self.graph.add_edges_from(added_edges)
+            for dependency in self._dependencies[task]:
+                self.add_dependency(new_task, self.get_task(dependency))
+            for dependent in self._dependents[task]:
+                self.add_dependency(self.get_task(dependent), new_task)
+
+        self.remove_task(task)
+        self._tasks_wait.set()
 
 
 class forkjoin(object):
@@ -381,19 +356,17 @@ class TaskSequence(object):
         self.last_fork_join_tasks = None
 
     def add(self, *tasks):
-        """
-        Add tasks to the sequence.
+        """Add tasks to the sequence.
 
         :param tasks: Each task might be:
-
-                      * A WorkflowTask instance, in which case, it will be
-                        added to the graph with a dependency between it and
-                        the task previously inserted into the sequence
-                      * A forkjoin of tasks, in which case it will be treated
-                        as a "fork-join" task in the sequence, i.e. all the
-                        fork-join tasks will depend on the last task in the
-                        sequence (could be fork join) and the next added task
-                        will depend on all tasks in this fork-join task
+            * A WorkflowTask instance, in which case, it will be
+              added to the graph with a dependency between it and
+              the task previously inserted into the sequence
+            * A forkjoin of tasks, in which case it will be treated
+              as a "fork-join" task in the sequence, i.e. all the
+              fork-join tasks will depend on the last task in the
+              sequence (could be fork join) and the next added task
+              will depend on all tasks in this fork-join task
         """
         for fork_join_tasks in tasks:
             if isinstance(fork_join_tasks, forkjoin):
@@ -474,6 +447,7 @@ class SubgraphTask(tasks.WorkflowTask):
 
     def add_task(self, task):
         self.graph.add_task(task)
+        self.add_dependency(task, self)
         self.tasks[task.id] = task
         if task.containing_subgraph and task.containing_subgraph is not self:
             raise RuntimeError('task {0}[{1}] cannot be contained in more '

--- a/cloudify/workflows/workflow_api.py
+++ b/cloudify/workflows/workflow_api.py
@@ -19,6 +19,26 @@ EXECUTION_CANCELLED_RESULT = 'execution_cancelled'
 cancel_request = False
 kill_request = False
 
+cancel_callbacks = set()
+kill_callbacks = set()
+
+
+def set_cancel_request():
+    global cancel_request
+    cancel_request = True
+    for f in cancel_callbacks:
+        f()
+
+
+def set_kill_request():
+    global cancel_request, kill_request
+    cancel_request = True
+    kill_request = True
+    for f in kill_request:
+        f()
+    for f in cancel_callbacks:
+        f()
+
 
 def has_cancel_request():
     """

--- a/cloudify/workflows/workflow_api.py
+++ b/cloudify/workflows/workflow_api.py
@@ -34,7 +34,7 @@ def set_kill_request():
     global cancel_request, kill_request
     cancel_request = True
     kill_request = True
-    for f in kill_request:
+    for f in kill_callbacks:
         f()
     for f in cancel_callbacks:
         f()

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -18,7 +18,6 @@ import functools
 import copy
 import uuid
 import threading
-import time
 import logging
 
 from proxy_tools import proxy

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -473,7 +473,7 @@ class _WorkflowContextBase(object):
 
         :return: A task dependency graph instance
         """
-        if next(self.internal.task_graph.tasks_iter(), None) is not None:
+        if self.internal.task_graph.tasks:
             raise RuntimeError('Cannot switch to graph mode when tasks have '
                                'already been executed')
 

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -67,7 +67,7 @@ except ImportError:
     from ordereddict import OrderedDict
 
 
-DEFAULT_LOCAL_TASK_THREAD_POOL_SIZE = 1
+DEFAULT_LOCAL_TASK_THREAD_POOL_SIZE = 8
 
 
 class CloudifyWorkflowRelationshipInstance(object):


### PR DESCRIPTION
Rewrite the TasksGraph, and the WorkflowTasks themselves, to use callbacks
instead of polling task state.

This makes the graph execution faster and less resource-intensive, as well as
lower latency; also, the code is more readable (I hope!) as there's no more
things like multi-line conditions in `_executable_tasks`, no networkx graphs,
and less moving parts in the tasks themselves and the _TaskDispatcher.

Also some changes to the tests.

See each commit message for details.

BTW, @geokala, this WOULD be net -200 lines, it's only +60 because of the types.yaml! :P