### PR TITLE
RD-2375 dsl-parser: cope with missing deployment_settings

### DIFF
--- a/dsl_parser/scan.py
+++ b/dsl_parser/scan.py
@@ -188,7 +188,7 @@ def scan_service_template(plan, handler, replace=False, search_secrets=False):
                         path='{0}.{1}'.format(LABELS, label_key),
                         replace=replace)
 
-    scan_properties(plan['deployment_settings'],
+    scan_properties(plan.get('deployment_settings'),
                     handler,
                     scope=DEPLOYMENT_SETTINGS_SCOPE,
                     context=plan,


### PR DESCRIPTION
blueprints restored from pre-6.0 snapshots won't necessarily have
that field, but still need to be able to be scanned, when creating
new deployments from them. Don't throw a KeyError if the value isn't
there.