### PR TITLE
RD-2111 Python 2.6 environment workaround

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -30,9 +30,9 @@ def build_docs(String project){
 def upload_docs(String project, String path){
   echo "upload docs to S3 for ${project}"
   uploadToDocsS3(
-    "${env.WORKSPACE}/project-docs/docs/${project}/_build/html", 
+    "${env.WORKSPACE}/project-docs/docs/${project}/_build/html",
     "${path}/"
-  )  
+  )
 }
 @Library('pipeline-shared-library') _
 pipeline {
@@ -84,7 +84,7 @@ pipeline {
                   echo "Python-3-incompatible code found"
                   cat futurize_diffs
                   exit 1
-                fi          
+                fi
                 """
               }
             }
@@ -138,14 +138,17 @@ pipeline {
                   echo 'eval "\$(pyenv init -)"' >> ~/.bashrc
                   echo 'eval "\$(pyenv virtualenv-init -)"' >> ~/.bashrc
                   fi'
-                pyenv install 2.6.9
+                echo 'Restoring Python 2.6.9 installation'
+                mkdir /tmp/pip-wheels
+                tar xzvf packaging/pyenv-2.6.9.tar.gz -C /
+                tar xzvf packaging/pip-wheels.tar.gz -C /tmp/pip-wheels
                 pyenv global 2.6.9
                 '''
                 // py26 uses py26-only-compatible versions of libs: pyyaml 4.2b4, hence the specialcased [dispatcher_py26]
                 sh '''#!/bin/bash
-                pip install -r dev-requirements.txt --user
-                pip install -r test-requirements.txt --user
-                pip install -e '.[dispatcher_py26]' --user
+                pip install -r dev-requirements.txt -f /tmp/pip-wheels --user
+                pip install -r test-requirements.txt -f /tmp/pip-wheels --user
+                pip install -e '.[dispatcher_py26]' -f /tmp/pip-wheels --user
                 '''
                 pytest('dsl_parser')
                 pytest('script_runner')

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -139,9 +139,11 @@ pipeline {
                   echo 'eval "\$(pyenv virtualenv-init -)"' >> ~/.bashrc
                   fi'
                 echo 'Restoring Python 2.6.9 installation'
+                curl -Lo /tmp/pyenv-2.6.9.tar https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/envs/pyenv-2.6.9.tar
+                curl -Lo /tmp/pip-wheels.tar https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/envs/pip-wheels.tar
                 mkdir /tmp/pip-wheels
-                tar xzvf packaging/pyenv-2.6.9.tar.gz -C /
-                tar xzvf packaging/pip-wheels.tar.gz -C /tmp/pip-wheels
+                tar xvf /tmp/pyenv-2.6.9.tar -C /
+                tar xvf /tmp/pip-wheels.tar -C /tmp/pip-wheels
                 pyenv global 2.6.9
                 '''
                 // py26 uses py26-only-compatible versions of libs: pyyaml 4.2b4, hence the specialcased [dispatcher_py26]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import sys
 from setuptools import setup, find_packages
 
 install_requires = [
-    'requests>=2.25.0,<3.0.0',
     'retrying==1.3.3',
     'proxy_tools==0.1.0',
     'bottle==0.12.18',
@@ -29,9 +28,9 @@ install_requires = [
 ]
 
 if sys.version_info[:3] < (2, 7, 9):
-    install_requires += ['pika==0.11.2', ]
+    install_requires += ['pika==0.11.2', 'requests==2.19.1', ]
 else:
-    install_requires += ['pika==1.1.0', ]
+    install_requires += ['pika==1.1.0', 'requests>=2.25.0,<3.0.0', ]
 
 try:
     from collections import OrderedDict  # NOQA


### PR DESCRIPTION
This is an attempt to maintain ability to run the tests for Python 2.6 even when the support for that software will be non-existent.

https://github.com/pypa/pypi-support/issues/978