### PR TITLE
WorkflowTaskResult.get: support cancel when task is already done

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -832,8 +832,9 @@ class WorkflowTaskResult(object):
         api.cancel_callbacks.discard(done.set)
 
         if api.has_cancel_request():
-            self.result = api.ExecutionCancelled()
-            raise self.result
+            if self._result is self._NOT_SET:
+                self.result = api.ExecutionCancelled()
+                raise self.result
 
         ctx = self.task.workflow_context
         if not ctx.internal.graph_mode:


### PR DESCRIPTION
When the task gets finished, but we received a cancel request in
the meantime, just return the finish value.

Only throw ExecutionCancelled if we were cancelled and the task
has no return value (yet).

In other words, if the task finishes at the same time as the execution
gets cancelled, the task finish value gets priority. Because well,
it did finish.