### PR TITLE
CYBL-1118 Automatically correct valid booleans

### DIFF
--- a/dsl_parser/utils.py
+++ b/dsl_parser/utils.py
@@ -266,6 +266,11 @@ def cast_to_type(value, type_name):
             return int(value)
         if type_name == 'float':
             return float(value)
+        if type_name == 'boolean':
+            if value == 'true':
+                return True
+            if value == 'false':
+                return False
     except ValueError:
         pass
 


### PR DESCRIPTION
Extend types auto-correction functionality to boolean type.  Map
strings: `"true"` to boolean `True` and `"false"` to `False`.