### PR TITLE
RD-3012 Make the required flag True by default

### DIFF
--- a/dsl_parser/elements/inputs.py
+++ b/dsl_parser/elements/inputs.py
@@ -103,7 +103,7 @@ class InputSchemaProperty(SchemaProperty):
         return self.build_dict_result(with_default=False)
 
     def validate(self):
-        if self.initial_value.get('required', False) \
+        if self.initial_value.get('required', True) \
                 and self.initial_value.get('hidden', False) \
                 and 'default' not in self.initial_value:
             raise exceptions.DSLParsingLogicException(

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -806,6 +806,7 @@ inputs:
     ip:
         type: string
         hidden: True
+        required: False
     port:
         type: integer
         hidden: False
@@ -825,6 +826,7 @@ inputs:
     ip:
         type: string
         hidden: True
+        required: False
     port:
         type: integer
         hidden: False
@@ -839,6 +841,33 @@ node_templates: {}
         self.assertEqual(
             False, parsed[consts.INPUTS]['port'][consts.HIDDEN])
         self.assertNotIn(consts.HIDDEN, parsed[consts.INPUTS]['app_name'])
+
+    def test_input_hidden_required(self):
+        yaml = """
+tosca_definitions_version: cloudify_dsl_1_3
+inputs:
+    ip:
+        type: string
+        hidden: True
+        required: True
+        default: 127.0.0.1
+"""
+        parsed = self.parse(yaml)
+        self.assertEqual(1, len(parsed[consts.INPUTS]))
+        self.assertEqual(
+            '127.0.0.1', parsed[consts.INPUTS]['ip'][consts.DEFAULT])
+
+    def test_input_required_by_default(self):
+        yaml = """
+tosca_definitions_version: cloudify_dsl_1_3
+inputs:
+    ip:
+        type: string
+        hidden: True
+"""
+        with self.assertRaisesRegex(DSLParsingException,
+                                    r'should have a default value: \'ip\''):
+            self.parse(yaml)
 
 
 class TestInputsConstraints(AbstractTestParser):


### PR DESCRIPTION
The blueprint's input `required` is True unless directly specified
otherwise.  This is making blueprint validation consistent with
deployment create.