### PR TITLE
RemoteWorkflowTask: bring back the 'sending' state

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -476,7 +476,7 @@ class RemoteWorkflowTask(WorkflowTask):
 
         :return: a WorkflowTaskResult instance wrapping the async result
         """
-        should_send = self._state == TASK_PENDING
+        should_send = self._state in (TASK_PENDING, TASK_SENDING)
         if self._state == TASK_PENDING:
             self.set_state(TASK_SENDING)
         try:

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -470,14 +470,6 @@ class RemoteWorkflowTask(WorkflowTask):
                 '__cloudify_context'].pop(skipped_field, None)
         return task
 
-    def _update_stored_state(self, state, **kwargs):
-        # no need to store SENDING - all work after SENDING but before SENT
-        # can safely be rerun
-        if state == TASK_SENDING:
-            return
-        return super(RemoteWorkflowTask, self)._update_stored_state(
-            state, **kwargs)
-
     @with_execute_after
     def apply_async(self):
         """Send the task to an agent.


### PR DESCRIPTION
Some tests depend on there being a "SENDING" state/event stored.
Well, let's bring it back for compat. I didn't really want to do that, but alas.

This fixes eg. `integration_tests/tests/agentless_tests/test_events.py::EventsTest::test_search_event_message`