### PR TITLE
RD-1482 Add deployment state to the deployment response

### DIFF
--- a/cloudify/models_states.py
+++ b/cloudify/models_states.py
@@ -53,6 +53,43 @@ class ExecutionState(object):
     QUEUED_STATE = [QUEUED]
     END_STATES = [TERMINATED, FAILED, CANCELLED]
 
+    # In progress execution states
+    IN_PROGRESS_STATES = [
+        PENDING,
+        STARTED,
+        CANCELLED,
+        FORCE_CANCELLING,
+        KILL_CANCELLING
+    ]
+
+
+class DeploymentState(object):
+    # Installation states
+    ACTIVE = 'active'
+    INACTIVE = 'inactive'
+
+    # Latest execution states
+    IN_PROGRESS = 'in_progress'
+    COMPLETED = 'completed'
+    FAILED = 'failed'
+    CANCELLED = 'cancelled'
+
+    # deployment states
+    GOOD = 'good'
+    REQUIRE_ATTENTION = 'require_attention'
+
+    EXECUTION_STATES_SUMMARY = {
+        ExecutionState.TERMINATED: COMPLETED,
+        ExecutionState.FAILED: FAILED,
+        ExecutionState.CANCELLED: CANCELLED,
+        ExecutionState.PENDING: IN_PROGRESS,
+        ExecutionState.STARTED: IN_PROGRESS,
+        ExecutionState.CANCELLING: IN_PROGRESS,
+        ExecutionState.FORCE_CANCELLING: IN_PROGRESS,
+        ExecutionState.KILL_CANCELLING: IN_PROGRESS,
+        ExecutionState.QUEUED: IN_PROGRESS
+    }
+
 
 # needs to be separate because python3 doesn't allow `if` in listcomps
 # using names from class scope

--- a/cloudify_rest_client/deployments.py
+++ b/cloudify_rest_client/deployments.py
@@ -122,6 +122,27 @@ class Deployment(dict):
         """
         return self.get('deployment_groups')
 
+    @property
+    def latest_execution_status(self):
+        """
+        :return: The deployment latest execution status
+        """
+        return self.get('latest_execution_status')
+
+    @property
+    def installation_status(self):
+        """
+        :return: The deployment installation status
+        """
+        return self.get('installation_status')
+
+    @property
+    def deployment_status(self):
+        """
+        :return: The overall deployment status
+        """
+        return self.get('deployment_status')
+
 
 class Workflow(dict):
 


### PR DESCRIPTION
This PR created in order to expose all the deployment statuses from the backend and it can be used on the client side to check all deployment statuses 