### PR TITLE
BlockinReqRespHandler: synchronously delete the queue

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -571,7 +571,7 @@ class BlockingRequestResponseHandler(TaskConsumer):
         channel.basic_ack(method.delivery_tag)
         self.delete_queue(
             self._queue_name(properties.correlation_id),
-            wait=False, if_empty=False)
+            wait=True, if_empty=False)
         self._response.put(body)
 
 


### PR DESCRIPTION
We'd do good to delete this response queue synchronously, otherwise
it might not actually get deleted if we close the process before
the delete request gets sent