### PR TITLE
Revert "RD-2316 Look for the resources in update_blueprint path (#774)"

### DIFF
--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -306,7 +306,7 @@ def _resource_paths(blueprint_id, deployment_id, tenant_name, resource_path):
     """For the given resource_path, generate all firesever paths to try.
 
     Eg. for path of "foo.txt", generate:
-        - /resources/deployments/default_tenant/dep1/updated_blueprint/foo.txt
+        - /resources/deployments/default_tenant/dep1/foo.txt
         - /resources/blueprints/default_tenant/bp1/foo.txt
         - /foo.txt
     """
@@ -315,7 +315,6 @@ def _resource_paths(blueprint_id, deployment_id, tenant_name, resource_path):
             constants.FILE_SERVER_DEPLOYMENTS_FOLDER,
             tenant_name,
             deployment_id,
-            'updated_blueprint',
             resource_path
         ).replace('\\', '/')
 

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -154,9 +154,8 @@ class CloudifyContextTest(testtools.TestCase):
     @mock.patch('cloudify.manager.get_rest_client')
     def test_download_resource_tried_urls(self, _):
         # check that download_resource tries the urls:
-        # - http://.../resources/deployments/
-        #                default_tenant/dep/updated_blueprint/file.txt
-        #   (deployment update resource)
+        # - http://...//resources/deployments/default_tenant/dep/file.txt
+        #   (deployment resource)
         # - http://.../resources/blueprints/default_tenant/bp/file.txt
         #   (blueprint resource)
         # - http://.../resources/file.txt'
@@ -178,7 +177,7 @@ class CloudifyContextTest(testtools.TestCase):
             os.environ[constants.REST_PORT_KEY]
         )
         self.assertEqual([args[0] for _c, args, _k in mock_get.mock_calls], [
-            '{0}/resources/deployments/{1}/{2}/updated_blueprint/{3}'.format(
+            '{0}/resources/deployments/{1}/{2}/{3}'.format(
                 base_url,
                 self.context.tenant_name,
                 self.context.deployment.id,


### PR DESCRIPTION
This reverts commit bc0de25a7ac962fb75337a7234c08d58d648155a.

Turns out sourcing files from the deployment's directory (e.g.
http://...//resources/deployments/default_tenant/dep/file.txt) is a
feature we shouldn't break.