### PR TITLE
RD-1410 Add labels/blueprints endpoint

### DIFF
--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -62,7 +62,8 @@ from cloudify_rest_client.deployment_modifications import (
     DeploymentModificationsClient)
 from cloudify_rest_client.inter_deployment_dependencies import (
     InterDeploymentDependencyClient)
-from cloudify_rest_client.labels import DeploymentsLabelsClient
+from cloudify_rest_client.labels import (DeploymentsLabelsClient,
+                                         BlueprintsLabelsClient)
 from cloudify_rest_client.filters import FiltersClient
 
 try:
@@ -489,3 +490,4 @@ class CloudifyClient(object):
             self._client)
         self.deployments_labels = DeploymentsLabelsClient(self._client)
         self.filters = FiltersClient(self._client)
+        self.blueprints_labels = BlueprintsLabelsClient(self._client)

--- a/cloudify_rest_client/labels.py
+++ b/cloudify_rest_client/labels.py
@@ -23,22 +23,34 @@ class Label(dict):
         return self['creator_id']
 
 
-class DeploymentsLabelsClient(object):
-    def __init__(self, api):
+class _LabelsClient(object):
+    def __init__(self, api, resource_name):
         self.api = api
+        self.resource_name = resource_name
 
     def list_keys(self):
         """
-        Returns all defined label keys, from all deployments.
+        Returns all defined label keys, from all elements of the resource.
         """
-        response = self.api.get('/labels/deployments')
+        response = self.api.get('/labels/{0}'.format(self.resource_name))
         return ListResponse(response['items'], response['metadata'])
 
     def list_key_values(self, label_key):
         """
         Returns all deployments labels' values for the specified key.
 
-        :param label_key: The deployments labels' key to list the values for.
+        :param label_key: The resource labels' key to list the values for.
         """
-        response = self.api.get('/labels/deployments/{0}'.format(label_key))
+        response = self.api.get(
+            '/labels/{0}/{1}'.format(self.resource_name, label_key))
         return ListResponse(response['items'], response['metadata'])
+
+
+class DeploymentsLabelsClient(_LabelsClient):
+    def __init__(self, api):
+        super().__init__(api, 'deployments')
+
+
+class BlueprintsLabelsClient(_LabelsClient):
+    def __init__(self, api):
+        super().__init__(api, 'blueprints')

--- a/cloudify_rest_client/labels.py
+++ b/cloudify_rest_client/labels.py
@@ -48,9 +48,9 @@ class _LabelsClient(object):
 
 class DeploymentsLabelsClient(_LabelsClient):
     def __init__(self, api):
-        super().__init__(api, 'deployments')
+        super(DeploymentsLabelsClient, self).__init__(api, 'deployments')
 
 
 class BlueprintsLabelsClient(_LabelsClient):
     def __init__(self, api):
-        super().__init__(api, 'blueprints')
+        super(BlueprintsLabelsClient, self).__init__(api, 'blueprints')


### PR DESCRIPTION
This PR adds the rest-client mechanism for the `labels/blueprints` endpoint.

The complementary PR for the rest service is https://github.com/cloudify-cosmo/cloudify-manager/pull/2681