### PR TITLE
RD-2579 _SetNodeInstanceStateTask: force-set the state

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -25,7 +25,6 @@ from cloudify.manager import (
     get_rest_client,
     get_node_instance,
     update_execution_status,
-    update_node_instance
 )
 from cloudify.constants import (
     MGMTWORKER_QUEUE,
@@ -976,10 +975,11 @@ class _SetNodeInstanceStateTask(_LocalTask):
         }
 
     def remote(self):
-        node_instance = get_node_instance(self._node_instance_id)
-        node_instance.state = self._state
-        update_node_instance(node_instance)
-        return node_instance
+        get_rest_client().node_instances.update(
+            self._node_instance_id,
+            force=True,
+            state=self._state
+        )
 
     def local(self):
         self.storage.update_node_instance(

--- a/cloudify_rest_client/node_instances.py
+++ b/cloudify_rest_client/node_instances.py
@@ -146,7 +146,8 @@ class NodeInstancesClient(object):
                node_instance_id,
                state=None,
                runtime_properties=None,
-               version=1):
+               version=1,
+               force=False):
         """
         Update node instance with the provided state & runtime_properties.
 
@@ -155,6 +156,7 @@ class NodeInstancesClient(object):
         :param runtime_properties: The updated runtime properties.
         :param version: Current version value of this node instance in
          Cloudify's storage (used for optimistic locking).
+        :param force: ignore the version check - use with caution
         :return: The updated node instance.
         """
         assert node_instance_id
@@ -164,7 +166,10 @@ class NodeInstancesClient(object):
             data['runtime_properties'] = runtime_properties
         if state is not None:
             data['state'] = state
-        response = self.api.patch(uri, data=data)
+        params = {}
+        if force:
+            params['force'] = True
+        response = self.api.patch(uri, params=params, data=data)
         return NodeInstance(response)
 
     def _create_filters(


### PR DESCRIPTION
We used to first fetch the instance, to figure out the current
version, and then set the new state anyway.
So, the only reason we fetched it, was so that our update always
succeeds - we didn't react to the received state in any way.
We can simply just cut out the middleman, and force-set the
state directly, without fetching it.

And anyway, force-setting, like we (essentially) did before,
and do now, does make sense for the state - instance state is never
changed concurrently, only runtime-properties are (and that's what
version is for).