### PR TITLE
RD-2015 Fix condition in for namespaced workflows

### DIFF
--- a/dsl_parser/elements/operation.py
+++ b/dsl_parser/elements/operation.py
@@ -297,8 +297,9 @@ def process_operation(
 
     if (utils.is_valid_url(operation_mapping) or
         _is_local_script_resource_exists(resource_bases, operation_mapping) or
-        _is_remote_script_resource(operation_mapping,
-                                   remote_resources_namespaces)):
+        (not candidate_plugins and _is_remote_script_resource(
+            operation_mapping, remote_resources_namespaces))):
+
         operation_payload = copy.deepcopy(operation_payload or {})
         if constants.SCRIPT_PATH_PROPERTY in operation_payload:
             message = "Cannot define '{0}' property in '{1}' for {2} '{3}'" \


### PR DESCRIPTION
if `_is_remote_script_resource(operation_mapping, remote_resources_namespaces)` returns true, but we actually have a plugin to run the operation, we don't want to default to script plugin running it, but instead it should continue to the other branch, under `if candidate_plugins`