### PR TITLE
Allow restoring builtin tasks

### DIFF
--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -513,5 +513,10 @@ OP_TYPES = {
     'RemoteWorkflowTask': tasks.RemoteWorkflowTask,
     'LocalWorkflowTask': tasks.LocalWorkflowTask,
     'NOPLocalWorkflowTask': tasks.NOPLocalWorkflowTask,
-    'SubgraphTask': SubgraphTask
+    'SubgraphTask': SubgraphTask,
+    'SetNodeInstanceStateTask': tasks.SetNodeInstanceStateTask,
+    'GetNodeInstanceStateTask': tasks.GetNodeInstanceStateTask,
+    'SendNodeEventTask': tasks.SendNodeEventTask,
+    'SendWorkflowEventTask': tasks.SendWorkflowEventTask,
+    'UpdateExecutionStatusTask': tasks.UpdateExecutionStatusTask,
 }


### PR DESCRIPTION
For the tasks to be restored, their name needs to be pointed back
to the actual class.

This fixes all the test_resume inte-tests