### PR TITLE
RD-1397 Allow complex weekdays in DSL validation

### DIFF
--- a/dsl_parser/elements/deployment_schedules.py
+++ b/dsl_parser/elements/deployment_schedules.py
@@ -106,7 +106,7 @@ class Weekday(Element):
     def validate(self):
         weekdays_list = ['su', 'mo', 'tu', 'we', 'th', 'fr', 'sa']
         err_msg = "{0} is not a valid weekday value. Accepted values: {1}"
-        weekday_value = self.initial_value.lower()
+        weekday_value = self.initial_value.lower()[-2:]
         if weekday_value not in weekdays_list:
             raise exceptions.DSLParsingException(
                 1, err_msg.format(weekday_value, weekdays_list))


### PR DESCRIPTION
The change is to allow complex weekdays such as _2mo_ for the 2nd monday of the month, or _l-fr_ for the last friday of the month  to pass validation at the DSL