### PR TITLE
CYBL-1107-Automatically fix inputs' types

### DIFF
--- a/cloudify_rest_client/deployment_updates.py
+++ b/cloudify_rest_client/deployment_updates.py
@@ -241,7 +241,8 @@ class DeploymentUpdatesClient(object):
                                        reinstall_list=None,
                                        preview=False,
                                        update_plugins=True,
-                                       runtime_only_evaluation=None):
+                                       runtime_only_evaluation=None,
+                                       auto_correct_types=None):
         if force:
             warnings.warn("The 'force' flag is deprecated", DeprecationWarning)
         data = {
@@ -261,6 +262,8 @@ class DeploymentUpdatesClient(object):
             data['reinstall_list'] = reinstall_list
         if runtime_only_evaluation is not None:
             data['runtime_only_evaluation'] = runtime_only_evaluation
+        if auto_correct_types is not None:
+            data['auto_correct_types'] = auto_correct_types
         uri = '/deployment-updates/{0}/update/initiate'.format(deployment_id)
         response = self.api.put(uri, data=data)
         return DeploymentUpdate(response)

--- a/dsl_parser/utils.py
+++ b/dsl_parser/utils.py
@@ -255,6 +255,23 @@ def parse_value(
         exceptions.ERROR_VALUE_DOES_NOT_MATCH_TYPE, err_msg)
 
 
+def cast_to_type(value, type_name):
+    """Try converting value to the specified type_name if possible."""
+
+    if not isinstance(value, text_type):
+        return value
+
+    try:
+        if type_name == 'integer':
+            return int(value)
+        if type_name == 'float':
+            return float(value)
+    except ValueError:
+        pass
+
+    return value
+
+
 def load_yaml(raw_yaml, error_message, filename=None):
     try:
         return yaml_loader.load(raw_yaml, filename)


### PR DESCRIPTION
* Inputs type casting functionality

In some rare (?) cases there might exist deployments with invalid type
of inputs (e.g. '20' stored where input type should be integer).  This
patch adds functionality to attempt to automatically cast types of input
values to expected (a.k.a. inputs auto-correction).

* Update rest_client to pass add_correct_types flag