### PR TITLE
Parse datetime utils: handle shorter months

### DIFF
--- a/cloudify/tests/test_utils.py
+++ b/cloudify/tests/test_utils.py
@@ -258,9 +258,18 @@ class TestDateTimeUtils(TestCase):
         current_month = now.month
         expected_month = 1 if current_month == 12 else current_month + 1
         expected_year = now.year + (2 if current_month == 12 else 1)
+        expected_day = now.day
         expected_datetime = now.replace(
-            second=0, microsecond=0, year=expected_year, month=expected_month)
+            day=1, second=0, microsecond=0, year=expected_year,
+            month=expected_month)
+        expected_datetime += timedelta(days=expected_day - 1)
         self.assertEqual(parsed_datetime, expected_datetime)
+
+    def test_parse_timedelta_month_days(self):
+        dt = datetime(2021, 3, 31)
+        parsed = utils.parse_and_apply_timedelta('1mo', dt)
+        # march 31st + 1 mo would be april 31st, but that's may 1st
+        self.assertEqual(parsed, datetime(2021, 5, 1))
 
     def test_parse_utc_datetime_years_delta(self):
         parsed_datetime = utils.parse_utc_datetime("+2y")

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -1006,7 +1006,9 @@ def parse_and_apply_timedelta(expr, date_time):
     if period in ['mo', 'month']:
         new_month = (date_time.month + number) % 12
         new_year = date_time.year + (date_time.month + number) // 12
-        return date_time.replace(month=new_month, year=new_year)
+        new_day = date_time.day
+        date_time = date_time.replace(day=1, month=new_month, year=new_year)
+        return date_time + timedelta(days=new_day - 1)
     if period in ['w', 'week']:
         return date_time + timedelta(days=number * 7)
     if period in ['d', 'day']:


### PR DESCRIPTION
Adding a "month" timedelta is not that easy! We'd like to have used
dateutil.relativedelta here, but we don't have dateutil in here, and
I don't want to pull it in for just this.

Just doing .replace(month=month+delta) isn't enough, because for
some values that's a ValueError: eg. you can't add 1month to
March 31st this way, because that would end up being April 31st, and
that doesn't exist.

Instead, .replace the month for a datetime with day=1
(so Mar31 -> Apr01) and then add the original number of days as a
timedelta, which does carry over the month
(so Apr01 + 30 days -> Apr31 -> May01).