### PR TITLE
RD-1165 Add get_group_capability

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -726,13 +726,6 @@ class InterDeploymentDependencyCreatingFunction(Function):
             {}
         )[self.function_identifier] = self.target_deployment
 
-    def evaluate(self, handler):
-        return self._evaluate(handler)
-
-    @abc.abstractmethod
-    def _evaluate(self, handler):
-        pass
-
     @abc.abstractproperty
     def target_deployment(self):
         pass
@@ -771,7 +764,7 @@ class GetCapability(InterDeploymentDependencyCreatingFunction):
 
         self.capability_path = args
 
-    def _evaluate(self, handler):
+    def evaluate(self, handler):
         return handler.get_capability(self.capability_path)
 
     def validate(self, plan):

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -777,6 +777,44 @@ class GetCapability(InterDeploymentDependencyCreatingFunction):
         return target_deployment, first_arg
 
 
+@register(name='get_group_capability', func_eval_type=RUNTIME_FUNC)
+class GetGroupCapability(Function):
+    def __init__(self, args, **kwargs):
+        self.capability_path = None
+        super(GetGroupCapability, self).__init__(args, **kwargs)
+
+    def parse_args(self, args):
+        if not isinstance(args, list):
+            raise ValueError(
+                "`get_group_capability` function argument should be a list. "
+                "Instead it is a {0} with the value: {1}."
+                .format(type(args), args))
+        if len(args) < 2:
+            raise ValueError(
+                "`get_group_capability` function argument should be a list "
+                "with 2 elements at least - [ group ID, capability ID "
+                "[, key/index[, key/index [...]]] ]. Instead it is: [{0}]"
+                .format(','.join('{0}'.format(a) for a in args))
+            )
+        for arg_index, arg in enumerate(args):
+            if arg_index == 1 and isinstance(arg, list):
+                continue
+            if not isinstance(arg, (text_type, int)) and not is_function(arg):
+                raise ValueError(
+                    "`get_group_capability` function arguments can't be "
+                    "complex values; only strings/ints/functions are "
+                    "accepted. Instead, the item with index {0} is {1} "
+                    "of type {2}".format(arg_index, arg, type(arg))
+                )
+        self.capability_path = args
+
+    def evaluate(self, handler):
+        return handler.get_group_capability(self.capability_path)
+
+    def validate(self, plan):
+        pass
+
+
 @register(name='get_label', func_eval_type=RUNTIME_FUNC)
 class GetLabel(Function):
     def __init__(self, args, **kwargs):
@@ -1069,6 +1107,7 @@ class _RuntimeEvaluationHandler(_EvaluationHandler):
         self._secrets_cache = {}
         self._capabilities_cache = {}
         self._labels_cache = {}
+        self._group_capabilities_cache = {}
 
     def get_input(self, input_name):
         return self._storage.get_input(input_name)
@@ -1106,6 +1145,14 @@ class _RuntimeEvaluationHandler(_EvaluationHandler):
             capability = self._storage.get_capability(capability_path)
             self._capabilities_cache[capability_id] = capability
         return self._capabilities_cache[capability_id]
+
+    def get_group_capability(self, capability_path):
+        capability_id = _convert_attribute_list_to_python_syntax_string(
+            capability_path)
+        if capability_id not in self._group_capabilities_cache:
+            capability = self._storage.get_group_capability(capability_path)
+            self._group_capabilities_cache[capability_id] = capability
+        return self._group_capabilities_cache[capability_id]
 
     def get_label(self, label_key, values_list_index):
         labels_cache_entry = (label_key if values_list_index is None else

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -760,16 +760,13 @@ class GetCapability(InterDeploymentDependencyCreatingFunction):
                 "[, key/index[, key/index [...]]] ]. Instead it is: [{0}]"
                 .format(','.join('{0}'.format(a) for a in args))
             )
-        for arg_index in range(len(args)):
-            if not isinstance(args[arg_index], (text_type, int)) \
-                    and not is_function(args[arg_index]):
+        for arg_index, arg in enumerate(args):
+            if not isinstance(arg, (text_type, int)) and not is_function(arg):
                 raise ValueError(
                     "`get_capability` function arguments can't be complex "
                     "values; only strings/ints/functions are accepted. "
-                    "Instead, the item with "
-                    "index {0} is {1} of type {2}".format(
-                        arg_index, args[arg_index], type(args[arg_index])
-                    )
+                    "Instead, the item with index {0} is {1} of type {2}"
+                    .format(arg_index, arg, type(arg))
                 )
 
         self.capability_path = args

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -259,12 +259,14 @@ imports:"""
         return ordered_nodes
 
     def _mock_evaluation_storage(self, node_instances=None, nodes=None,
-                                 inputs=None, secrets=None):
+                                 inputs=None, secrets=None,
+                                 capabilities=None):
         self._mock_storage = _MockRuntimeEvaluationStorage(
             node_instances or [],
             nodes or [],
             inputs or {},
-            secrets or {})
+            secrets or {},
+            capabilities or {})
         return self._mock_storage
 
     def get_secret(self, secret_name):
@@ -274,11 +276,12 @@ imports:"""
 
 
 class _MockRuntimeEvaluationStorage(object):
-    def __init__(self, node_instances, nodes, inputs, secrets):
+    def __init__(self, node_instances, nodes, inputs, secrets, capabilities):
         self._node_instances = node_instances
         self._nodes = nodes
         self._inputs = inputs or {}
         self._secrets = secrets or {}
+        self._capabilities = capabilities or {}
 
     def get_input(self, input_name):
         return self._inputs[input_name]
@@ -308,26 +311,9 @@ class _MockRuntimeEvaluationStorage(object):
             return Mock(value=self._secrets[secret_id])
         return Mock(value=secret_id + '_value')
 
-    @staticmethod
-    def get_capability(capability_path):
-        mock_deployments = {
-            'dep_1': {
-                'capabilities': {
-                    'cap_a': 'value_a_1',
-                    'cap_b': 'value_b_1'
-                }
-            },
-            'dep_2': {
-                'capabilities': {
-                    'cap_a': 'value_a_2',
-                    'cap_b': 'value_b_2'
-                }
-            }
-        }
-
+    def get_capability(self, capability_path):
         dep_id, cap_id = capability_path[0], capability_path[1]
-
-        return mock_deployments[dep_id]['capabilities'][cap_id]
+        return self._capabilities[dep_id][cap_id]
 
     @staticmethod
     def set_inter_deployment_dependency(*_, **__):

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -269,33 +269,23 @@ imports:"""
 
         return ordered_nodes
 
-    def _mock_evaluation_storage(self, node_instances=None, nodes=None,
-                                 inputs=None, secrets=None, labels=None,
-                                 capabilities=None):
-        self._mock_storage = _MockRuntimeEvaluationStorage(
-            node_instances or [],
-            nodes or [],
-            inputs or {},
-            secrets or {},
-            capabilities or {},
-            labels or {})
-        return self._mock_storage
+    @property
+    def _mock_evaluation_storage(self):
+        return _MockRuntimeEvaluationStorage
 
     def get_secret(self, secret_name):
-        if self._mock_storage:
-            return self._mock_storage.get_secret(secret_name)
         return self._mock_evaluation_storage().get_secret(secret_name)
 
 
 class _MockRuntimeEvaluationStorage(object):
-    def __init__(self, node_instances, nodes, inputs, secrets, capabilities,
-                 labels):
-        self._node_instances = node_instances
-        self._nodes = nodes
-        self._inputs = inputs
-        self._secrets = secrets
-        self._capabilities = capabilities
-        self._labels = labels
+    def __init__(self, node_instances=None, nodes=None, inputs=None,
+                 secrets=None, capabilities=None, labels=None):
+        self._node_instances = node_instances or []
+        self._nodes = nodes or []
+        self._inputs = inputs or {}
+        self._secrets = secrets or {}
+        self._capabilities = capabilities or {}
+        self._labels = labels or {}
 
     def get_input(self, input_name):
         return self._inputs[input_name]

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -279,13 +279,15 @@ imports:"""
 
 class _MockRuntimeEvaluationStorage(object):
     def __init__(self, node_instances=None, nodes=None, inputs=None,
-                 secrets=None, capabilities=None, labels=None):
+                 secrets=None, capabilities=None, labels=None,
+                 group_capabilities=None):
         self._node_instances = node_instances or []
         self._nodes = nodes or []
         self._inputs = inputs or {}
         self._secrets = secrets or {}
         self._capabilities = capabilities or {}
         self._labels = labels or {}
+        self._group_capabilities = group_capabilities or {}
 
     def get_input(self, input_name):
         return self._inputs[input_name]
@@ -323,3 +325,7 @@ class _MockRuntimeEvaluationStorage(object):
         if values_list_index is not None:
             return self._labels[label_key][values_list_index]
         return self._labels[label_key]
+
+    def get_group_capability(self, capability_path):
+        group_id, cap_id = capability_path[0], capability_path[1]
+        return self._group_capabilities[group_id][cap_id]

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -173,6 +173,13 @@ imports:"""
     -   {0}""".format(filename if not as_uri else self._path2url(filename))
         return yaml
 
+    def _local_resolver_rules(self):
+        types_path = os.path.join(
+            os.path.dirname(__file__), 'minimal_types.yaml')
+        return [
+            {'http://local-test-resolver/types.yaml': 'file://' + types_path}
+        ]
+
     def parse(self, dsl_string,
               resources_base_path=None,
               dsl_version=BASIC_VERSION_SECTION_DSL_1_0,
@@ -181,8 +188,9 @@ imports:"""
         # add dsl version if missing
         if DSL_VERSION_PREFIX not in dsl_string:
             dsl_string = dsl_version + dsl_string
-            if not resolver:
-                resolver = DefaultImportResolver()
+        if not resolver:
+            resolver = DefaultImportResolver(
+                rules=self._local_resolver_rules())
         return dsl_parse(dsl_string,
                          resources_base_path=resources_base_path,
                          resolver=resolver,
@@ -212,6 +220,9 @@ imports:"""
                         dsl_path,
                         resources_base_path=None,
                         resolver=None):
+        if not resolver:
+            resolver = DefaultImportResolver(
+                rules=self._local_resolver_rules())
         return dsl_parse_from_path(dsl_path,
                                    resources_base_path,
                                    resolver=resolver)

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -259,14 +259,15 @@ imports:"""
         return ordered_nodes
 
     def _mock_evaluation_storage(self, node_instances=None, nodes=None,
-                                 inputs=None, secrets=None,
+                                 inputs=None, secrets=None, labels=None,
                                  capabilities=None):
         self._mock_storage = _MockRuntimeEvaluationStorage(
             node_instances or [],
             nodes or [],
             inputs or {},
             secrets or {},
-            capabilities or {})
+            capabilities or {},
+            labels or {})
         return self._mock_storage
 
     def get_secret(self, secret_name):
@@ -276,12 +277,14 @@ imports:"""
 
 
 class _MockRuntimeEvaluationStorage(object):
-    def __init__(self, node_instances, nodes, inputs, secrets, capabilities):
+    def __init__(self, node_instances, nodes, inputs, secrets, capabilities,
+                 labels):
         self._node_instances = node_instances
         self._nodes = nodes
-        self._inputs = inputs or {}
-        self._secrets = secrets or {}
-        self._capabilities = capabilities or {}
+        self._inputs = inputs
+        self._secrets = secrets
+        self._capabilities = capabilities
+        self._labels = labels
 
     def get_input(self, input_name):
         return self._inputs[input_name]
@@ -315,19 +318,10 @@ class _MockRuntimeEvaluationStorage(object):
         dep_id, cap_id = capability_path[0], capability_path[1]
         return self._capabilities[dep_id][cap_id]
 
-    @staticmethod
-    def set_inter_deployment_dependency(*_, **__):
+    def set_inter_deployment_dependency(self, *_, **__):
         pass
 
-    @staticmethod
-    def get_label(label_key, values_list_index):
-        mock_labels = {
-            'key1': ['val1', 'val2'],
-            'key2': ['val3', 'val4'],
-            'key3': ['dep_1', 'dep_2'],
-        }
-
+    def get_label(self, label_key, values_list_index):
         if values_list_index is not None:
-            return mock_labels[label_key][values_list_index]
-
-        return mock_labels[label_key]
+            return self._labels[label_key][values_list_index]
+        return self._labels[label_key]

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -319,9 +319,6 @@ class _MockRuntimeEvaluationStorage(object):
         dep_id, cap_id = capability_path[0], capability_path[1]
         return self._capabilities[dep_id][cap_id]
 
-    def set_inter_deployment_dependency(self, *_, **__):
-        pass
-
     def get_label(self, label_key, values_list_index):
         if values_list_index is not None:
             return self._labels[label_key][values_list_index]

--- a/dsl_parser/tests/minimal_types.yaml
+++ b/dsl_parser/tests/minimal_types.yaml
@@ -1,0 +1,35 @@
+###
+# this is a minimal version of Cloudify types.yaml, to be used only in
+# dsl-parser unittests
+###
+
+
+plugins:
+  default_workflows:
+    executor: central_deployment_agent
+    install: false
+
+node_types:
+  cloudify.nodes.Root: {}
+
+  cloudify.nodes.Compute:
+    derived_from: cloudify.nodes.Root
+
+  cloudify.nodes.SoftwareComponent:
+    derived_from: cloudify.nodes.Root
+
+  cloudify.nodes.WebServer:
+    derived_from: cloudify.nodes.SoftwareComponent
+    properties:
+      port:
+        default: 80
+
+relationships:
+  cloudify.relationships.depends_on: {}
+
+  cloudify.relationships.contained_in:
+    derived_from: cloudify.relationships.depends_on
+
+workflows:
+  install:
+    mapping: 'default_workflows.cloudify.plugins.workflows.install'

--- a/dsl_parser/tests/namespace/test_functions.py
+++ b/dsl_parser/tests/namespace/test_functions.py
@@ -613,7 +613,7 @@ outputs:
     def test_node_template_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -631,8 +631,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -792,7 +794,7 @@ outputs:
     def test_node_template_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -810,8 +812,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -831,7 +835,7 @@ imports:
     def test_node_type_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 node_types:
   test:
     properties:
@@ -848,8 +852,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -884,7 +890,7 @@ imports:
     def test_node_template_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -898,8 +904,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -919,7 +927,7 @@ imports:
     def test_node_type_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -937,8 +945,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -954,7 +964,7 @@ imports:
     def test_outputs_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -966,8 +976,10 @@ outputs:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -1073,7 +1085,7 @@ imports:
     def test_node_template_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -1087,8 +1099,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -1100,7 +1114,7 @@ imports:
     def test_node_type_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -1124,8 +1138,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -1143,7 +1159,7 @@ imports:
     def test_dsl_definitions_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
@@ -1173,8 +1189,10 @@ node_templates:
 imports:
     - ns--blueprint:first_layer
 """
-        resolver = Resolver({'blueprint:first_layer': basic_yaml,
-                             'blueprint:second_layer': second_layer})
+        resolver = Resolver({
+            'blueprint:first_layer': basic_yaml,
+            'blueprint:second_layer': second_layer
+        }, rules=self._local_resolver_rules())
         third_layer = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     - ns2--blueprint:second_layer
@@ -1194,7 +1212,7 @@ imports:
     def test_node_template_defaults_from_data_type(self):
         blueprint_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.6/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
   test_config:
     type: my.test_config
@@ -1246,7 +1264,7 @@ node_templates:
     def test_node_template_incorrect_data_type(self):
         blueprint_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.6/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
   test_config:
     type: my.test_config
@@ -1289,7 +1307,7 @@ node_templates:
     def test_node_template_only_some_defaults_from_data_type(self):
         blueprint_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.6/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
   test_config:
     type: my.test_config
@@ -1346,7 +1364,7 @@ node_templates:
     def test_node_template_observe_required_param(self):
         blueprint_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.6/types.yaml
+  - http://local-test-resolver/types.yaml
 
 inputs:
   test_config:
@@ -1395,7 +1413,7 @@ node_templates:
     def test_node_template_observe_data_type_required_param(self):
         blueprint_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.6/types.yaml
+  - http://local-test-resolver/types.yaml
 
 inputs:
   test_config:

--- a/dsl_parser/tests/namespace/test_functions.py
+++ b/dsl_parser/tests/namespace/test_functions.py
@@ -570,7 +570,7 @@ outputs:
         value: { get_property: [test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml))
         self.assertEqual(
             'value',
             plan[constants.OUTPUTS]['port']['value'])
@@ -605,7 +605,7 @@ outputs:
         value: { get_property: [test--middle_test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml))
         self.assertEqual(
             'value',
             plan[constants.OUTPUTS]['port']['value'])
@@ -751,7 +751,7 @@ outputs:
         value: { get_attribute: [test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml))
         self.assertEqual(
             {'get_attribute': ['test--node', 'key']},
             plan[constants.OUTPUTS]['port']['value'])
@@ -786,7 +786,7 @@ outputs:
         value: { get_attribute: [test--middle_test--node, key] }
 """
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml))
         self.assertEqual(
             {'get_attribute': ['test--middle_test--node', 'key']},
             plan[constants.OUTPUTS]['port']['value'])
@@ -1025,7 +1025,7 @@ imports:
     -   {0}--{1}
 """.format('test', import_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml))
         self.assertEqual(
             {'get_capability': ['dep_1', 'cap_a']},
             plan[constants.OUTPUTS]['test--port']['value'])
@@ -1049,7 +1049,7 @@ imports:
     -   {0}--{1}
 """.format('test', import_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml))
         self.assertEqual(
             8080,
             plan[constants.OUTPUTS]['test--port']['value'])
@@ -1077,7 +1077,7 @@ imports:
     -   {0}--{1}
 """.format('test', layer2_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml))
         self.assertEqual(
             8080,
             plan[constants.OUTPUTS]['test--middle_test--port']['value'])
@@ -1399,8 +1399,7 @@ node_templates:
   test_node:
     type: my.node.type
 """
-        plan = prepare_deployment_plan(self.parse(blueprint_yaml),
-                                       self.get_secret)
+        plan = prepare_deployment_plan(self.parse(blueprint_yaml))
         self.assertEqual(
             None,
             plan[constants.INPUTS].get('test_config')

--- a/dsl_parser/tests/namespace/test_general_namespace.py
+++ b/dsl_parser/tests/namespace/test_general_namespace.py
@@ -80,7 +80,7 @@ imports:
     def test_namespace_on_cloudify_basic_types(self):
         yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-    -   test--http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    -   test--http://local-test-resolver/types.yaml
 """
         self.assertRaises(exceptions.DSLParsingLogicException,
                           self.parse, yaml)
@@ -88,7 +88,7 @@ imports:
     def test_namespace_with_cloudify_types_from_imported(self):
         layer1 = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-    -   http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    -   http://local-test-resolver/types.yaml
 """
         layer1_import_path = self.make_yaml_file(layer1)
         main_yaml = """
@@ -102,7 +102,7 @@ imports:
     def test_namespace_on_cloudify_types_from_imported(self):
         layer1 = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-    -   test--http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    -   test--http://local-test-resolver/types.yaml
 """
         layer1_import_path = self.make_yaml_file(layer1)
         main_yaml = """

--- a/dsl_parser/tests/namespace/test_relationships.py
+++ b/dsl_parser/tests/namespace/test_relationships.py
@@ -314,7 +314,7 @@ node_templates:
 
         main_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-    - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
     -   {0}--{1}
 """.format('test', import_file_name)
         main_yaml_path = self.make_file_with_name(content=main_yaml,

--- a/dsl_parser/tests/test_blueprint_import.py
+++ b/dsl_parser/tests/test_blueprint_import.py
@@ -22,7 +22,7 @@ class TestImportedBlueprints(AbstractTestParser):
     basic_blueprint = """
 tosca_definitions_version: cloudify_dsl_1_3
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 """
     blueprint_with_blueprint_import = """
 tosca_definitions_version: cloudify_dsl_1_3
@@ -38,7 +38,7 @@ imported_blueprints:
         yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     -   {0}
-    -   http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
 """.format(imported_blueprint)
 
         parsed_yaml = self.parse(yaml)
@@ -48,18 +48,18 @@ imports:
     def test_imported_list_with_namespace(self):
         layer1 = """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 """
         layer1_import_path = self.make_yaml_file(layer1)
         layer2 = """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
   - {0}--{1}
 """.format('test1', layer1_import_path)
         layer2_import_path = self.make_yaml_file(layer2)
         main_yaml = """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
   - {0}--{1}
 """.format('test', layer2_import_path)
         parsed_yaml = self.parse_1_3(main_yaml)
@@ -67,8 +67,9 @@ imports:
         self.assertEqual(len(imported_blueprints), 0)
 
     def test_basic_blueprint_import(self):
-        resolver = ResolverWithBlueprintSupport({'blueprint:test':
-                                                 self.basic_blueprint})
+        resolver = ResolverWithBlueprintSupport({
+            'blueprint:test': self.basic_blueprint
+        }, rules=self._local_resolver_rules())
         yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     -   ns--blueprint:test
@@ -81,12 +82,10 @@ imports:
             imported_blueprints)
 
     def test_merge_imported_lists(self):
-        resolver =\
-            ResolverWithBlueprintSupport(
-                {'blueprint:test':
-                    self.blueprint_with_blueprint_import,
-                 'blueprint:another_test':
-                     self.blueprint_with_blueprint_import})
+        resolver = ResolverWithBlueprintSupport({
+            'blueprint:test': self.blueprint_with_blueprint_import,
+            'blueprint:another_test': self.blueprint_with_blueprint_import
+        }, rules=self._local_resolver_rules())
         layer1 = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
   - ns--blueprint:test
@@ -94,14 +93,14 @@ imports:
         layer1_import_path = self.make_yaml_file(layer1)
         layer2 = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
   - {0}--{1}
   - ns--blueprint:another_test
 """.format('test1', layer1_import_path)
         layer2_import_path = self.make_yaml_file(layer2)
         main_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
   - {0}--{1}
 """.format('test', layer2_import_path)
         parsed_yaml = self.parse(main_yaml, resolver=resolver)
@@ -130,8 +129,9 @@ namespaces_mapping:
 """
 
     def test_merging_namespaces_mapping(self):
-        resolver = ResolverWithBlueprintSupport({'blueprint:test':
-                                                self.blueprint_imported})
+        resolver = ResolverWithBlueprintSupport({
+            'blueprint:test': self.blueprint_imported
+        }, rules=self._local_resolver_rules())
         layer1 = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
   - namespace--blueprint:test
@@ -162,11 +162,10 @@ imports:
                               namespaces_mapping)
 
     def test_blueprints_imports_with_the_same_import(self):
-        resolver = ResolverWithBlueprintSupport({'blueprint:test':
-                                                self.blueprint_imported,
-                                                 'blueprint:other':
-                                                     self.blueprint_imported
-                                                 })
+        resolver = ResolverWithBlueprintSupport({
+            'blueprint:test': self.blueprint_imported,
+            'blueprint:other': self.blueprint_imported
+        }, rules=self._local_resolver_rules())
         yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
     -   same--blueprint:test
@@ -200,7 +199,7 @@ node_types:
         local_types_path = self.make_yaml_file(self.basic_blueprint)
         main_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
   - {0}
 """.format(local_types_path)
         self.parse(main_yaml)
@@ -209,16 +208,17 @@ imports:
         imported_yaml = """
 tosca_definitions_version: cloudify_dsl_1_3
 imports:
-  - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+  - http://local-test-resolver/types.yaml
 inputs:
     port:
         default: 90
 """
-        resolver = ResolverWithBlueprintSupport({'blueprint:test':
-                                                 imported_yaml})
+        resolver = ResolverWithBlueprintSupport({
+            'blueprint:test': imported_yaml
+        }, rules=self._local_resolver_rules())
         yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-    - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
     - ns--blueprint:test
 """
         self.parse(yaml, resolver=resolver)

--- a/dsl_parser/tests/test_cloudify_basic_types_mark.py
+++ b/dsl_parser/tests/test_cloudify_basic_types_mark.py
@@ -24,7 +24,7 @@ class TestCloudifyBasicTypesMark(AbstractTestParser):
     def test_marking(self):
         main_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
 imports:
-    -   http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
 
 node_types:
   test_type:
@@ -32,7 +32,7 @@ node_types:
       prop1:
         default: value
 """
-        resolver = DefaultImportResolver()
+        resolver = DefaultImportResolver(rules=self._local_resolver_rules())
         merged_blueprint = parse_from_import_blueprint(
             dsl_location=None,
             dsl_string=main_yaml,

--- a/dsl_parser/tests/test_get_capability.py
+++ b/dsl_parser/tests/test_get_capability.py
@@ -20,6 +20,21 @@ from dsl_parser.tests.abstract_test_parser import AbstractTestParser
 
 
 class TestGetCapability(AbstractTestParser):
+    def setUp(self):
+        super(TestGetCapability, self).setUp()
+        self.mock_storage = self._mock_evaluation_storage(
+            capabilities={
+                'dep_1': {
+                    'cap_a': 'value_a_1',
+                    'cap_b': 'value_b_1'
+                },
+                'dep_2': {
+                    'cap_a': 'value_a_2',
+                    'cap_b': 'value_b_2'
+                }
+            }
+        )
+
     def test_has_intrinsic_functions_property(self):
         yaml = """
 relationships:
@@ -107,8 +122,7 @@ node_templates:
             ]}
         }
 
-        functions.evaluate_functions(
-            payload, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(payload, {}, self.mock_storage)
 
         self.assertEqual(payload['a'], 'value_a_1')
         self.assertEqual(payload['b'], 'value_a_2')
@@ -131,8 +145,7 @@ node_templates:
         self.assertEqual({'get_capability': ['dep_1', 'cap_a']},
                          node['properties']['property'])
 
-        functions.evaluate_functions(
-            parsed, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(parsed, {}, self.mock_storage)
         self.assertEqual(node['properties']['property'], 'value_a_1')
 
     def test_capabilities_in_outputs(self):
@@ -151,8 +164,7 @@ outputs:
         self.assertEqual({'get_capability': ['dep_1', 'cap_a']},
                          outputs['output']['value'])
 
-        functions.evaluate_functions(
-            parsed, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(parsed, {}, self.mock_storage)
         self.assertEqual(outputs['output']['value'], 'value_a_1')
 
     def test_capabilities_in_inputs(self):
@@ -177,8 +189,7 @@ outputs:
         self.assertEqual({'get_capability': ['dep_1', 'cap_a']},
                          outputs['output']['value'])
 
-        functions.evaluate_functions(
-            parsed, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(parsed, {}, self.mock_storage)
         self.assertEqual(outputs['output']['value'], 'value_a_1')
 
     def test_get_capability_not_list(self):

--- a/dsl_parser/tests/test_get_secret.py
+++ b/dsl_parser/tests/test_get_secret.py
@@ -144,8 +144,7 @@ node_templates:
                             inputs:
                                 a: { get_secret: target_op_secret_id }
 """
-        parsed = prepare_deployment_plan(self.parse(yaml),
-                                         self.get_secret)
+        parsed = prepare_deployment_plan(self.parse(yaml), self.get_secret)
         webserver_node = None
         for node in parsed.node_templates:
             if node['id'] == 'webserver':
@@ -310,7 +309,7 @@ node_templates:
 class TestNestedGetSecret(AbstractTestParser):
     def setUp(self):
         super(TestNestedGetSecret, self).setUp()
-        self._mock_evaluation_storage(
+        self.mock_storage = self._mock_evaluation_storage(
             secrets={
                 'no_parse_secret': '}',
                 'hello_secret': '{"hello": "test"}',
@@ -358,7 +357,7 @@ outputs:
         with self.assertRaisesRegex(exceptions.FunctionEvaluationError,
                                     '.*not parse.*no_parse_secret.*'):
             functions.evaluate_functions(
-                payload, {}, self._mock_storage)
+                payload, {}, self.mock_storage)
 
     def test_get_secret_wrong_key_name(self):
         payload = {
@@ -367,7 +366,7 @@ outputs:
         with self.assertRaisesRegex(exceptions.FunctionEvaluationError,
                                     '.*not find.*test.*hello_secret.*'):
             functions.evaluate_functions(
-                payload, {}, self._mock_storage)
+                payload, {}, self.mock_storage)
 
     def test_get_secret_list_bad_index(self):
         payload = {
@@ -376,7 +375,7 @@ outputs:
         with self.assertRaisesRegex(exceptions.FunctionEvaluationError,
                                     '.*not find.*somestring.*soft_secret.*'):
             functions.evaluate_functions(
-                payload, {}, self._mock_storage)
+                payload, {}, self.mock_storage)
 
     def test_get_secret_list_index_out_of_bounds(self):
         payload = {
@@ -385,7 +384,7 @@ outputs:
         with self.assertRaisesRegex(exceptions.FunctionEvaluationError,
                                     '.*not find.*3.*soft_secret.*'):
             functions.evaluate_functions(
-                payload, {}, self._mock_storage)
+                payload, {}, self.mock_storage)
 
     def test_get_secret_bad_key_mid_list(self):
         payload = {
@@ -394,14 +393,14 @@ outputs:
         with self.assertRaisesRegex(exceptions.FunctionEvaluationError,
                                     '.*not find.*lkie.*big_secret.*'):
             functions.evaluate_functions(
-                payload, {}, self._mock_storage)
+                payload, {}, self.mock_storage)
 
     def test_get_nested_secret_from_dict(self):
         payload = {
             'a': {'get_secret': ['hello_secret', 'hello']},
         }
         functions.evaluate_functions(
-            payload, {}, self._mock_storage)
+            payload, {}, self.mock_storage)
         self.assertEqual(payload['a'], 'test')
 
     def test_get_nested_secret_from_list(self):
@@ -409,13 +408,12 @@ outputs:
             'a': {'get_secret': ['soft_secret', 1]},
         }
         functions.evaluate_functions(
-            payload, {}, self._mock_storage)
+            payload, {}, self.mock_storage)
         self.assertEqual(payload['a'], 'wave')
 
     def test_get_deeply_nested_secret(self):
         payload = {
             'a': {'get_secret': ['big_secret', 'something', 0, 'like', 1]},
         }
-        functions.evaluate_functions(
-            payload, {}, self._mock_storage)
+        functions.evaluate_functions(payload, {}, self.mock_storage)
         self.assertEqual(payload['a'], 'that')

--- a/dsl_parser/tests/test_labels.py
+++ b/dsl_parser/tests/test_labels.py
@@ -112,6 +112,17 @@ blueprint_labels:
 
 
 class TestGetLabel(AbstractTestParser):
+    def setUp(self):
+        super(TestGetLabel, self).setUp()
+        self.mock_storage = self._mock_evaluation_storage(
+            capabilities={'dep_1': {'cap_a': 'value_a_1'}},
+            labels={
+                'key1': ['val1', 'val2'],
+                'key2': ['val3', 'val4'],
+                'key3': ['dep_1', 'dep_2'],
+            }
+        )
+
     def test_has_intrinsic_functions_property(self):
         yaml = """
 relationships:
@@ -190,8 +201,7 @@ node_templates:
             ]}
         }
 
-        functions.evaluate_functions(
-            payload, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(payload, {}, self.mock_storage)
 
         self.assertEqual(payload['a'], ['val1', 'val2'])
         self.assertEqual(payload['b'], 'val1')
@@ -218,8 +228,7 @@ node_templates:
         self.assertEqual({'get_label': ['key2', 0]},
                          node['properties']['property_2'])
 
-        functions.evaluate_functions(
-            parsed, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(parsed, {}, self.mock_storage)
         self.assertEqual(node['properties']['property_1'], ['val1', 'val2'])
         self.assertEqual(node['properties']['property_2'], 'val3')
 
@@ -245,8 +254,7 @@ outputs:
         self.assertEqual({'get_label': ['key2', 0]},
                          outputs['output_2']['value'])
 
-        functions.evaluate_functions(
-            parsed, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(parsed, {}, self.mock_storage)
         self.assertEqual(outputs['output_1']['value'], ['val1', 'val2'])
         self.assertEqual(outputs['output_2']['value'], 'val3')
 
@@ -279,8 +287,7 @@ outputs:
         self.assertEqual({'get_label': 'key2'},
                          outputs['output_2']['value'])
 
-        functions.evaluate_functions(
-            parsed, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(parsed, {}, self.mock_storage)
         self.assertEqual(outputs['output_1']['value'], 'val1')
         self.assertEqual(outputs['output_2']['value'], ['val3', 'val4'])
 
@@ -302,8 +309,7 @@ outputs:
                                              'cap_a']},
                          outputs['output_1']['value'])
 
-        functions.evaluate_functions(
-            parsed, {}, self._mock_evaluation_storage())
+        functions.evaluate_functions(parsed, {}, self.mock_storage)
         self.assertEqual(outputs['output_1']['value'], 'value_a_1')
 
     def test_get_label_short_list(self):

--- a/dsl_parser/tests/test_outputs.py
+++ b/dsl_parser/tests/test_outputs.py
@@ -211,7 +211,8 @@ outputs:
             }
         }]
         nodes = [{'id': 'webserver'}]
-        storage = self._mock_evaluation_storage(instances, nodes)
+        storage = self._mock_evaluation_storage(
+            instances, nodes, capabilities={'dep_1': {'cap_a': 'value_a_1'}})
 
         parsed = prepare_deployment_plan(self.parse_1_1(yaml),
                                          storage.get_secret)

--- a/dsl_parser/tests/test_register_function.py
+++ b/dsl_parser/tests/test_register_function.py
@@ -76,7 +76,9 @@ outputs:
             }
         }]
         nodes = [{'id': 'webserver'}]
-        storage = self._mock_evaluation_storage(node_instances, nodes)
+        storage = self._mock_evaluation_storage(
+            node_instances, nodes,
+            capabilities={'dep_1': {'cap_a': 'value_a_1'}})
 
         parsed = prepare_deployment_plan(self.parse(yaml), storage.get_secret)
 

--- a/dsl_parser/tests/test_relationships_overloading.py
+++ b/dsl_parser/tests/test_relationships_overloading.py
@@ -517,7 +517,7 @@ imports:
     def test_side_import_expending_relationships(self):
         side_blueprint = """
 imports:
-    - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
 
 node_types:
   test_other_type:
@@ -537,7 +537,7 @@ node_templates:
         side_import_file_name = self.make_yaml_file(side_blueprint)
         node_blueprint = """
 imports:
-    - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
 
 node_types:
   test_type:
@@ -578,7 +578,7 @@ imports:
     def test_side_import_not_expending_relationships_failure(self):
         side_blueprint = """
 imports:
-    - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
 
 node_types:
   test_other_type:
@@ -598,7 +598,7 @@ node_templates:
         side_import_file_name = self.make_yaml_file(side_blueprint)
         node_blueprint = """
 imports:
-    - http://www.getcloudify.org/spec/cloudify/4.5/types.yaml
+    - http://local-test-resolver/types.yaml
 
 node_types:
   test_type:

--- a/dsl_parser/tests/utils.py
+++ b/dsl_parser/tests/utils.py
@@ -18,7 +18,8 @@ from ..import_resolver.default_import_resolver import DefaultImportResolver
 
 
 class ResolverWithBlueprintSupport(DefaultImportResolver):
-    def __init__(self, blueprint_mapping, resources_base_path=None):
+    def __init__(self, blueprint_mapping, resources_base_path=None,
+                 rules=None):
         """
         :param blueprint_mapping: This is a mapping between blueprint import
         command and this options
@@ -30,7 +31,7 @@ class ResolverWithBlueprintSupport(DefaultImportResolver):
                 blueprint import in a isolated environment.
         :param resources_base_path: base path of the blueprint.
         """
-        super(ResolverWithBlueprintSupport, self).__init__()
+        super(ResolverWithBlueprintSupport, self).__init__(rules=rules)
         self.blueprint_mapping = blueprint_mapping
         self.resources_base_path = resources_base_path
 


### PR DESCRIPTION
`get_group_capability` is a new intrinsic function that gets 
capabilities of all deployments in a deployments group.

That logic is... mostly not here. Similar to other intrinsic
functions (eg. `get_capability`), this side only returns whatever
it received from the storage backend, so the interesting part
is going to be there (ie. in c-manager).

So this is mostly boring and trivial.
However... I have sweetened the deal (pray I don't alter it any
further!), and the commits leading up to the actual implementation
refactor some of the tests, and simplify functions.py just a bit.
The results aren't half bad!