### PR TITLE
CYBL-1114 Reevaluate plugins update statuses

### DIFF
--- a/cloudify_rest_client/plugins_update.py
+++ b/cloudify_rest_client/plugins_update.py
@@ -109,7 +109,8 @@ class PluginsUpdateClient(object):
     def update_plugins(self, blueprint_id, force=False, plugin_names=None,
                        to_latest=None, all_to_latest=True,
                        to_minor=None, all_to_minor=False,
-                       mapping=None, auto_correct_types=False):
+                       mapping=None, auto_correct_types=False,
+                       reevaluate_active_statuses=False,):
         """
         Updates the plugins in all the deployments that use the given
         blueprint.
@@ -132,6 +133,8 @@ class PluginsUpdateClient(object):
          constraints)
         :param auto_correct_types: auto_correct_types flag to run deployments
         update with.
+        :param reevaluate_active_statuses: reevaluate active plugin-updates'
+        states based on relevant executions statuses.
         :return: a PluginUpdate object.
         """
         if mapping and mapping.get('updates'):
@@ -152,6 +155,7 @@ class PluginsUpdateClient(object):
                 mapping=mapping,
                 force=force,
                 auto_correct_types=auto_correct_types,
+                reevaluate_active_statuses=reevaluate_active_statuses
             )
         )
         return PluginsUpdate(response)

--- a/cloudify_rest_client/plugins_update.py
+++ b/cloudify_rest_client/plugins_update.py
@@ -133,8 +133,8 @@ class PluginsUpdateClient(object):
          constraints)
         :param auto_correct_types: auto_correct_types flag to run deployments
         update with.
-        :param reevaluate_active_statuses: reevaluate active plugin-updates'
-        states based on relevant executions statuses.
+        :param reevaluate_active_statuses: reevaluate active plugin-updates' and
+        deployment-updates' states based on relevant executions statuses.
         :return: a PluginUpdate object.
         """
         if mapping and mapping.get('updates'):

--- a/cloudify_rest_client/plugins_update.py
+++ b/cloudify_rest_client/plugins_update.py
@@ -133,8 +133,8 @@ class PluginsUpdateClient(object):
          constraints)
         :param auto_correct_types: auto_correct_types flag to run deployments
         update with.
-        :param reevaluate_active_statuses: reevaluate active plugin-updates' and
-        deployment-updates' states based on relevant executions statuses.
+        :param reevaluate_active_statuses: reevaluate active plugin-updates'
+        and deployment-updates' states based on relevant executions statuses.
         :return: a PluginUpdate object.
         """
         if mapping and mapping.get('updates'):


### PR DESCRIPTION
The purpose of this modification is to provide the administrator with a tool to reconcile the statuses of plugins updates according to statuses of relevant executions.

The new `reevaluate_active_statuses` flag in the `PluginsUpdateClient.update_plugins()` will force reevaluation of active plugins-updates' statuses based on following scheme:

```
 execution status | new plugins_update status
------------------+---------------------------
 terminated       | successful
 failed           | failed
 cancelled        | failed
 cancelling       | failed
 force_cancelling | failed
 kill_cancelling  | failed
```