### PR TITLE
RD-1414 Retry all 404 requests to blueprints/snapshots

### DIFF
--- a/cloudify/cluster.py
+++ b/cloudify/cluster.py
@@ -91,7 +91,7 @@ class ClusterHTTPClient(HTTPClient):
 
         This is because the file replication is asynchronous.
         """
-        if re.search('/(blueprints|snapshots)/[^/]+/archive', response.url):
+        if re.search('/(blueprints|snapshots)/', response.url):
             return True
         disposition = response.headers.get('Content-Disposition')
         if not disposition:


### PR DESCRIPTION
In principle, any request to those, can touch the filesystem, so any
404 there should be retried with another node