### PR TITLE
RD-1507 Change value to values in blueprint_labels

### DIFF
--- a/dsl_parser/elements/misc.py
+++ b/dsl_parser/elements/misc.py
@@ -141,7 +141,7 @@ class LabelValue(Element):
 
 class Label(DictNoDefaultElement):
     schema = {
-        'value': LabelValue
+        'values': LabelValue
     }
 
     def validate(self, **kwargs):
@@ -149,13 +149,19 @@ class Label(DictNoDefaultElement):
         A label's value cannot be a runtime property, since labels are
         assigned to deployment during its creation.
         """
-        err_msg = "The label's value cannot be a runtime property. Please " \
-                  "remove the `get_attribute` function from the values of {0}"
+        type_err_msg = "The label's value must be a string or an intrinsic " \
+                       "function. Please modify the values of {0}"
+        get_attr_err_msg = "The label's value cannot be a runtime property. " \
+                           "Please remove the `get_attribute` function from " \
+                           "the values of {0}"
 
-        for value in self.initial_value['value']:
+        for value in self.initial_value['values']:
+            if not isinstance(value, (dict, text_type)):
+                raise exceptions.DSLParsingException(
+                    1, type_err_msg.format(self.name))
             if isinstance(value, dict) and 'get_attribute' in value:
                 raise exceptions.DSLParsingException(
-                    1, err_msg.format(self.name))
+                    1, get_attr_err_msg.format(self.name))
 
 
 class Labels(DictElement):

--- a/dsl_parser/tests/test_labels.py
+++ b/dsl_parser/tests/test_labels.py
@@ -21,20 +21,20 @@ blueprint_labels: {}
         yaml_1 = """
 labels:
     key1:
-        value:
+        values:
             - key1_val1
     key2:
-        value:
+        values:
             - key2_val1
             - key2_val2
 """
         yaml_2 = """
 blueprint_labels:
     key1:
-        value:
+        values:
             - key1_val1
     key2:
-        value:
+        values:
             - key2_val1
             - key2_val2
 """
@@ -43,9 +43,9 @@ blueprint_labels:
             parsed = self.parse(yaml)
             labels = parsed[labels_type]
             self.assertEqual(2, len(labels))
-            self.assertEqual(['key1_val1'], labels['key1']['value'])
+            self.assertEqual(['key1_val1'], labels['key1']['values'])
             self.assertEqual(['key2_val1', 'key2_val2'],
-                             labels['key2']['value'])
+                             labels['key2']['values'])
 
     def test_label_is_scanned(self):
         yaml_1 = """
@@ -57,10 +57,10 @@ inputs:
 
 labels:
     concat:
-        value:
+        values:
             - { concat: ['a', 'b'] }
     get_input:
-        value:
+        values:
             - { get_input: a }
 """
         yaml_2 = """
@@ -72,18 +72,18 @@ inputs:
 
 blueprint_labels:
     concat:
-        value:
+        values:
             - { concat: ['a', 'b'] }
     get_input:
-        value:
+        values:
             - { get_input: a }
 """
         for yaml, labels_type in [(yaml_1, constants.LABELS),
                                   (yaml_2, constants.BLUEPRINT_LABELS)]:
             plan = prepare_deployment_plan(self.parse(yaml))
             labels = plan[labels_type]
-            self.assertEqual(['ab'], labels['concat']['value'])
-            self.assertEqual(['some_value'], labels['get_input']['value'])
+            self.assertEqual(['ab'], labels['concat']['values'])
+            self.assertEqual(['some_value'], labels['get_input']['values'])
 
     def test_label_value_get_attribute_fail(self):
         yaml_1 = """
@@ -91,7 +91,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 labels:
     get_attribute:
-        value:
+        values:
           - val1
           - { get_attribute: [ node, attr ] }
 """
@@ -100,11 +100,33 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 blueprint_labels:
     get_attribute:
-        value:
+        values:
           - val1
           - { get_attribute: [ node, attr ] }
 """
         message_regex = '.*cannot be a runtime property.*'
+        for yaml in yaml_1, yaml_2:
+            self.assertRaisesRegex(exceptions.DSLParsingException,
+                                   message_regex, self.parse, yaml)
+
+    def test_label_value_type_fail(self):
+        yaml_1 = """
+tosca_definitions_version: cloudify_dsl_1_3
+
+labels:
+    get_attribute:
+        values:
+          - [val1, val2]
+"""
+        yaml_2 = """
+tosca_definitions_version: cloudify_dsl_1_3
+
+blueprint_labels:
+    get_attribute:
+        values:
+          - [val1, val2]
+"""
+        message_regex = '.*must be a string or an intrinsic function.*'
         for yaml in yaml_1, yaml_2:
             self.assertRaisesRegex(exceptions.DSLParsingException,
                                    message_regex, self.parse, yaml)


### PR DESCRIPTION
- Changing `value` to `values` in the `blueprint_labels` section in the blueprint.
- Limiting the values to be of type `text_type` or dictionary.

Complementary PR https://github.com/cloudify-cosmo/cloudify-manager/pull/2701