### PR TITLE
update_operation: pass through exception_causes

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1499,11 +1499,11 @@ class RemoteContextHandler(CloudifyWorkflowContextHandler):
             # it's not serializable! just store a null (as is back-compatible)
             result = None
         if exception is not None:
-            exception = str(exception)
+            exception_text = str(exception)
             exception_causes = getattr(exception, 'causes', None)
         self.rest_client.operations.update(
             operation_id, state=state, result=result,
-            exception=exception, exception_causes=exception_causes)
+            exception=exception_text, exception_causes=exception_causes)
 
     def get_tasks_graph(self, execution_id, name):
         graphs = self.rest_client.tasks_graphs.list(execution_id, name)


### PR DESCRIPTION
well if we str() the exception and then getattr causes, then obviously
the causes is None, because we're getattr-ing off of the string!
instead, let's getattr from the actual exception.

I could've just as well simply reversed the order of the two lines,
but this seems better