### PR TITLE
dsl_parser tests: drop pointless timeout

### DIFF
--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -17,8 +17,6 @@ import tempfile
 import shutil
 import os
 import uuid
-from functools import wraps
-from multiprocessing import Process
 
 import testtools
 from mock import Mock
@@ -32,22 +30,6 @@ from dsl_parser.import_resolver.default_import_resolver import \
 from dsl_parser.version import DSL_VERSION_PREFIX
 from dsl_parser.multi_instance import (create_deployment_plan,
                                        modify_deployment)
-
-
-def timeout(seconds=10):
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            process = Process(None, func, None, args, kwargs)
-            process.start()
-            process.join(seconds)
-            if process.is_alive():
-                process.terminate()
-                raise RuntimeError(
-                    'test timeout exceeded [timeout={0}]'.format(seconds))
-            if process.exitcode != 0:
-                raise RuntimeError()
-        return wraps(func)(wrapper)
-    return decorator
 
 
 class AbstractTestParser(testtools.TestCase):

--- a/dsl_parser/tests/test_functions.py
+++ b/dsl_parser/tests/test_functions.py
@@ -17,7 +17,6 @@ from testtools import ExpectedException
 
 from dsl_parser import exceptions, functions
 from dsl_parser.tasks import prepare_deployment_plan
-from dsl_parser.tests.abstract_test_parser import timeout
 from dsl_parser.tests.abstract_test_parser import AbstractTestParser
 
 
@@ -603,7 +602,6 @@ node_templates:
             self.assertIn('index is out of range. Got 10 but list size is 3',
                           str(e))
 
-    @timeout(seconds=10)
     def test_not_circular_nested_property_path(self):
         yaml = """
 node_types:
@@ -627,7 +625,6 @@ node_templates:
 """
         prepare_deployment_plan(self.parse(yaml))
 
-    @timeout(seconds=10)
     def test_get_property_from_get_input(self):
         yaml = """
 inputs:
@@ -713,7 +710,6 @@ node_templates:
         )
         self.assertEqual('secret', evaluated['properties']['b'])
 
-    @timeout(seconds=10)
     def test_get_property_from_get_input_data_type(self):
         yaml = """
 inputs:
@@ -742,7 +738,6 @@ node_templates:
         plan = prepare_deployment_plan(self.parse_1_2(yaml))
         self.assertEqual('secret', plan['nodes'][0]['properties']['b'])
 
-    @timeout(seconds=10)
     def test_get_property_from_get_input_missing_key(self):
         yaml = """
 inputs:
@@ -764,7 +759,6 @@ node_templates:
             prepare_deployment_plan(
                 self.parse(yaml), inputs={'dict_input': {'other_key': 42}})
 
-    @timeout(seconds=10)
     def get_property_from_get_property(self):
         yaml = """
 node_types:


### PR DESCRIPTION
No point of putting a timeout around parsing.

Funnily, this actually CAUSES timeouts in tests, because well,
no wonder, it runs a subprocess, who knows how long can that take
to spawn.