### PR TITLE
SubgraphTask: pass kwargs to super

### DIFF
--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -393,7 +393,8 @@ class SubgraphTask(tasks.WorkflowTask):
         super(SubgraphTask, self).__init__(
             graph.ctx,
             task_id,
-            total_retries=total_retries)
+            total_retries=total_retries,
+            **kwargs)
         self.graph = graph
         self.tasks = {}
         self.failed_task = None


### PR DESCRIPTION
The superclass still needs to see the kwargs: at least the info
kwarg must be passed through, so that it can be stored/dumped.

Fixes `integration_tests/tests/agentless_tests/test_runtime_functions.py -k test_change_flag_update_resume`