### PR TITLE
plugin.prefix: fall back to name if package_name is empty

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -1162,7 +1162,7 @@ class PluginContext(str):
     def prefix(self):
         """The plugin prefix."""
         return utils.plugin_prefix(
-            name=self.package_name,
+            name=self.package_name or self.name,
             version=self.package_version,
             deployment_id=self._deployment_id,
             tenant_name=self._tenant_name)


### PR DESCRIPTION
we used to do that in the separate figuring-out-the-prefix method,
now we use the property instead, so let's have the property behave
the same way.