### PR TITLE
RD-1602 Async inter deployment dependencies

### DIFF
--- a/cloudify/deployment_dependencies.py
+++ b/cloudify/deployment_dependencies.py
@@ -16,6 +16,7 @@
 DEPENDENCY_CREATOR = 'dependency_creator'
 SOURCE_DEPLOYMENT = 'source_deployment'
 TARGET_DEPLOYMENT = 'target_deployment'
+TARGET_DEPLOYMENT_FUNC = 'target_deployment_func'
 EXTERNAL_SOURCE = 'external_source'
 EXTERNAL_TARGET = 'external_target'
 
@@ -23,6 +24,7 @@ EXTERNAL_TARGET = 'external_target'
 def create_deployment_dependency(dependency_creator,
                                  source_deployment,
                                  target_deployment=None,
+                                 target_deployment_func=None,
                                  external_source=None,
                                  external_target=None):
     dependency = {
@@ -31,6 +33,8 @@ def create_deployment_dependency(dependency_creator,
     }
     if target_deployment:
         dependency[TARGET_DEPLOYMENT] = target_deployment
+    if target_deployment_func:
+        dependency[TARGET_DEPLOYMENT_FUNC] = target_deployment_func
     if external_source:
         dependency[EXTERNAL_SOURCE] = external_source
     if external_target:

--- a/cloudify_rest_client/inter_deployment_dependencies.py
+++ b/cloudify_rest_client/inter_deployment_dependencies.py
@@ -62,7 +62,8 @@ class InterDeploymentDependencyClient(object):
         )
 
     def create(self, dependency_creator, source_deployment, target_deployment,
-               external_source=None, external_target=None):
+               external_source=None, external_target=None,
+               target_deployment_func=None):
         """Creates an inter-deployment dependency.
 
         :param dependency_creator: a string representing the entity that
@@ -78,11 +79,14 @@ class InterDeploymentDependencyClient(object):
         :param external_target: if the source deployment uses an external
         resource as target, pass here a JSON containing the target deployment
         metadata, i.e. deployment name, tenant name, and the manager host(s).
+        :param target_deployment_func: a function used to determine the target
+        deployment.
         :return: an InterDeploymentDependency object.
         """
         data = create_deployment_dependency(dependency_creator,
                                             source_deployment,
                                             target_deployment,
+                                            target_deployment_func,
                                             external_source,
                                             external_target)
         response = self.api.put(
@@ -115,8 +119,8 @@ class InterDeploymentDependencyClient(object):
         data = create_deployment_dependency(dependency_creator,
                                             source_deployment,
                                             target_deployment,
-                                            external_source,
-                                            external_target)
+                                            external_source=external_source,
+                                            external_target=external_target)
         data['is_component_deletion'] = is_component_deletion
         self.api.delete('/{self._uri_prefix}'.format(self=self), data=data)
 


### PR DESCRIPTION
Add target_deployment_func in create_deployment_dependencies

Until today the inter-deployment dependencies REST client did not handle
target_deployment_func.  As we plan on using it instead of a direct DB
access when creating inter-deployment dependencies, it's a must-have.