### PR TITLE
Bump pyyaml to 5.3.1

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -141,8 +141,13 @@ pipeline {
                   fi'
                 pyenv install 2.6.9
                 pyenv global 2.6.9
-                '''    
-                install_test_dependencies('py26')
+                '''
+                // py26 uses py26-only-compatible versions of libs: pyyaml 4.2b4, hence the specialcased [dispatcher_py26]
+                sh '''#!/bin/bash
+                pip install -r dev-requirements.txt --user
+                pip install -r test-requirements.txt --user
+                pip install -e '.[dispatcher_py26]' --user
+                '''
                 pytest('dsl_parser')
                 pytest('script_runner')
                 pytest('cloudify')

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,13 @@ setup(
         # for running workflows (in the mgmtworker and the cli), as opposed
         # to eg. just executing operations (in the agent)
         'dispatcher': [
+            'PyYAML==5.3.1',
+            'networkx==1.9.1',
+        ],
+        # this is just a hack to allow running unittests on py26.
+        # DO NOT USE THIS ANYWHERE ELSE.
+        # to be removed ASAP whenever we can drop py26 agents.
+        'dispatcher_py26': [
             'PyYAML==4.2b4',
             'networkx==1.9.1',
         ],


### PR DESCRIPTION
Py 2.6 doesn't support pyyaml 5.3.1. Therefore, specialcase it to keep 4.2.

The only place we still allow py 2.6 is the agent, and that does NOT
install the `.[dispatcher]` extra anyway. But we do want to be able to
still run unittests.