### PR TITLE
RD-2288 Remove useless retries

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -740,8 +740,6 @@ class WorkflowHandler(TaskHandler):
     def _update_execution_status(self, status, error=None):
         if self.ctx.local or not self.update_execution_status:
             return
-
-        caught_error = None
         return update_execution_status(self.ctx.execution_id, status, error)
 
 

--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -742,17 +742,7 @@ class WorkflowHandler(TaskHandler):
             return
 
         caught_error = None
-        for _ in range(3):
-            try:
-                return update_execution_status(
-                    self.ctx.execution_id, status, error)
-            except Exception as e:
-                self.ctx.logger.exception(
-                    'Update execution status got unexpected rest error: %s', e)
-                caught_error = e
-                sleep(5)
-        else:
-            raise caught_error
+        return update_execution_status(self.ctx.execution_id, status, error)
 
 
 TASK_HANDLERS = {

--- a/cloudify/tests/test_dispatch.py
+++ b/cloudify/tests/test_dispatch.py
@@ -156,11 +156,11 @@ class TestDispatchTaskHandler(testtools.TestCase):
     @patch('cloudify.dispatch.get_rest_client')
     @patch('cloudify.dispatch.WorkflowHandler._workflow_cancelled')
     @patch('cloudify.dispatch.update_execution_status',
-           side_effect=[Exception('first loop'), Exception('second loop'),
-                        InvalidExecutionUpdateStatus('test invalid update')])
+           side_effect=[InvalidExecutionUpdateStatus('started')])
     def test_workflow_starting_with_execution_cancelled(
             self, mock_update_execution_status, mock_workflow_cancelled,
             *args, **kwargs):
+        """If the set-status-to-started call fails, execution is cancelled"""
         workflow_handler = dispatch.WorkflowHandler(
             cloudify_context={'task_name': 'test'},
             args=(), kwargs={})
@@ -186,7 +186,6 @@ class TestDispatchTaskHandler(testtools.TestCase):
             mock_update_execution_status.assert_called_with(
                 'test_execution_id', 'started', None)
             mock_workflow_cancelled.assert_called_with()
-            self.assertEqual(3, mock_update_execution_status.call_count)
         finally:
             workflow_handler._func = _normal_func
             workflow_handler._ctx = _normal_ctx
@@ -196,8 +195,7 @@ class TestDispatchTaskHandler(testtools.TestCase):
     @patch('cloudify.dispatch.get_rest_client')
     @patch('cloudify.dispatch.WorkflowHandler._workflow_cancelled')
     @patch('cloudify.dispatch.update_execution_status',
-           side_effect=[Exception('first loop'), Exception('second loop'),
-                        InvalidExecutionUpdateStatus('test invalid update')])
+           side_effect=[InvalidExecutionUpdateStatus('started')])
     def test_workflow_starting_without_masked_tenant(
             self, mock_update_execution_status, mock_workflow_cancelled,
             mock_rest_client, *args, **kwargs):
@@ -233,8 +231,7 @@ class TestDispatchTaskHandler(testtools.TestCase):
     @patch('cloudify.dispatch.get_rest_client')
     @patch('cloudify.dispatch.WorkflowHandler._workflow_cancelled')
     @patch('cloudify.dispatch.update_execution_status',
-           side_effect=[Exception('first loop'), Exception('second loop'),
-                        InvalidExecutionUpdateStatus('test invalid update')])
+           side_effect=[InvalidExecutionUpdateStatus('test invalid update')])
     def test_workflow_starting_with_masked_tenant(
             self, mock_update_execution_status, mock_workflow_cancelled,
             mock_rest_client, *args, **kwargs):


### PR DESCRIPTION
I don't know why was this request retried. No other request is
retried like this.

All this does, is makes a 401 get displayed multiple times,
and in case a 500 happens, it will be hidden by the additional 401s.

This dates back to CFY-1599, which was related to cancelling, but
I dont see how this specifically relates. Anyway, CFY-1599 didn't
really solve the cancel-in-pending issue, only by the time we
introduced kill-cancels that was really fixed.