### PR TITLE
dsl-parser test_workflows: proper escape sequence

### DIFF
--- a/dsl_parser/tests/namespace/test_workflows.py
+++ b/dsl_parser/tests/namespace/test_workflows.py
@@ -305,7 +305,7 @@ workflows:
                   - max_length: 2
                   - min_length: 1
                   - valid_values: [ 'hi', 'ho' ]
-                  - pattern: \w+
+                  - pattern: \\w+
 """  # noqa
         yaml_path = self.make_file_with_name(content=yaml_content,
                                              filename='stub.py')


### PR DESCRIPTION
In a non-r'' string, you want `\\w`, not `\w`. Just `\w` is still two characters,
(backslash, w), but emits a warning.