### PR TITLE
rabbitmq_client: re-compute the url on every try

### DIFF
--- a/cloudify/rabbitmq_client.py
+++ b/cloudify/rabbitmq_client.py
@@ -52,10 +52,10 @@ class RabbitMQClient(object):
         request_kwargs.setdefault('headers', {})\
             .setdefault('Content-Type', 'application/json',)
 
-        url = '{0}/api/{1}'.format(self.base_url, url)
         while True:
+            full_url = '{0}/api/{1}'.format(self.base_url, url)
             try:
-                response = request_method(url, **request_kwargs)
+                response = request_method(full_url, **request_kwargs)
                 response.raise_for_status()
                 # Successful call, return the results
                 break
@@ -63,7 +63,7 @@ class RabbitMQClient(object):
                 base_message = (
                     'Failed making request to rabbitmq {url}. '
                     'Error was: {err_type}- {err_msg}. '.format(
-                        url=url,
+                        url=full_url,
                         err_type=type(err),
                         err_msg=str(err),
                     )


### PR DESCRIPTION
Yes we did change `self._target_host` every iteration.
However, that was formatted into the `url` only ONCE.

Now, format the whole url every iteration instead.