### PR TITLE
RD-655 Propagate workflow parameters to executions

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -864,6 +864,11 @@ class CloudifyContext(CommonContext):
             self._provider_context = self._endpoint.get_provider_context()
         return self._provider_context
 
+    @property
+    def workflow_parameters(self):
+        """Get workflow parameters associated with this context."""
+        return self._context.get('workflow_parameters', {})
+
     def get_operation(self):
         """Get the operation object for the currently-executed task."""
         return self._endpoint.get_operation(self.task_id)

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -410,9 +410,7 @@ def get_kerberos_indication(kerberos_env):
 
 def get_workflow_parameters():
     """Get workflow parameters (except `ctx` key) as a dict."""
-    p = workflow_parameters
-    if not isinstance(p, dict):
-        p = dict(p)
+    p = workflow_parameters.copy()
     if 'ctx' in p:
         del p['ctx']
     return p

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -35,7 +35,7 @@ from contextlib import contextmanager, closing
 from dsl_parser.constants import PLUGIN_INSTALL_KEY, PLUGIN_NAME_KEY
 
 from cloudify import constants
-from cloudify.state import workflow_ctx, ctx
+from cloudify.state import workflow_parameters, workflow_ctx, ctx
 from cloudify._compat import StringIO, parse_version
 from cloudify.constants import SUPPORTED_ARCHIVE_TYPES
 from cloudify.amqp_client import BlockingRequestResponseHandler
@@ -406,6 +406,16 @@ def get_kerberos_indication(kerberos_env):
     if kerberos_env is None:
         return None
     return str(kerberos_env).lower() == 'true'
+
+
+def get_workflow_parameters():
+    """Get workflow parameters (except `ctx` key) as a dict."""
+    p = workflow_parameters
+    if not isinstance(p, dict):
+        p = dict(p)
+    if 'ctx' in p:
+        del p['ctx']
+    return p
 
 
 class LocalCommandRunner(object):

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1417,6 +1417,7 @@ class RemoteContextHandler(CloudifyWorkflowContextHandler):
         return {'local': False,
                 'bypass_maintenance': utils.get_is_bypass_maintenance(),
                 'rest_token': utils.get_rest_token(),
+                'workflow_parameters': utils.get_workflow_parameters(),
                 'execution_token': utils.get_execution_token(),
                 'execution_creator_username':
                     utils.get_execution_creator_username()}


### PR DESCRIPTION
Add one more operation context parameter (`workflow_parameter`).  The
parameter is a copy of workflow's parameters, except for the `ctx` key
(which is both not necessary, hard to serialize and maybe even risky).