### PR TITLE
RD-2800 Add a display_label input property

### DIFF
--- a/dsl_parser/constants.py
+++ b/dsl_parser/constants.py
@@ -46,6 +46,7 @@ LABELS = 'labels'
 BLUEPRINT_LABELS = 'blueprint_labels'
 DEFAULT_SCHEDULES = 'default_schedules'
 DEPLOYMENT_SETTINGS = 'deployment_settings'
+DISPLAY_LABEL = 'display_label'
 
 HOST_TYPE = 'cloudify.nodes.Compute'
 DEPENDS_ON_REL_TYPE = 'cloudify.relationships.depends_on'

--- a/dsl_parser/elements/inputs.py
+++ b/dsl_parser/elements/inputs.py
@@ -91,7 +91,8 @@ class InputSchemaProperty(SchemaProperty):
         'default': InputSchemaPropertyDefault,
         'description': SchemaPropertyDescription,
         'type': SchemaInputType,
-        'constraints': Constraints
+        'constraints': Constraints,
+        'display_label': SchemaPropertyDescription,
     }
 
     def parse(self):

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -762,6 +762,28 @@ node_templates:
             self.parse(yaml),
             inputs={'port': {'a': 2}})
 
+    def test_input_display_label(self):
+        yaml = """
+inputs:
+    ip:
+        display_label: IP address
+        default: 127.0.0.1
+    port:
+        display_label: Port number
+        default: 8080
+node_templates: {}
+"""
+        parsed = self.parse(yaml)
+        self.assertEqual(2, len(parsed[consts.INPUTS]))
+        self.assertEqual(
+            '127.0.0.1', parsed[consts.INPUTS]['ip'][consts.DEFAULT])
+        self.assertEqual(
+            8080, parsed[consts.INPUTS]['port'][consts.DEFAULT])
+        self.assertEqual(
+            'IP address', parsed[consts.INPUTS]['ip'][consts.DISPLAY_LABEL])
+        self.assertEqual(
+            'Port number', parsed[consts.INPUTS]['port'][consts.DISPLAY_LABEL])
+
 
 class TestInputsConstraints(AbstractTestParser):
     def test_constraints_successful(self):


### PR DESCRIPTION
It is a simple string that will be used in UI instead of a input name.

Blueprint snippet:

```yaml
inputs:
  aws_access_key_id:
    type: string
    display_label: AWS Access Key ID
    default: { get_secret: aws_access_key_id }
```