### PR TITLE
RD-513 Use a single AMQP queue per execution

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -529,8 +529,10 @@ class NoWaitSendHandler(SendHandler):
     wait_for_publish = False
 
 
-class _RequestResponseHandlerBase(TaskConsumer):
-    queue_exclusive = False
+class BlockingRequestResponseHandler(TaskConsumer):
+    def __init__(self, *args, **kwargs):
+        super(BlockingRequestResponseHandler, self).__init__(*args, **kwargs)
+        self._response = queue.Queue()
 
     def register(self, connection, channel):
         self._connection = connection
@@ -542,7 +544,7 @@ class _RequestResponseHandlerBase(TaskConsumer):
     def _declare_queue(self, queue_name):
         self._connection.channel_method(
             'queue_declare', queue=queue_name, durable=True,
-            exclusive=self.queue_exclusive)
+            exclusive=True)
         self._connection.channel_method(
             'queue_bind', queue=queue_name, exchange=self.exchange)
         if OLD_PIKA:
@@ -561,8 +563,12 @@ class _RequestResponseHandlerBase(TaskConsumer):
     def make_response_queue(self, correlation_id):
         self._declare_queue(self._queue_name(correlation_id))
 
-    def publish(self, message, correlation_id, routing_key='',
-                expiration=None):
+    def publish(self, message, correlation_id=None, routing_key='',
+                expiration=None, timeout=None):
+        if correlation_id is None:
+            correlation_id = uuid.uuid4().hex
+        self.make_response_queue(correlation_id)
+
         if expiration is not None:
             # rabbitmq wants it to be a string
             expiration = '{0}'.format(expiration)
@@ -575,28 +581,6 @@ class _RequestResponseHandlerBase(TaskConsumer):
                 expiration=expiration),
             'routing_key': routing_key
         })
-
-    def process(self, channel, method, properties, body):
-        raise NotImplementedError()
-
-
-class BlockingRequestResponseHandler(_RequestResponseHandlerBase):
-    # when the process closes, a blockin handler's queues can be deleted,
-    # because there's no way to resume waiting on those
-    queue_exclusive = True
-
-    def __init__(self, *args, **kwargs):
-        super(BlockingRequestResponseHandler, self).__init__(*args, **kwargs)
-        self._response = queue.Queue()
-
-    def publish(self, message, *args, **kwargs):
-        timeout = kwargs.pop('timeout', None)
-        correlation_id = kwargs.pop('correlation_id', None)
-        if correlation_id is None:
-            correlation_id = uuid.uuid4().hex
-        self.make_response_queue(correlation_id)
-        super(BlockingRequestResponseHandler, self).publish(
-            message, correlation_id, *args, **kwargs)
 
         try:
             return json.loads(
@@ -615,36 +599,6 @@ class BlockingRequestResponseHandler(_RequestResponseHandlerBase):
             self._queue_name(properties.correlation_id),
             wait=False, if_empty=False)
         self._response.put(body)
-
-
-class CallbackRequestResponseHandler(_RequestResponseHandlerBase):
-    def __init__(self, *args, **kwargs):
-        super(CallbackRequestResponseHandler, self).__init__(*args, **kwargs)
-        self.callbacks = {}
-
-    def publish(self, message, *args, **kwargs):
-        callback = kwargs.pop('callback', None)
-        correlation_id = kwargs.pop('correlation_id', None)
-        if correlation_id is None:
-            correlation_id = uuid.uuid4().hex
-
-        if callback:
-            self.callbacks[correlation_id] = callback
-            self.make_response_queue(correlation_id)
-        super(CallbackRequestResponseHandler, self).publish(
-            message, correlation_id, *args, **kwargs)
-
-    def process(self, channel, method, properties, body):
-        if properties.correlation_id in self.callbacks:
-            try:
-                response = json.loads(body.decode('utf-8'))
-                self.callbacks[properties.correlation_id](response)
-            except ValueError:
-                logger.error('Error parsing response: {0}'.format(body))
-        channel.basic_ack(method.delivery_tag)
-        self.delete_queue(
-            self._queue_name(properties.correlation_id),
-            wait=False, if_empty=False)
 
 
 def get_client(amqp_host=None,

--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -195,9 +195,6 @@ class AMQPConnection(object):
         out_channel.confirm_delivery()
         for handler in self._handlers:
             handler.register(self, out_channel)
-            logger.info('Registered handler for {0} [{1}]'
-                        .format(handler.__class__.__name__,
-                                handler.routing_key))
         self.connect_wait.set()
         return out_channel
 

--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -691,6 +691,7 @@ class WorkflowHandler(TaskHandler):
         )
 
     def _workflow_succeeded(self):
+        self.ctx.cleanup(finished=True)
         self._update_execution_status(Execution.TERMINATED)
         dry_run = ' (dry run)' if self.ctx.dry_run else ''
         self.ctx.internal.send_workflow_event(
@@ -701,6 +702,7 @@ class WorkflowHandler(TaskHandler):
         )
 
     def _workflow_failed(self, exception, error_traceback=None):
+        self.ctx.cleanup(finished=True)
         try:
             self.ctx.internal.send_workflow_event(
                 event_type='workflow_failed',
@@ -717,6 +719,7 @@ class WorkflowHandler(TaskHandler):
             raise exception
 
     def _workflow_cancelled(self):
+        self.ctx.cleanup(finished=False)
         self._update_execution_status(Execution.CANCELLED)
         self.ctx.internal.send_workflow_event(
             event_type='workflow_cancelled',

--- a/cloudify/tests/test_dispatch.py
+++ b/cloudify/tests/test_dispatch.py
@@ -281,8 +281,9 @@ class TestDispatchTaskHandler(testtools.TestCase):
         workflow_handler._func = func2
         workflow_handler._ctx = type('MockWorkflowContext', (object,), {
             'local': False,
-            'logger': MagicMock(),
-            'internal': MagicMock(),
+            'logger': Mock(),
+            'cleanup': Mock(),
+            'internal': Mock(),
             'execution_id': 'test_execution_id',
             'workflow_id': 'test_workflow_id',
             'dry_run': False,

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -469,7 +469,7 @@ class RemoteWorkflowTask(WorkflowTask):
         try:
             self._set_queue_kwargs()
             self.workflow_context.internal.handler.wait_for_result(
-                self.async_result, self, self._task_target)
+                self, self._task_target)
             if should_send:
                 self.workflow_context.internal.send_task_event(
                     TASK_SENDING, self)

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -468,16 +468,14 @@ class RemoteWorkflowTask(WorkflowTask):
             self.set_state(TASK_SENDING)
         try:
             self._set_queue_kwargs()
-            task = self.workflow_context.internal.handler.get_task(
-                self, queue=self._task_queue, target=self._task_target,
-                tenant=self._task_tenant)
             self.workflow_context.internal.handler.wait_for_result(
-                self.async_result, self, task)
+                self.async_result, self, self._task_target)
             if should_send:
                 self.workflow_context.internal.send_task_event(
                     TASK_SENDING, self)
                 self.set_state(TASK_SENT)
-                self.workflow_context.internal.handler.send_task(self, task)
+                self.workflow_context.internal.handler.send_task(
+                    self, self._task_target, self._task_queue)
         except (exceptions.NonRecoverableError,
                 exceptions.RecoverableError) as e:
             self.set_state(TASK_FAILED)

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1236,9 +1236,6 @@ class CloudifyWorkflowContextHandler(object):
     def get_send_task_event_func(self, task):
         raise NotImplementedError('Implemented by subclasses')
 
-    def get_task(self, workflow_task, queue=None, target=None, tenant=None):
-        raise NotImplementedError('Implemented by subclasses')
-
     @property
     def operation_cloudify_context(self):
         raise NotImplementedError('Implemented by subclasses')
@@ -1476,20 +1473,11 @@ class RemoteContextHandler(CloudifyWorkflowContextHandler):
     def get_send_task_event_func(self, task):
         return events.send_task_event_func_remote
 
-    def get_task(self, workflow_task, queue=None, target=None, tenant=None):
-        # augment cloudify context with target and queue
-        tenant = tenant or workflow_task.cloudify_context.get('tenant')
+    def send_task(self, *args, **kwargs):
+        return self._dispatcher.send_task(*args, **kwargs)
 
-        # Remote task
-        return self._dispatcher.make_subtask(
-            tenant, target, task_id=workflow_task.id,
-            kwargs=workflow_task.kwargs, queue=queue)
-
-    def send_task(self, workflow_task, task):
-        return self._dispatcher.send_task(workflow_task, task)
-
-    def wait_for_result(self, result, workflow_task, task):
-        return self._dispatcher.wait_for_result(result, workflow_task, task)
+    def wait_for_result(self, *args, **kwargs):
+        return self._dispatcher.wait_for_result(*args, **kwargs)
 
     @property
     def operation_cloudify_context(self):
@@ -1673,9 +1661,6 @@ class LocalCloudifyWorkflowContextHandler(CloudifyWorkflowContextHandler):
 
     def get_send_task_event_func(self, task):
         return events.send_task_event_func_local
-
-    def get_task(self, workflow_task, queue=None, target=None, tenant=None):
-        raise NotImplementedError('Not implemented by local workflow tasks')
 
     @property
     def operation_cloudify_context(self):

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1293,7 +1293,6 @@ class CloudifyWorkflowContextHandler(object):
         raise NotImplementedError('Implemented by subclasses')
 
 
-
 class _WorkflowTaskHandler(object):
     def __init__(self, workflow_ctx):
         self._logger = logging.getLogger('dispatch')
@@ -1330,7 +1329,7 @@ class _WorkflowTaskHandler(object):
         try:
             response = json.loads(body.decode('utf-8'))
         except ValueError:
-            logger.error('Error parsing response: %s', body)
+            self._logger.error('Error parsing response: %s', body)
             channel.basic_ack(method.delivery_tag)
             return
         if properties.correlation_id in self._tasks:


### PR DESCRIPTION
Instead of making a queue+amqp connection per task, make
only one for the whole execution.

Also some simplifications around.