### PR TITLE
RD-1345 Use pika 0.11.2 for python version < 2.7.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'fasteners==0.13.0',
 ]
 
-if sys.version_info[:2] == (2, 6):
+if sys.version_info[:3] < (2, 7, 9):
     install_requires += ['pika==0.11.2', ]
 else:
     install_requires += ['pika==1.1.0', ]


### PR DESCRIPTION
This PR address the issue of `ssl` package where python 2.7.x earlier than 2.7.9 doesn't support ssl contexts which means we should check that and make all the python versions lower than 2.7.9 and also have 2.6 run the old pika instead which is 0.11.2 instead of running the latest one which is 1.1.0

