### PR TITLE
RD-959 Add labels to DSL

### DIFF
--- a/dsl_parser/constants.py
+++ b/dsl_parser/constants.py
@@ -42,6 +42,7 @@ NAMESPACES_MAPPING = 'namespaces_mapping'
 CONSTRAINTS = 'constraints'
 DEFAULT = 'default'
 TYPE = 'type'
+LABELS = 'labels'
 
 HOST_TYPE = 'cloudify.nodes.Compute'
 DEPENDS_ON_REL_TYPE = 'cloudify.relationships.depends_on'

--- a/dsl_parser/elements/blueprint.py
+++ b/dsl_parser/elements/blueprint.py
@@ -87,7 +87,8 @@ class Blueprint(Element):
         'data_types': data_types.DataTypes,
         'capabilities': misc.Capabilities,
         'imported_blueprints': misc.ImportedBlueprints,
-        'namespaces_mapping': misc.NamespacesMapping
+        'namespaces_mapping': misc.NamespacesMapping,
+        'labels': misc.Labels
     }
 
     requires = {
@@ -128,5 +129,6 @@ class Blueprint(Element):
                 self.child(misc.ImportedBlueprints).value,
             constants.NAMESPACES_MAPPING:
                 self.child(misc.NamespacesMapping).value,
-            constants.DATA_TYPES: self.child(data_types.DataTypes).value
+            constants.DATA_TYPES: self.child(data_types.DataTypes).value,
+            constants.LABELS: self.child(misc.Labels).value
         })

--- a/dsl_parser/elements/misc.py
+++ b/dsl_parser/elements/misc.py
@@ -144,10 +144,6 @@ class Label(DictNoDefaultElement):
         'value': LabelValue
     }
 
-
-class Labels(DictElement):
-    schema = Dict(type=Label)
-
     def validate(self, **kwargs):
         """
         A label's value cannot be a runtime property, since labels are
@@ -156,11 +152,14 @@ class Labels(DictElement):
         err_msg = "The label's value cannot be a runtime property. Please " \
                   "remove the `get_attribute` function from the values of {0}"
 
-        for label in self.children():
-            label_value = label.value['value']
-            label_values = (label_value if isinstance(label_value, list)
-                            else [label_value])
-            for value in label_values:
-                if isinstance(value, dict) and 'get_attribute' in value:
-                    raise exceptions.DSLParsingException(
-                        1, err_msg.format(label.name))
+        label_value = self.initial_value['value']
+        label_values = (label_value if isinstance(label_value, list)
+                        else [label_value])
+        for value in label_values:
+            if isinstance(value, dict) and 'get_attribute' in value:
+                raise exceptions.DSLParsingException(
+                    1, err_msg.format(self.name))
+
+
+class Labels(DictElement):
+    schema = Dict(type=Label)

--- a/dsl_parser/elements/misc.py
+++ b/dsl_parser/elements/misc.py
@@ -13,7 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-from dsl_parser import elements
+from dsl_parser import elements, exceptions
 from dsl_parser._compat import text_type
 from dsl_parser.elements import version as element_version
 from dsl_parser.framework.elements import (DictElement,
@@ -132,3 +132,35 @@ class NamespacesMapping(DictElement):
     namespaces.
     """
     schema = Dict(type=NamespaceMapping)
+
+
+class LabelValue(Element):
+    required = True
+    schema = Leaf(type=(text_type, list, dict))
+
+
+class Label(DictNoDefaultElement):
+    schema = {
+        'value': LabelValue
+    }
+
+
+class Labels(DictElement):
+    schema = Dict(type=Label)
+
+    def validate(self, **kwargs):
+        """
+        A label's value cannot be a runtime property, since labels are
+        assigned to deployment during its creation.
+        """
+        err_msg = "The label's value cannot be a runtime property. Please " \
+                  "remove the `get_attribute` function from the values of {0}"
+
+        for label in self.children():
+            label_value = label.value['value']
+            label_values = (label_value if isinstance(label_value, list)
+                            else [label_value])
+            for value in label_values:
+                if isinstance(value, dict) and 'get_attribute' in value:
+                    raise exceptions.DSLParsingException(
+                        1, err_msg.format(label.name))

--- a/dsl_parser/scan.py
+++ b/dsl_parser/scan.py
@@ -14,6 +14,7 @@
 #  * limitations under the License.
 
 from dsl_parser.constants import (NODES,
+                                  LABELS,
                                   INPUTS,
                                   OUTPUTS,
                                   POLICIES,
@@ -28,6 +29,7 @@ OUTPUTS_SCOPE = 'outputs'
 POLICIES_SCOPE = 'policies'
 SCALING_GROUPS_SCOPE = 'scaling_groups'
 CAPABILITIES_SCOPE = 'capabilities'
+LABELS_SCOPE = 'labels'
 
 # Searching for secrets in the blueprint only one time of the few times
 # that scan_service_template is called
@@ -175,6 +177,13 @@ def scan_service_template(plan, handler, replace=False, search_secrets=False):
                         path='{0}.{1}'.format(
                             CAPABILITIES,
                             capability_name),
+                        replace=replace)
+    for label_key, label in plan.get('labels', {}).items():
+        scan_properties(label,
+                        handler,
+                        scope=LABELS_SCOPE,
+                        context=label,
+                        path='{0}.{1}'.format(LABELS, label_key),
                         replace=replace)
 
     if collect_secrets and len(secrets) > 0:

--- a/dsl_parser/tests/test_labels.py
+++ b/dsl_parser/tests/test_labels.py
@@ -1,0 +1,71 @@
+from dsl_parser import constants, exceptions
+from dsl_parser.tasks import prepare_deployment_plan
+from dsl_parser.tests.abstract_test_parser import AbstractTestParser
+
+
+class TestLabels(AbstractTestParser):
+
+    def test_labels_definition(self):
+        yaml = """
+labels: {}
+"""
+        parsed = self.parse(yaml)
+        self.assertEqual(0, len(parsed[constants.LABELS]))
+
+    def test_label_definition(self):
+        yaml = """
+labels:
+    key1:
+        value: key1_val1
+    key2:
+        value:
+          - key2_val1
+          - key2_val2
+"""
+        parsed = self.parse(yaml)
+        labels = parsed[constants.LABELS]
+        self.assertEqual(2, len(labels))
+        self.assertEqual('key1_val1', labels['key1']['value'])
+        self.assertEqual(['key2_val1', 'key2_val2'], labels['key2']['value'])
+
+    def test_label_is_scanned(self):
+        yaml = """
+tosca_definitions_version: cloudify_dsl_1_3
+
+inputs:
+    a:
+        default: some_value
+
+labels:
+    concat:
+        value: { concat: ['a', 'b'] }
+    get_input:
+        value: { get_input: a }
+"""
+        plan = prepare_deployment_plan(self.parse(yaml))
+        labels = plan[constants.LABELS]
+        self.assertEqual('ab', labels['concat']['value'])
+        self.assertEqual('some_value', labels['get_input']['value'])
+
+    def test_label_value_get_attribute_fail(self):
+        yaml_1 = """
+tosca_definitions_version: cloudify_dsl_1_3
+
+labels:
+    get_attribute:
+        value: { get_attribute: [ node, attr ] }
+"""
+        yaml_2 = """
+tosca_definitions_version: cloudify_dsl_1_3
+
+labels:
+    get_attribute:
+        value:
+          - val1
+          - { get_attribute: [ node, attr ] }
+"""
+        message_regex = '.*cannot be a runtime property.*'
+        self.assertRaisesRegex(
+            exceptions.DSLParsingException, message_regex, self.parse, yaml_1)
+        self.assertRaisesRegex(
+            exceptions.DSLParsingException, message_regex, self.parse, yaml_2)


### PR DESCRIPTION
This PR handles adding `labels` to the DSL. Now, if you want to add labels to a deployment, you can do it straight from the blueprint itself by specifying them under `labels`. 

The labels' values are specified under the key `value`, so in the future, we will be able to add other keys to the `label` element (such as `description` or `constraints`).