### PR TITLE
dispatch: send cancelled event before setting the status

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -363,13 +363,13 @@ class WorkflowHandler(TaskHandler):
 
     def _workflow_cancelled(self):
         self.ctx.cleanup(finished=False)
-        self._update_execution_status(Execution.CANCELLED)
         self.ctx.internal.send_workflow_event(
             event_type='workflow_cancelled',
             message="'{0}' workflow execution cancelled".format(
                 self.ctx.workflow_id),
             additional_context=self._get_hook_params()
         )
+        self._update_execution_status(Execution.CANCELLED)
 
     def _get_hook_params(self):
         is_system_workflow = self.cloudify_context.get('is_system_workflow')


### PR DESCRIPTION
when the execution state is changed to cancelled, we can't send
events anymore. The event needs to be sent BEFORE the execution
is actually cancelled. Otherwise we just get 401s on the attempt
to try and send the event.