### PR TITLE
RD-1091 plugin_installer: skip setting the uninstalled state

### DIFF
--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -85,7 +85,8 @@ def _manage_plugin_state(pre_state, post_state, allow_missing=False):
     def _decorator(f):
         @wraps(f)
         def _inner(plugin, *args, **kwargs):
-            _set_state(plugin, state=pre_state)
+            if pre_state:
+                _set_state(plugin, state=pre_state)
             try:
                 rv = f(plugin, *args, **kwargs)
             except Exception as e:
@@ -93,7 +94,8 @@ def _manage_plugin_state(pre_state, post_state, allow_missing=False):
                            error=str(e))
                 raise
             else:
-                _set_state(plugin, state=post_state)
+                if post_state:
+                    _set_state(plugin, state=post_state)
                 return rv
         return _inner
     return _decorator
@@ -285,7 +287,7 @@ def _pip_install(source, venv, args):
             shutil.rmtree(plugin_dir, ignore_errors=True)
 
 
-@_manage_plugin_state(pre_state=PluginInstallationState.UNINSTALLING,
+@_manage_plugin_state(pre_state=None,
                       post_state=PluginInstallationState.UNINSTALLED,
                       allow_missing=True)
 def uninstall(plugin, deployment_id=None):


### PR DESCRIPTION
This makes the uninstall task not set the "UNINSTALLING" state
at all (just deletes the plugin and then sets UNINSTALLED, or ERROR).

The reasons are:
1. If the set-state fails, we end up not deleting the plugin
   directory. For some users this is a very fatal error (working
   on a plugin and deleting/uploading the plugin often, you end up
   keeping the old code)
2. The UNINSTALLING state is not very important because the plugin
   stays in this state for only the very short amount of time that
   it takes to delete a directory (if that fails, it goes to the
   ERROR state anyway). In practice, the set-state is going to take
   longer than the delete itself.

Taking those into account, the risk-of-fatal-error vs usefulness
suggests to just skip setting that state.