### PR TITLE
RD-2948 Make ctx.operation.retry honor its retry_after

### DIFF
--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -370,6 +370,7 @@ class WorkflowTask(object):
             # operation explicitly requested a retry, so we ignore
             # the handler set on the task.
             handler_result = HandlerResult.retry()
+            handler_result.retry_after = result.retry_after
         elif self.on_failure:
             handler_result = self.on_failure(self)
         else:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ mock>=1.0.1
 testtools==2.3.0
 pytest
 pytest-cov
-pytest-xdist
-testfixtures
+pytest-xdist==1.34.0
+testfixtures==6.18.0
 coverage==4.5.1 # coverage - This is done because of coverage pyhotn package bug, https://github.com/nedbat/coveragepy/issues/716
 decorator==4.4.2


### PR DESCRIPTION
It used to be set in the `else` branch but not in the "retry" branch.
Whoops :)