### PR TITLE
Remove python 2.6 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,6 @@ checkout:
 
 
 executors:
-  py26:
-    docker:
-        # staying on old debian image, because buster dropped libssl1.0-dev, which
-        # is required to compile py2.6 via pyenv
-      - image: circleci/python:2.7-stretch
   py27:
     docker:
       - image: circleci/python:2.7
@@ -69,22 +64,6 @@ commands:
               << parameters.s3_path >> \
               --delete \
               --acl public-read
-
-  setup_py26:
-    steps:
-      - run:
-          name: Install and set python version with pyenv
-          command: |
-                   set -eux
-                   git clone https://github.com/yyuu/pyenv.git ~/.pyenv
-                   export PYENV_ROOT="$HOME/.pyenv"
-                   export PATH="$PYENV_ROOT/bin:$PATH"
-                   echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $BASH_ENV
-                   echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $BASH_ENV
-                   sudo apt-get install -y build-essential libssl1.0-dev zlib1g-dev xz-utils
-                   echo -e 'if [ $SHLVL = 1 ]; then eval "$(pyenv init -)"; fi' >> $BASH_ENV
-                   pyenv install 2.6.9
-                   pyenv global 2.6.9
 
   install_test_dependencies:
     parameters:
@@ -142,22 +121,6 @@ jobs:
       - run:
           name: Run flake8
           command: flake8 dsl_parser script_runner cloudify cloudify_rest_client
-
-  test_py26:
-    executor: py26
-    steps:
-      - checkout
-      - setup_py26
-      - install_test_dependencies:
-          cache_prefix: py26
-      - pytest:
-          target: dsl_parser
-      - pytest:
-          target: script_runner
-      - pytest:
-          target: cloudify
-      - store_test_results:
-          path: test-results
 
   test_py27:
     executor: py27
@@ -295,9 +258,6 @@ workflows:
       - py3_compat
       - flake8_py27
       - flake8_py36
-      - test_py26:
-          requires:
-            - flake8_py27
       - test_py27:
           requires:
             - flake8_py27

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -106,50 +106,6 @@ pipeline {
     }
     stage('tests'){
       parallel{
-        stage('test_py26'){
-          steps{
-            sh script: "mkdir -p ${env.WORKSPACE}/test-py26 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py26", label: "copying repo to seperate workspace"
-            container('py26'){
-              dir("${env.WORKSPACE}/test-py26") {
-                echo 'setup_py26 - Install and set python version with pyenv'
-                sh '''
-                #!/bin/bash
-                set -eux
-                git clone https://github.com/yyuu/pyenv.git ~/.pyenv
-                export PYENV_ROOT="$HOME/.pyenv"
-                export PATH="$PYENV_ROOT/bin:$PATH"
-                echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc
-                sudo apt-get install -y build-essential libssl1.0-dev zlib1g-dev xz-utils
-                echo 'if [ -e $SHLVL = 1 ]; then
-                  echo 'eval "\$(pyenv init -)"' >> ~/.bashrc
-                  echo 'eval "\$(pyenv virtualenv-init -)"' >> ~/.bashrc
-                  fi'
-                echo 'Restoring Python 2.6.9 installation'
-                curl -Lo /tmp/pyenv-2.6.9.tar https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/envs/pyenv-2.6.9.tar
-                curl -Lo /tmp/pip-wheels.tar https://cloudify-release-eu.s3-eu-west-1.amazonaws.com/cloudify/envs/pip-wheels.tar
-                mkdir /tmp/pip-wheels
-                tar xvf /tmp/pyenv-2.6.9.tar -C /
-                tar xvf /tmp/pip-wheels.tar -C /tmp/pip-wheels
-                pyenv global 2.6.9
-                '''
-                // py26 uses py26-only-compatible versions of libs: pyyaml 4.2b4, hence the specialcased [dispatcher_py26]
-                sh '''#!/bin/bash
-                pip install -r dev-requirements.txt -f /tmp/pip-wheels --user
-                pip install -r test-requirements.txt -f /tmp/pip-wheels --user
-                pip install -e '.[dispatcher_py26]' -f /tmp/pip-wheels --user
-                '''
-                pytest('dsl_parser')
-                pytest('script_runner')
-                pytest('cloudify')
-              }
-            }
-          }
-          post {
-            always {
-              junit '**/test-results/*.xml'
-            }
-          }
-        }
         stage('test_py27'){
           steps{
             sh script: "mkdir -p ${env.WORKSPACE}/test-py27 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py27", label: "copying repo to seperate workspace"

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -8,21 +8,6 @@ spec:
       limits:
         cpu: 0.2
         memory: 256Mi
-  - name: py26
-    image: circleci/python:2.7-stretch
-    command:
-    - cat
-    tty: true
-    securityContext:
-        runAsUser: 0
-        privileged: true
-    resources:
-      requests:
-        cpu: 1
-        memory: 2Gi
-      limits:
-        cpu: 2
-        memory: 2Gi
   - name: py27
     image: circleci/python:2.7
     command:
@@ -33,7 +18,7 @@ spec:
         privileged: true
     resources:
       requests:
-        cpu: 1
+        cpu: 1.5
         memory: 2Gi
       limits:
         cpu: 2
@@ -48,7 +33,7 @@ spec:
       privileged: true
     resources:
       requests:
-        cpu: 1
+        cpu: 1.5
         memory: 2Gi
       limits:
         cpu: 2.5


### PR DESCRIPTION
We don't build anything for py2.6 any more since pip got unhappy,
so let's not test on it.