### PR TITLE
RD-2751 Attach the execution id to the events/logs create

### DIFF
--- a/cloudify/logs.py
+++ b/cloudify/logs.py
@@ -22,6 +22,7 @@ import datetime
 from cloudify import constants, manager
 from cloudify import event as _event
 from cloudify.utils import (get_execution_creator_username,
+                            get_execution_id,
                             is_management_environment,
                             ENV_AGENT_LOG_LEVEL,
                             ENV_AGENT_LOG_DIR,
@@ -357,11 +358,12 @@ def _log_message(logger, message):
 def _publish_message(message, message_type, logger):
     if u'message' in message:
         _log_message(logger, message)
+    execution_id = get_execution_id()
     client = manager.get_rest_client()
     if message_type == 'log':
-        client.events.create(logs=[message])
+        client.events.create(logs=[message], execution_id=execution_id)
     else:
-        client.events.create(events=[message])
+        client.events.create(events=[message], execution_id=execution_id)
 
 
 def setup_logger_base(log_level, log_dir=None):

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -306,6 +306,14 @@ def get_execution_token():
         return None
 
 
+def get_execution_id():
+    """The current execution ID"""
+    try:
+        return _get_current_context().execution_id
+    except RuntimeError:  # There is no context
+        return None
+
+
 def get_instances_of_node(rest_client,
                           deployment_id=None,
                           node_id=None,

--- a/cloudify_rest_client/events.py
+++ b/cloudify_rest_client/events.py
@@ -77,16 +77,21 @@ class EventsClient(object):
         response = self.api.get(uri, _include=_include, params=params)
         return ListResponse(response['items'], response['metadata'])
 
-    def create(self, events=None, logs=None):
+    def create(self, events=None, logs=None, execution_id=None):
         """Create events & logs
 
         :param events: List of events to be created
         :param logs: List of logs to be created
+        :param execution_id: Create logs/events for this execution - only
+                             used if the request is not authenticated by an
+                             execution token (then, the token's execution
+                             takes precedence).
         :return: None
         """
         self.api.post('/events', data={
             'events': events,
             'logs': logs,
+            'execution_id': execution_id,
         }, expected_status_code=(201, 204))
 
     def delete(self, deployment_id, include_logs=False, message=None,


### PR DESCRIPTION
Turns out it's not always the case that we only create events/logs
via a request authenticated by an execution token - when running hooks,
we are authenticated by the user's rest token instead.

So, allow passing in the execution id, so that requests authenticated
by a rest token, know which execution are they related to.