### PR TITLE
Fill `managerment_host` for LocalEndpoint.get_brokers()

### DIFF
--- a/cloudify/endpoint.py
+++ b/cloudify/endpoint.py
@@ -308,6 +308,7 @@ class LocalEndpoint(Endpoint):
                     'default': '127.0.0.1'
                 },
                 'ca_cert_content': '',
+                'management_host': '127.0.0.1',
             })
         ]
 


### PR DESCRIPTION
This is probably only used in tests