### PR TITLE
RD-1414 Cluster client: also retry /archive 404s

### DIFF
--- a/cloudify/cluster.py
+++ b/cloudify/cluster.py
@@ -13,6 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+import re
 import types
 import random
 import requests
@@ -90,6 +91,8 @@ class ClusterHTTPClient(HTTPClient):
 
         This is because the file replication is asynchronous.
         """
+        if re.search('/(blueprints|snapshots)/[^/]+/archive', response.url):
+            return True
         disposition = response.headers.get('Content-Disposition')
         if not disposition:
             return False


### PR DESCRIPTION
We retry fileserver downloads with other cluster nodes, because
filesystem replication is asynchronous.
However /blueprints/<id>/archive is also a fileserver download,
but it's gated behind restservice so that its 404s dont necessarily
have the headers we're looking for. And in principle I suppose
error messages don't need to have that header.

So, also look at the URL when deciding whether to retry. Can't think
of a better way.

(same for snapshots, but of course snapshots aren't as important,
because we're not really downloading them all that much; but
blueprints, we do, in the upload_blueprint workflow)