### PR TITLE
get_task_configuration: int() the retries count

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1105,7 +1105,7 @@ class CloudifyWorkflowContextInternal(object):
         retry_interval = workflows.get(
             'task_retry_interval',
             self.workflow_context._task_retry_interval)
-        return dict(total_retries=total_retries,
+        return dict(total_retries=int(total_retries),
                     retry_interval=retry_interval)
 
     def get_subgraph_task_configuration(self):


### PR DESCRIPTION
it might be a float, not an integer, but let's int() it so that it displays nicely

in 6.1+ it's not a float anymore, since cloudify-cosmo/cloudify-manager#3047