### PR TITLE
RD-1158 Add .deployment_groups to the deployment restclient response

### DIFF
--- a/cloudify_rest_client/deployments.py
+++ b/cloudify_rest_client/deployments.py
@@ -114,6 +114,13 @@ class Deployment(dict):
         """
         return self.get('labels')
 
+    @property
+    def deployment_groups(self):
+        """
+        :return: IDs of deployment groups that this deployment belongs to
+        """
+        return self.get('deployment_groups')
+
 
 class Workflow(dict):
 


### PR DESCRIPTION
Note that "groups" already means the scaling groups in the
deployment.