### PR TITLE
node/instances create_many: pass deployment_id separately

### DIFF
--- a/cloudify_rest_client/node_instances.py
+++ b/cloudify_rest_client/node_instances.py
@@ -109,17 +109,19 @@ class NodeInstancesClient(object):
         self._wrapper_cls = NodeInstance
         self._uri_prefix = 'node-instances'
 
-    def create_many(self, node_instances):
+    def create_many(self, deployment_id, node_instances):
         """Create multiple node-instances.
 
+        :param deployment_id: the new instances belong to this deployment
         :param node_instances: list of dicts representing the instances
              to be created. Each node dict must contain at least the
-             keys: id, node_id, deployment_id.
+             keys: id, node_id.
         :return: None
         """
         self.api.post(
             '/{self._uri_prefix}'.format(self=self),
             data={
+                'deployment_id': deployment_id,
                 'node_instances': node_instances
             },
             expected_status_code=(201, 204),

--- a/cloudify_rest_client/nodes.py
+++ b/cloudify_rest_client/nodes.py
@@ -222,17 +222,18 @@ class NodesClient(object):
         else:
             return result[0]
 
-    def create_many(self, nodes):
+    def create_many(self, deployment_id, nodes):
         """Create multiple nodes.
 
+        :param deployment_id: the new nodes belong to this deployment
         :param nodes: list of dicts representing the nodes to be created.
-            Each node dict must contain at least the keys: id, type, and
-            deployment_id.
+            Each node dict must contain at least the keys: id, type.
         :return: None
         """
         self.api.post(
             '/{self._uri_prefix}'.format(self=self),
             data={
+                'deployment_id': deployment_id,
                 'nodes': nodes
             },
             expected_status_code=(201, 204),


### PR DESCRIPTION
these methods need the deployment id, and it seems better to pass it
separately rather than have to put it in every single node