### PR TITLE
RD-3115 dsl-parser tests: stop using testtools

### DIFF
--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -291,7 +291,9 @@ imports:"""
                 parsing_method(dsl)
             ex = cm.exception
         else:
-            ex = self.assertRaises(exception_type, parsing_method, dsl)
+            with self.assertRaises(exception_type) as cm:
+                parsing_method(dsl)
+            ex = cm.exception
         self.assertEqual(ex.err_code, expected_error_code)
         return ex
 

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -187,6 +187,10 @@ node_types:
         shutil.rmtree(self._temp_dir)
         super(AbstractTestParser, self).tearDown()
 
+    def assertRaisesRegex(self, *args, **kwargs):
+        # py2.7-compat
+        return self.assertRaisesRegexp(*args, **kwargs)
+
     def make_file_with_name(self, content, filename, base_dir=None):
         base_dir = os.path.join(self._temp_dir, base_dir) \
             if base_dir else self._temp_dir

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -317,6 +317,7 @@ imports:"""
     def get_secret(self, secret_name):
         return self.mock_evaluation_storage().get_secret(secret_name)
 
+
 # 2.7 compat
 if not hasattr(AbstractTestParser, 'assertRaisesRegex'):
     AbstractTestParser.assertRaisesRegex = \

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -187,10 +187,6 @@ node_types:
         shutil.rmtree(self._temp_dir)
         super(AbstractTestParser, self).tearDown()
 
-    def assertRaisesRegex(self, *args, **kwargs):
-        # py2.7-compat
-        return self.assertRaisesRegexp(*args, **kwargs)
-
     def make_file_with_name(self, content, filename, base_dir=None):
         base_dir = os.path.join(self._temp_dir, base_dir) \
             if base_dir else self._temp_dir
@@ -320,3 +316,8 @@ imports:"""
 
     def get_secret(self, secret_name):
         return self.mock_evaluation_storage().get_secret(secret_name)
+
+# 2.7 compat
+if not hasattr(AbstractTestParser, 'assertRaisesRegex'):
+    AbstractTestParser.assertRaisesRegex = \
+        AbstractTestParser.assertRaisesRegexp

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -17,8 +17,8 @@ import tempfile
 import shutil
 import os
 import uuid
+import unittest
 
-import testtools
 from mock import Mock
 
 from dsl_parser._compat import pathname2url, urljoin
@@ -91,7 +91,7 @@ class _MockRuntimeEvaluationStorage(object):
         return self.get_capability(capability_path)
 
 
-class AbstractTestParser(testtools.TestCase):
+class AbstractTestParser(unittest.TestCase):
     BASIC_VERSION_SECTION_DSL_1_0 = """
 tosca_definitions_version: cloudify_dsl_1_0
     """

--- a/dsl_parser/tests/interfaces/test_interfaces_merger.py
+++ b/dsl_parser/tests/interfaces/test_interfaces_merger.py
@@ -13,14 +13,14 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import testtools
+import unittest
 
 from dsl_parser.interfaces.interfaces_merger import InterfaceMerger
 from dsl_parser.interfaces.interfaces_merger import InterfacesMerger
 from dsl_parser.interfaces.operation_merger import OperationMerger
 
 
-class InterfaceMergerTest(testtools.TestCase):
+class InterfaceMergerTest(unittest.TestCase):
 
     def _assert_interface(self,
                           overriding_interface,
@@ -81,7 +81,7 @@ class InterfaceMergerTest(testtools.TestCase):
         )
 
 
-class InterfacesMergerTest(testtools.TestCase):
+class InterfacesMergerTest(unittest.TestCase):
 
     def _assert_interfaces(self,
                            overriding_interfaces,

--- a/dsl_parser/tests/interfaces/test_interfaces_parser.py
+++ b/dsl_parser/tests/interfaces/test_interfaces_parser.py
@@ -13,7 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import testtools
+import unittest
 from dsl_parser.interfaces.constants import NO_OP
 
 from dsl_parser.interfaces.interfaces_parser import (
@@ -26,7 +26,7 @@ from dsl_parser.elements import operation
 from dsl_parser.tests.interfaces import validate
 
 
-class InterfacesParserTest(testtools.TestCase):
+class InterfacesParserTest(unittest.TestCase):
 
     def _validate_type_interfaces(self, interfaces):
         validate(interfaces, operation.NodeTypeInterfaces)

--- a/dsl_parser/tests/interfaces/test_operation_merger.py
+++ b/dsl_parser/tests/interfaces/test_operation_merger.py
@@ -13,7 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import testtools
+import unittest
 
 from dsl_parser.interfaces.constants import NO_OP
 from dsl_parser.interfaces.utils import operation_mapping
@@ -51,7 +51,7 @@ def raw_operation_mapping(implementation=None,
     return result
 
 
-class NodeTemplateNodeTypeOperationMergerTest(testtools.TestCase):
+class NodeTemplateNodeTypeOperationMergerTest(unittest.TestCase):
 
     def _assert_operations(self,
                            node_template_operation,
@@ -1122,7 +1122,7 @@ class NodeTemplateNodeTypeOperationMergerTest(testtools.TestCase):
         )
 
 
-class NodeTypeNodeTypeOperationMergerTest(testtools.TestCase):
+class NodeTypeNodeTypeOperationMergerTest(unittest.TestCase):
 
     def _assert_operations(self,
                            overriding_node_type_operation,

--- a/dsl_parser/tests/namespace/test_functions.py
+++ b/dsl_parser/tests/namespace/test_functions.py
@@ -647,8 +647,8 @@ imports:
         else:
             raise RuntimeError('No node "ip" found')
         self.assertEqual(ip['id'], 'ns2--ns--ip')
-        self.assertEquals(ip['properties']['port'],
-                          {'get_property': ['ns2--ns--node', 'port']})
+        self.assertEqual(ip['properties']['port'],
+                         {'get_property': ['ns2--ns--node', 'port']})
 
 
 class TestGetAttribute(AbstractTestParser):
@@ -829,8 +829,8 @@ imports:
         else:
             raise RuntimeError('No node "ip" found')
         self.assertEqual(ip['id'], 'ns2--ns--ip')
-        self.assertEquals(ip['properties']['port'],
-                          {'get_attribute': ['ns2--ns--node', 'port']})
+        self.assertEqual(ip['properties']['port'],
+                         {'get_attribute': ['ns2--ns--node', 'port']})
 
     def test_node_type_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """
@@ -920,9 +920,9 @@ imports:
         else:
             raise RuntimeError('No node "ip" found')
         self.assertEqual(ip['id'], 'ns2--ns--ip')
-        self.assertEquals(ip['properties']['port'],
-                          {'concat':
-                            ['one', {'get_input': 'ns2--ns--port'}, 'three']})
+        self.assertEqual(ip['properties']['port'],
+                         {'concat':
+                           ['one', {'get_input': 'ns2--ns--port'}, 'three']})
 
     def test_node_type_properties_with_blueprint_import(self):
         basic_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """

--- a/dsl_parser/tests/namespace/test_node_templates.py
+++ b/dsl_parser/tests/namespace/test_node_templates.py
@@ -33,12 +33,12 @@ imports:
     -   {0}--{1}
 """.format('test', import_file_name)
         parsed_yaml = self.parse(main_yaml)
-        self.assertEquals(1, len(parsed_yaml[constants.NODES]))
+        self.assertEqual(1, len(parsed_yaml[constants.NODES]))
         node = parsed_yaml[constants.NODES][0]
-        self.assertEquals('test--test_node', node['id'])
-        self.assertEquals('test--test_type', node['type'])
-        self.assertEquals('val', node[constants.PROPERTIES]['key'])
-        self.assertEquals(2, node['instances']['deploy'])
+        self.assertEqual('test--test_node', node['id'])
+        self.assertEqual('test--test_type', node['type'])
+        self.assertEqual('val', node[constants.PROPERTIES]['key'])
+        self.assertEqual(2, node['instances']['deploy'])
 
     def test_namespaced_script_plugin_interface_use(self):
         imported_yaml = self.BASIC_VERSION_SECTION_DSL_1_0 + """
@@ -223,15 +223,15 @@ imports:
 
         multi_plan = self.parse_multi(main_yaml)
         nodes_instances = multi_plan[constants.NODE_INSTANCES]
-        self.assertEquals(2, len(nodes_instances))
-        self.assertEquals(2, len(set(self._node_ids(nodes_instances))))
+        self.assertEqual(2, len(nodes_instances))
+        self.assertEqual(2, len(set(self._node_ids(nodes_instances))))
 
         self.assertIn('host_', nodes_instances[0]['id'])
         self.assertIn('host_', nodes_instances[1]['id'])
-        self.assertEquals(nodes_instances[0]['id'],
-                          nodes_instances[0]['host_id'])
-        self.assertEquals(nodes_instances[1]['id'],
-                          nodes_instances[1]['host_id'])
+        self.assertEqual(nodes_instances[0]['id'],
+                         nodes_instances[0]['host_id'])
+        self.assertEqual(nodes_instances[1]['id'],
+                         nodes_instances[1]['host_id'])
         node = multi_plan[constants.NODES][0]
         node_props = node[constants.CAPABILITIES]['scalable']['properties']
         self.assertEqual(1, node_props['min_instances'])

--- a/dsl_parser/tests/namespace/test_plugins.py
+++ b/dsl_parser/tests/namespace/test_plugins.py
@@ -184,8 +184,8 @@ node_templates:
         self.assertEqual(expected_plugin1, plugin1)
         self.assertEqual(expected_plugin2, plugin2)
         self.assertEqual(expected_test_plugin1, test_plugin1)
-        self.assertEquals(parsed[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
-                          [plugin2])
+        self.assertEqual(parsed[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
+                         [plugin2])
 
     def test_plugins_merging_with_no_collision(self):
         imported_yaml = self.BASIC_VERSION_SECTION_DSL_1_3 + """

--- a/dsl_parser/tests/namespace/test_relationships.py
+++ b/dsl_parser/tests/namespace/test_relationships.py
@@ -51,18 +51,18 @@ imports:
         parsed_yaml = self.parse_1_3(main_yaml)
         test_relationship = (parsed_yaml[constants.RELATIONSHIPS]
                              ['test--test_relationship'])
-        self.assertEquals('test--test_relationship', test_relationship['name'])
-        self.assertEquals(test_relationship[constants.TYPE_HIERARCHY],
-                          ['test--empty_rel', 'test--test_relationship'])
+        self.assertEqual('test--test_relationship', test_relationship['name'])
+        self.assertEqual(test_relationship[constants.TYPE_HIERARCHY],
+                         ['test--empty_rel', 'test--test_relationship'])
         result_test_interface_3 = \
             (test_relationship[interfaces_const.SOURCE_INTERFACES]
              ['test_interface3'])
-        self.assertEquals(interfaces_const.NO_OP,
+        self.assertEqual(interfaces_const.NO_OP,
                           result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             (test_relationship[interfaces_const.TARGET_INTERFACES]
              ['test_interface4'])
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test--test_plugin.task_name',
                               inputs={'key':
                                       {'default': 'value',
@@ -73,7 +73,7 @@ imports:
                               timeout=None,
                               timeout_recoverable=None),
             result_test_interface_4['test_interface4_op1'])
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test--test_plugin.task_name',
                               inputs={},
                               executor=None,
@@ -114,18 +114,18 @@ imports:
         parsed_yaml = self.parse_1_3(main_yaml)
         test_relationship = (parsed_yaml[constants.RELATIONSHIPS]
                              ['test--test_relationship'])
-        self.assertEquals('test--test_relationship', test_relationship['name'])
-        self.assertEquals(test_relationship[constants.TYPE_HIERARCHY],
+        self.assertEqual('test--test_relationship', test_relationship['name'])
+        self.assertEqual(test_relationship[constants.TYPE_HIERARCHY],
                           ['test--empty_rel', 'test--test_relationship'])
         result_test_interface_3 = \
             (test_relationship[interfaces_const.SOURCE_INTERFACES]
              ['test_interface3'])
-        self.assertEquals(interfaces_const.NO_OP,
+        self.assertEqual(interfaces_const.NO_OP,
                           result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             (test_relationship[interfaces_const.TARGET_INTERFACES]
              ['test_interface4'])
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test--test_plugin.task_name',
                               inputs={'key':
                                       {'default': 'value',
@@ -138,20 +138,20 @@ imports:
             result_test_interface_4['test_interface4_op1'])
         test_relationship = (parsed_yaml[constants.RELATIONSHIPS]
                              ['other_test--test_relationship'])
-        self.assertEquals('other_test--test_relationship',
+        self.assertEqual('other_test--test_relationship',
                           test_relationship['name'])
-        self.assertEquals(test_relationship[constants.TYPE_HIERARCHY],
+        self.assertEqual(test_relationship[constants.TYPE_HIERARCHY],
                           ['other_test--empty_rel',
                            'other_test--test_relationship'])
         result_test_interface_3 = \
             (test_relationship[interfaces_const.SOURCE_INTERFACES]
                 ['test_interface3'])
-        self.assertEquals(interfaces_const.NO_OP,
+        self.assertEqual(interfaces_const.NO_OP,
                           result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             (test_relationship[interfaces_const.TARGET_INTERFACES]
                 ['test_interface4'])
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(
                 implementation='other_test--test_plugin.task_name',
                 inputs={'key':
@@ -184,14 +184,14 @@ relationships:
 """.format('test', import_file_name)
         parsed = self.parse(main_yaml)
         relationships = parsed[constants.RELATIONSHIPS]
-        self.assertEquals(2, len(relationships))
+        self.assertEqual(2, len(relationships))
         test_relationship = relationships['test_relationship']
         properties = test_relationship[constants.PROPERTIES]
-        self.assertEquals({'default': 2}, properties[
+        self.assertEqual({'default': 2}, properties[
             'prop'])
         test_relationship = relationships['test--test_relationship']
         properties = test_relationship[constants.PROPERTIES]
-        self.assertEquals({'default': 1}, properties[
+        self.assertEqual({'default': 1}, properties[
             'prop'])
 
     def test_relationships_merging_with_no_collision(self):
@@ -214,14 +214,14 @@ relationships:
 """.format('test', import_file_name)
         parsed = self.parse(main_yaml)
         relationships = parsed[constants.RELATIONSHIPS]
-        self.assertEquals(2, len(relationships))
+        self.assertEqual(2, len(relationships))
         test_relationship = relationships['test_relationship2']
         properties = test_relationship[constants.PROPERTIES]
-        self.assertEquals({'default': 2}, properties[
+        self.assertEqual({'default': 2}, properties[
             'prop'])
         test_relationship = relationships['test--test_relationship1']
         properties = test_relationship[constants.PROPERTIES]
-        self.assertEquals({'default': 1}, properties[
+        self.assertEqual({'default': 1}, properties[
             'prop'])
 
     def test_namespaced_script_plugin_use(self):

--- a/dsl_parser/tests/namespace/test_relationships.py
+++ b/dsl_parser/tests/namespace/test_relationships.py
@@ -58,7 +58,7 @@ imports:
             (test_relationship[interfaces_const.SOURCE_INTERFACES]
              ['test_interface3'])
         self.assertEqual(interfaces_const.NO_OP,
-                          result_test_interface_3['test_interface3_op1'])
+                         result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             (test_relationship[interfaces_const.TARGET_INTERFACES]
              ['test_interface4'])
@@ -116,12 +116,12 @@ imports:
                              ['test--test_relationship'])
         self.assertEqual('test--test_relationship', test_relationship['name'])
         self.assertEqual(test_relationship[constants.TYPE_HIERARCHY],
-                          ['test--empty_rel', 'test--test_relationship'])
+                         ['test--empty_rel', 'test--test_relationship'])
         result_test_interface_3 = \
             (test_relationship[interfaces_const.SOURCE_INTERFACES]
              ['test_interface3'])
         self.assertEqual(interfaces_const.NO_OP,
-                          result_test_interface_3['test_interface3_op1'])
+                         result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             (test_relationship[interfaces_const.TARGET_INTERFACES]
              ['test_interface4'])
@@ -139,15 +139,15 @@ imports:
         test_relationship = (parsed_yaml[constants.RELATIONSHIPS]
                              ['other_test--test_relationship'])
         self.assertEqual('other_test--test_relationship',
-                          test_relationship['name'])
+                         test_relationship['name'])
         self.assertEqual(test_relationship[constants.TYPE_HIERARCHY],
-                          ['other_test--empty_rel',
-                           'other_test--test_relationship'])
+                         ['other_test--empty_rel',
+                          'other_test--test_relationship'])
         result_test_interface_3 = \
             (test_relationship[interfaces_const.SOURCE_INTERFACES]
                 ['test_interface3'])
         self.assertEqual(interfaces_const.NO_OP,
-                          result_test_interface_3['test_interface3_op1'])
+                         result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             (test_relationship[interfaces_const.TARGET_INTERFACES]
                 ['test_interface4'])

--- a/dsl_parser/tests/namespace/test_workflows.py
+++ b/dsl_parser/tests/namespace/test_workflows.py
@@ -86,9 +86,9 @@ workflows:
         workflow_plugins_to_install = \
             parsed[constants.WORKFLOW_PLUGINS_TO_INSTALL]
         self.assertEqual(2, len(workflow_plugins_to_install))
-        self.assertEqual(['test--test_plugin', 'test_plugin'],
-                         [workflow_plugins_to_install[1]['name'],
-                          workflow_plugins_to_install[0]['name']])
+        self.assertEqual({'test--test_plugin', 'test_plugin'},
+                         {workflow_plugins_to_install[0]['name'],
+                          workflow_plugins_to_install[1]['name']})
 
     def test_workflows_merging_with_no_collision(self):
         imported_yaml = self.basic_blueprint()

--- a/dsl_parser/tests/namespace/test_workflows.py
+++ b/dsl_parser/tests/namespace/test_workflows.py
@@ -86,9 +86,9 @@ workflows:
         workflow_plugins_to_install = \
             parsed[constants.WORKFLOW_PLUGINS_TO_INSTALL]
         self.assertEqual(2, len(workflow_plugins_to_install))
-        self.assertItemsEqual(['test--test_plugin', 'test_plugin'],
-                              [workflow_plugins_to_install[1]['name'],
-                               workflow_plugins_to_install[0]['name']])
+        self.assertEqual(['test--test_plugin', 'test_plugin'],
+                         [workflow_plugins_to_install[1]['name'],
+                          workflow_plugins_to_install[0]['name']])
 
     def test_workflows_merging_with_no_collision(self):
         imported_yaml = self.basic_blueprint()

--- a/dsl_parser/tests/scaling/test_multi_instance.py
+++ b/dsl_parser/tests/scaling/test_multi_instance.py
@@ -181,9 +181,9 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
         webserver_db_rel = self._relationships_by_target_name(
             webserver_relationships, 'db')[0]
         self.assertEqual(host2['id'],
-                          webserver_host_rel['target_id'])
+                         webserver_host_rel['target_id'])
         self.assertEqual(db['id'],
-                          webserver_db_rel['target_id'])
+                         webserver_db_rel['target_id'])
 
         db_dependent_relationships = db_dependent['relationships']
         self.assertEqual(2, len(db_dependent_relationships))
@@ -192,9 +192,9 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
         db_dependent_host_rel = self._relationships_by_target_name(
             db_dependent_relationships, 'host1')[0]
         self.assertEqual(db['id'],
-                          db_dependent_db_rel['target_id'])
+                         db_dependent_db_rel['target_id'])
         self.assertEqual(host1['id'],
-                          db_dependent_host_rel['target_id'])
+                         db_dependent_host_rel['target_id'])
 
     def test_prepare_deployment_plan_single_none_host_node(self):
 

--- a/dsl_parser/tests/scaling/test_multi_instance.py
+++ b/dsl_parser/tests/scaling/test_multi_instance.py
@@ -38,13 +38,13 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
 
         multi_plan = self.parse_multi(yaml)
         nodes = multi_plan['node_instances']
-        self.assertEquals(2, len(nodes))
-        self.assertEquals(2, len(set(self._node_ids(nodes))))
+        self.assertEqual(2, len(nodes))
+        self.assertEqual(2, len(set(self._node_ids(nodes))))
 
         self.assertIn('host_', nodes[0]['id'])
         self.assertIn('host_', nodes[1]['id'])
-        self.assertEquals(nodes[0]['id'], nodes[0]['host_id'])
-        self.assertEquals(nodes[1]['id'], nodes[1]['host_id'])
+        self.assertEqual(nodes[0]['id'], nodes[0]['host_id'])
+        self.assertEqual(nodes[1]['id'], nodes[1]['host_id'])
 
     def test_two_nodes_one_contained_in_other(self):
 
@@ -59,19 +59,19 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
 """
         multi_plan = self.parse_multi(yaml)
         nodes = multi_plan['node_instances']
-        self.assertEquals(2, len(nodes))
-        self.assertEquals(2, len(set(self._node_ids(nodes))))
+        self.assertEqual(2, len(nodes))
+        self.assertEqual(2, len(set(self._node_ids(nodes))))
         db = self._nodes_by_name(nodes, 'db')[0]
         host = self._nodes_by_name(nodes, 'host')[0]
 
         self.assertIn('host_', host['id'])
         self.assertIn('db_', db['id'])
-        self.assertEquals(host['id'], host['host_id'])
-        self.assertEquals(host['id'], db['host_id'])
+        self.assertEqual(host['id'], host['host_id'])
+        self.assertEqual(host['id'], db['host_id'])
 
         db_relationships = db['relationships']
-        self.assertEquals(1, len(db_relationships))
-        self.assertEquals(host['id'], db_relationships[0]['target_id'])
+        self.assertEqual(1, len(db_relationships))
+        self.assertEqual(host['id'], db_relationships[0]['target_id'])
 
     def test_two_nodes_one_contained_in_other_two_instances(self):
 
@@ -90,7 +90,7 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
 """
         multi_plan = self.parse_multi(yaml)
         nodes = multi_plan['node_instances']
-        self.assertEquals(4, len(nodes))
+        self.assertEqual(4, len(nodes))
         self.assertEqual(4, len(set(self._node_ids(nodes))))
 
         db_nodes = self._nodes_by_name(nodes, 'db')
@@ -114,11 +114,11 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
         self.assertNotEqual(db_1['host_id'], db_2['host_id'])
 
         db1_relationships = db_1['relationships']
-        self.assertEquals(1, len(db1_relationships))
-        self.assertEquals(db_1['host_id'], db1_relationships[0]['target_id'])
+        self.assertEqual(1, len(db1_relationships))
+        self.assertEqual(db_1['host_id'], db1_relationships[0]['target_id'])
         db2_relationships = db_2['relationships']
-        self.assertEquals(1, len(db2_relationships))
-        self.assertEquals(db_2['host_id'], db2_relationships[0]['target_id'])
+        self.assertEqual(1, len(db2_relationships))
+        self.assertEqual(db_2['host_id'], db2_relationships[0]['target_id'])
 
     def test_single_connected_to(self):
         yaml = self.BASE_BLUEPRINT + """
@@ -149,8 +149,8 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
 
         multi_plan = self.parse_multi(yaml)
         nodes = multi_plan['node_instances']
-        self.assertEquals(5, len(nodes))
-        self.assertEquals(5, len(set(self._node_ids(nodes))))
+        self.assertEqual(5, len(nodes))
+        self.assertEqual(5, len(set(self._node_ids(nodes))))
 
         host1 = self._nodes_by_name(nodes, 'host1')[0]
         host2 = self._nodes_by_name(nodes, 'host2')[0]
@@ -164,36 +164,36 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
         self.assertIn('webserver_', webserver['id'])
         self.assertIn('db_dependent_', db_dependent['id'])
 
-        self.assertEquals(host1['id'], host1['host_id'])
-        self.assertEquals(host2['id'], host2['host_id'])
-        self.assertEquals(host1['id'], db['host_id'])
-        self.assertEquals(host2['id'], webserver['host_id'])
-        self.assertEquals(host1['id'], db_dependent['host_id'])
+        self.assertEqual(host1['id'], host1['host_id'])
+        self.assertEqual(host2['id'], host2['host_id'])
+        self.assertEqual(host1['id'], db['host_id'])
+        self.assertEqual(host2['id'], webserver['host_id'])
+        self.assertEqual(host1['id'], db_dependent['host_id'])
 
         db_relationships = db['relationships']
-        self.assertEquals(1, len(db_relationships))
-        self.assertEquals(host1['id'], db_relationships[0]['target_id'])
+        self.assertEqual(1, len(db_relationships))
+        self.assertEqual(host1['id'], db_relationships[0]['target_id'])
 
         webserver_relationships = webserver['relationships']
-        self.assertEquals(2, len(webserver_relationships))
+        self.assertEqual(2, len(webserver_relationships))
         webserver_host_rel = self._relationships_by_target_name(
             webserver_relationships, 'host2')[0]
         webserver_db_rel = self._relationships_by_target_name(
             webserver_relationships, 'db')[0]
-        self.assertEquals(host2['id'],
+        self.assertEqual(host2['id'],
                           webserver_host_rel['target_id'])
-        self.assertEquals(db['id'],
+        self.assertEqual(db['id'],
                           webserver_db_rel['target_id'])
 
         db_dependent_relationships = db_dependent['relationships']
-        self.assertEquals(2, len(db_dependent_relationships))
+        self.assertEqual(2, len(db_dependent_relationships))
         db_dependent_db_rel = self._relationships_by_target_name(
             db_dependent_relationships, 'db')[0]
         db_dependent_host_rel = self._relationships_by_target_name(
             db_dependent_relationships, 'host1')[0]
-        self.assertEquals(db['id'],
+        self.assertEqual(db['id'],
                           db_dependent_db_rel['target_id'])
-        self.assertEquals(host1['id'],
+        self.assertEqual(host1['id'],
                           db_dependent_host_rel['target_id'])
 
     def test_prepare_deployment_plan_single_none_host_node(self):
@@ -205,7 +205,7 @@ class TestMultiInstance(scaling.BaseTestMultiInstance):
 
         multi_plan = self.parse_multi(yaml)
         nodes = multi_plan['node_instances']
-        self.assertEquals(1, len(nodes))
+        self.assertEqual(1, len(nodes))
         self.assertIn('node1_id_', nodes[0]['id'])
         self.assertTrue('host_id' not in nodes[0])
 
@@ -284,8 +284,8 @@ plugins:
 """
         multi_plan = self.parse_multi(yaml)
         nodes = multi_plan['node_instances']
-        self.assertEquals(21, len(nodes))
-        self.assertEquals(21, len(set(self._node_ids(nodes))))
+        self.assertEqual(21, len(nodes))
+        self.assertEqual(21, len(set(self._node_ids(nodes))))
 
         network_1 = self._nodes_by_name(nodes, 'network')[0]
 
@@ -342,12 +342,12 @@ plugins:
 
         self.assertTrue('host_id' not in network_1)
 
-        self.assertEquals(host1_1['id'], host1_1['host_id'])
-        self.assertEquals(host1_2['id'], host1_2['host_id'])
-        self.assertEquals(host2_1['id'], host2_1['host_id'])
-        self.assertEquals(host2_2['id'], host2_2['host_id'])
-        self.assertEquals(host3_1['id'], host3_1['host_id'])
-        self.assertEquals(host3_2['id'], host3_2['host_id'])
+        self.assertEqual(host1_1['id'], host1_1['host_id'])
+        self.assertEqual(host1_2['id'], host1_2['host_id'])
+        self.assertEqual(host2_1['id'], host2_1['host_id'])
+        self.assertEqual(host2_2['id'], host2_2['host_id'])
+        self.assertEqual(host3_1['id'], host3_1['host_id'])
+        self.assertEqual(host3_2['id'], host3_2['host_id'])
 
         self._assert_each_node_valid_hosted(
             webserver1_nodes, host2_nodes)
@@ -380,27 +380,27 @@ plugins:
         db_dependent_3_relationships = db_dependent_3['relationships']
         db_dependent_4_relationships = db_dependent_4['relationships']
 
-        self.assertEquals(0, len(network_1_relationships))
-        self.assertEquals(0, len(host1_1_relationships))
-        self.assertEquals(0, len(host1_2_relationships))
-        self.assertEquals(0, len(host2_1_relationships))
-        self.assertEquals(0, len(host2_2_relationships))
-        self.assertEquals(0, len(host3_1_relationships))
-        self.assertEquals(0, len(host3_2_relationships))
-        self.assertEquals(2, len(webserver1_1_relationships))
-        self.assertEquals(2, len(webserver1_2_relationships))
-        self.assertEquals(5, len(webserver2_1_relationships))
-        self.assertEquals(5, len(webserver2_2_relationships))
-        self.assertEquals(5, len(webserver3_1_relationships))
-        self.assertEquals(5, len(webserver3_2_relationships))
-        self.assertEquals(1, len(db_1_relationships))
-        self.assertEquals(1, len(db_2_relationships))
-        self.assertEquals(1, len(db_3_relationships))
-        self.assertEquals(1, len(db_4_relationships))
-        self.assertEquals(1, len(db_dependent_1_relationships))
-        self.assertEquals(1, len(db_dependent_2_relationships))
-        self.assertEquals(1, len(db_dependent_3_relationships))
-        self.assertEquals(1, len(db_dependent_4_relationships))
+        self.assertEqual(0, len(network_1_relationships))
+        self.assertEqual(0, len(host1_1_relationships))
+        self.assertEqual(0, len(host1_2_relationships))
+        self.assertEqual(0, len(host2_1_relationships))
+        self.assertEqual(0, len(host2_2_relationships))
+        self.assertEqual(0, len(host3_1_relationships))
+        self.assertEqual(0, len(host3_2_relationships))
+        self.assertEqual(2, len(webserver1_1_relationships))
+        self.assertEqual(2, len(webserver1_2_relationships))
+        self.assertEqual(5, len(webserver2_1_relationships))
+        self.assertEqual(5, len(webserver2_2_relationships))
+        self.assertEqual(5, len(webserver3_1_relationships))
+        self.assertEqual(5, len(webserver3_2_relationships))
+        self.assertEqual(1, len(db_1_relationships))
+        self.assertEqual(1, len(db_2_relationships))
+        self.assertEqual(1, len(db_3_relationships))
+        self.assertEqual(1, len(db_4_relationships))
+        self.assertEqual(1, len(db_dependent_1_relationships))
+        self.assertEqual(1, len(db_dependent_2_relationships))
+        self.assertEqual(1, len(db_dependent_3_relationships))
+        self.assertEqual(1, len(db_dependent_4_relationships))
 
         self._assert_contained(webserver1_1_relationships +
                                webserver1_2_relationships,

--- a/dsl_parser/tests/scaling/test_scaling_policies_and_groups.py
+++ b/dsl_parser/tests/scaling/test_scaling_policies_and_groups.py
@@ -749,7 +749,7 @@ class TestNodeTemplateDefaultScalableProperties(AbstractTestParser):
 
     def assert_scalable_properties(self, blueprint, expected_default=1):
         plan = self.parse_1_3(blueprint)
-        self.assertEquals({
+        self.assertEqual({
             'default_instances': expected_default,
             'min_instances': 0,
             'max_instances': constants.UNBOUNDED,

--- a/dsl_parser/tests/test_blueprint_import.py
+++ b/dsl_parser/tests/test_blueprint_import.py
@@ -13,6 +13,8 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+import pytest
+
 from dsl_parser import constants, exceptions
 from dsl_parser.tests.utils import ResolverWithBlueprintSupport
 from dsl_parser.tests.abstract_test_parser import AbstractTestParser
@@ -128,6 +130,7 @@ namespaces_mapping:
   ns: blueprint
 """
 
+    @pytest.mark.xfail(reason='RD-3097')
     def test_merging_namespaces_mapping(self):
         resolver = ResolverWithBlueprintSupport({
             'blueprint:test': self.blueprint_imported
@@ -150,16 +153,16 @@ imports:
 """.format('test', layer2_import_path, 'other_test')
         parsed_yaml = self.parse(main_yaml, resolver=resolver)
         namespaces_mapping = parsed_yaml[constants.NAMESPACES_MAPPING]
-        self.assertItemsEqual({'other_test--test1--namespace': 'test',
-                               'test--test1--namespace': 'test',
-                               'other_test--test1--namespace--ns': 'blueprint',
-                               'test--test1--namespace--ns': 'blueprint',
-                               'other_test--namespace--ns': 'blueprint',
-                               'test--namespace': 'blueprint',
-                               'other_test--namespace': 'blueprint',
-                               'test--namespace--ns': 'blueprint'
-                               },
-                              namespaces_mapping)
+        self.assertItemsEqual({
+            'other_test--test1--namespace': 'test',
+            'test--test1--namespace': 'test',
+            'other_test--test1--namespace--ns': 'blueprint',
+            'test--test1--namespace--ns': 'blueprint',
+            'other_test--namespace--ns': 'blueprint',
+            'test--namespace': 'blueprint',
+            'other_test--namespace': 'blueprint',
+            'test--namespace--ns': 'blueprint'
+          }, namespaces_mapping)
 
     def test_blueprints_imports_with_the_same_import(self):
         resolver = ResolverWithBlueprintSupport({

--- a/dsl_parser/tests/test_blueprint_import.py
+++ b/dsl_parser/tests/test_blueprint_import.py
@@ -108,11 +108,9 @@ imports:
         parsed_yaml = self.parse(main_yaml, resolver=resolver)
         imported_blueprints = parsed_yaml[constants.IMPORTED_BLUEPRINTS]
         self.assertEqual(len(imported_blueprints), 3)
-        self.assertItemsEqual(
-            ['other_test',
-             'test',
-             'another_test'],
-            imported_blueprints)
+        self.assertEqual(
+            {'other_test', 'test', 'another_test'},
+            set(imported_blueprints))
 
     def test_not_valid_blueprint_import(self):
         yaml = """

--- a/dsl_parser/tests/test_constraints.py
+++ b/dsl_parser/tests/test_constraints.py
@@ -13,14 +13,14 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import testtools
+import unittest
 from mock import patch, MagicMock
 
 from dsl_parser import exceptions
 from dsl_parser import constraints
 
 
-class TestGeneralUtilFunctions(testtools.TestCase):
+class TestGeneralUtilFunctions(unittest.TestCase):
     def test_validate_args_raises(self):
         validation_funcs = {'some_type': lambda _: False}
         with patch('dsl_parser.constraints.VALIDATION_FUNCTIONS',
@@ -121,7 +121,7 @@ class TestGeneralUtilFunctions(testtools.TestCase):
             self.assertEqual(f(), validation_funcs['type2']())
 
 
-class TestConstraint(testtools.TestCase):
+class TestConstraint(unittest.TestCase):
     def test_str(self):
         class DummyConstraint(constraints.Constraint):
             name = 'name'
@@ -137,7 +137,7 @@ class TestConstraint(testtools.TestCase):
         self.assertEqual('name(arg1, 123) operator', str(constraint))
 
 
-class TestEqual(testtools.TestCase):
+class TestEqual(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.Equal(3)
@@ -153,7 +153,7 @@ class TestEqual(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestGreaterThan(testtools.TestCase):
+class TestGreaterThan(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.GreaterThan(3)
@@ -169,7 +169,7 @@ class TestGreaterThan(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestGreaterOrEqual(testtools.TestCase):
+class TestGreaterOrEqual(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.GreaterOrEqual(3)
@@ -185,7 +185,7 @@ class TestGreaterOrEqual(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestLessThan(testtools.TestCase):
+class TestLessThan(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.LessThan(3)
@@ -201,7 +201,7 @@ class TestLessThan(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestLessOrEqual(testtools.TestCase):
+class TestLessOrEqual(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.LessOrEqual(3)
@@ -217,7 +217,7 @@ class TestLessOrEqual(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestInRange(testtools.TestCase):
+class TestInRange(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.InRange([0, 5])
@@ -236,7 +236,7 @@ class TestInRange(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestValidValues(testtools.TestCase):
+class TestValidValues(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.ValidValues([0, 2])
@@ -252,7 +252,7 @@ class TestValidValues(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestLength(testtools.TestCase):
+class TestLength(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.Length(1)
@@ -268,7 +268,7 @@ class TestLength(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestMinLength(testtools.TestCase):
+class TestMinLength(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.MinLength(1)
@@ -284,7 +284,7 @@ class TestMinLength(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestMaxLength(testtools.TestCase):
+class TestMaxLength(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.MaxLength(1)
@@ -300,7 +300,7 @@ class TestMaxLength(testtools.TestCase):
         self.assertRaises(exceptions.ConstraintException, dummy.predicate, A())
 
 
-class TestPattern(testtools.TestCase):
+class TestPattern(unittest.TestCase):
 
     def test_successful(self):
         dummy = constraints.Pattern('a{3}b{1}c+')

--- a/dsl_parser/tests/test_deafult_import_resolver.py
+++ b/dsl_parser/tests/test_deafult_import_resolver.py
@@ -15,8 +15,7 @@
 
 import mock
 import requests
-
-import testtools
+import unittest
 
 from dsl_parser.exceptions import DSLParsingLogicException
 from dsl_parser.import_resolver.default_import_resolver import \
@@ -46,7 +45,7 @@ RETRY_URL = 'retry_url'
 RETRY_DELAY = 0
 
 
-class TestDefaultResolver(testtools.TestCase):
+class TestDefaultResolver(unittest.TestCase):
 
     def test_several_matching_rules(self):
         rules = [
@@ -271,7 +270,7 @@ class TestDefaultResolver(testtools.TestCase):
             self.assertEqual(MAX_NUMBER_RETRIES + 1, len(number_of_attempts))
 
 
-class TestDefaultResolverValidations(testtools.TestCase):
+class TestDefaultResolverValidations(unittest.TestCase):
 
     def test_illegal_default_resolver_rules_type(self):
         # wrong rules configuration - string instead of list

--- a/dsl_parser/tests/test_framework_parser.py
+++ b/dsl_parser/tests/test_framework_parser.py
@@ -13,7 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import testtools
+import unittest
 
 from dsl_parser._compat import text_type
 from dsl_parser import exceptions
@@ -23,7 +23,7 @@ from dsl_parser.framework import (parser,
                                   requirements)
 
 
-class TestSchemaSchemaValidation(testtools.TestCase):
+class TestSchemaSchemaValidation(unittest.TestCase):
 
     def assert_invalid(self, element_cls):
         self.assertRaises(exceptions.DSLParsingSchemaAPIException,
@@ -119,7 +119,7 @@ class TestSchemaSchemaValidation(testtools.TestCase):
         self.assert_invalid(TestList)
 
 
-class TestSchemaValidation(testtools.TestCase):
+class TestSchemaValidation(unittest.TestCase):
 
     def assert_valid(self, value, element_cls, strict=True):
         self.assertEqual(parser.parse(value=value,

--- a/dsl_parser/tests/test_framework_parser.py
+++ b/dsl_parser/tests/test_framework_parser.py
@@ -129,12 +129,12 @@ class TestSchemaValidation(testtools.TestCase):
 
     def assert_invalid(self, value, element_cls, strict=True,
                        error_code=1):
-        exc = self.assertRaises(exceptions.DSLParsingException,
-                                parser.parse,
-                                value=value,
-                                element_cls=element_cls,
-                                strict=strict)
-        self.assertEqual(exc.err_code, error_code)
+        with self.assertRaises(exceptions.DSLParsingException) as cm:
+            parser.parse(
+                value=value,
+                element_cls=element_cls,
+                strict=strict)
+        self.assertEqual(cm.exception.err_code, error_code)
 
     def test_primitive_leaf_element_type_schema_validation(self):
         class TestStrLeaf(elements.Element):

--- a/dsl_parser/tests/test_functions.py
+++ b/dsl_parser/tests/test_functions.py
@@ -13,8 +13,6 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-from testtools import ExpectedException
-
 from dsl_parser import exceptions, functions
 from dsl_parser.tasks import prepare_deployment_plan
 from dsl_parser.tests.abstract_test_parser import AbstractTestParser
@@ -964,8 +962,8 @@ node_templates:
         properties:
             property: { concat: [1, 2] }
 """
-        with ExpectedException(exceptions.FunctionValidationError,
-                               '.*version 1_1 or greater.*'):
+        with self.assertRaisesRegex(
+                exceptions.FunctionValidationError, 'version 1_1 or greater'):
             prepare_deployment_plan(self.parse(
                 yaml,
                 dsl_version=self.BASIC_VERSION_SECTION_DSL_1_0))
@@ -982,7 +980,7 @@ node_templates:
         properties:
             property: { concat: 1 }
 """
-        with ExpectedException(ValueError, '.*Illegal.*concat.*'):
+        with self.assertRaisesRegex(ValueError, 'Illegal.*concat'):
             prepare_deployment_plan(self.parse_1_1(yaml))
 
     def test_node_template_properties_simple(self):
@@ -1231,8 +1229,8 @@ node_templates:
         properties:
             property: { merge: [{}, {}] }
 """
-        with ExpectedException(exceptions.FunctionValidationError,
-                               '.*version 1_3 or greater.*'):
+        with self.assertRaisesRegex(
+                exceptions.FunctionValidationError, 'version 1_3 or greater'):
             prepare_deployment_plan(self.parse(
                 yaml,
                 dsl_version=self.BASIC_VERSION_SECTION_DSL_1_0))
@@ -1249,7 +1247,7 @@ node_templates:
         properties:
             property: { merge: 1 }
 """
-        with ExpectedException(ValueError, '.*Illegal.*merge.*'):
+        with self.assertRaisesRegex(ValueError, 'Illegal.*merge'):
             prepare_deployment_plan(self.parse_1_3(yaml))
 
     def test_node_template_properties_simple(self):

--- a/dsl_parser/tests/test_get_attributes_dict.py
+++ b/dsl_parser/tests/test_get_attributes_dict.py
@@ -1,5 +1,3 @@
-import testtools.testcase
-
 from dsl_parser import exceptions
 from dsl_parser import functions
 from dsl_parser.tasks import prepare_deployment_plan
@@ -287,9 +285,7 @@ node_templates:
         ]
         storage = self.mock_evaluation_storage(node_instances, nodes)
         payload = {'a': {'get_attributes_dict': ['goodnode', 'sing', 'eat']}}
-        with testtools.testcase.ExpectedException(
-                KeyError,
-                '.*Node not found.*'):
+        with self.assertRaisesRegex(KeyError, 'Node not found'):
             functions.evaluate_functions(payload, {}, storage)
 
     def test_get_attributes_dict_relationship(self):
@@ -478,9 +474,8 @@ node_templates:
         payload = {'a': {'get_attributes_dict': ['goodnode',
                                                  ['sing', 'song'],
                                                  'sing.song']}}
-        with testtools.testcase.ExpectedException(
-                exceptions.FunctionEvaluationError,
-                '.*ambiguous.*'):
+        with self.assertRaisesRegex(
+                exceptions.FunctionEvaluationError, 'ambiguous'):
             functions.evaluate_functions(payload, {}, storage)
 
     def test_get_attributess_dict_nested_duplicate_requested(self):
@@ -510,7 +505,6 @@ node_templates:
         storage = self.mock_evaluation_storage(node_instances, nodes)
 
         payload = {'a': {'get_attributes_dict': ['goodnode', 'sing', 'sing']}}
-        with testtools.testcase.ExpectedException(
-                exceptions.FunctionEvaluationError,
-                '.*duplicated.*'):
+        with self.assertRaisesRegex(
+                exceptions.FunctionEvaluationError, 'duplicated'):
             functions.evaluate_functions(payload, {}, storage)

--- a/dsl_parser/tests/test_get_attributes_list.py
+++ b/dsl_parser/tests/test_get_attributes_list.py
@@ -1,5 +1,3 @@
-import testtools.testcase
-
 from dsl_parser import functions
 from dsl_parser.tasks import prepare_deployment_plan
 from dsl_parser.tests.abstract_test_parser import AbstractTestParser
@@ -229,9 +227,7 @@ node_templates:
         ]
         storage = self.mock_evaluation_storage(node_instances, nodes)
         payload = {'a': {'get_attributes_list': ['goodnode', 'sing']}}
-        with testtools.testcase.ExpectedException(
-                KeyError,
-                '.*Node not found.*'):
+        with self.assertRaisesRegex(KeyError, 'Node not found'):
             functions.evaluate_functions(payload, {}, storage)
 
     def test_get_attributes_list_node_instance_ids(self):

--- a/dsl_parser/tests/test_import_resolver.py
+++ b/dsl_parser/tests/test_import_resolver.py
@@ -13,7 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import testtools
+import unittest
 
 from dsl_parser import utils
 from dsl_parser.constants import RESOLVER_IMPLEMENTATION_KEY, \
@@ -67,7 +67,7 @@ failed_custom_resolver_class_path = "%s:%s" % (
     FailedToInitializeCustomImportResolver.__name__)
 
 
-class CreateImportResolverTests(testtools.TestCase):
+class CreateImportResolverTests(unittest.TestCase):
 
     def _test_create_import_resolver(self,
                                      resolver_configuration=None,

--- a/dsl_parser/tests/test_import_resolver.py
+++ b/dsl_parser/tests/test_import_resolver.py
@@ -212,3 +212,9 @@ class CreateImportResolverTests(unittest.TestCase):
             resolver_configuration=resolver_configuration,
             err_msg_regex=r'Failed to instantiate resolver '
                           r'\(wrong class path\).*Invalid class path')
+
+
+# 2.7 compat
+if not hasattr(CreateImportResolverTests, 'assertRaisesRegex'):
+    CreateImportResolverTests.assertRaisesRegex = \
+        CreateImportResolverTests.assertRaisesRegexp

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -194,19 +194,19 @@ node_templates:
             prepare_deployment_plan(
                 self.parse(yaml), inputs={'port': '8080'})
 
-        msg = str(e).split('-')[0]  # get first part of message
-        self.assertTrue('name_i' in msg)
-        self.assertTrue('name_j' in msg)
-        self.assertFalse('port' in msg)
+        msg = str(cm.exception).split('-')[0]  # get first part of message
+        self.assertIn('name_i', msg)
+        self.assertIn('name_j', msg)
+        self.assertNotIn('port', msg)
 
         with self.assertRaises(MissingRequiredInputError) as cm:
             prepare_deployment_plan(
                 self.parse(yaml), inputs={})
 
-        msg = str(e).split('-')[0]  # get first part of message
-        self.assertTrue('name_j' in msg)
-        self.assertTrue('name_i' in msg)
-        self.assertTrue('port' in msg)
+        msg = str(cm.exception).split('-')[0]  # get first part of message
+        self.assertIn('name_j', msg)
+        self.assertIn('name_i', msg)
+        self.assertIn('port', msg)
 
     def test_inputs_default_value(self):
         yaml = """
@@ -268,9 +268,9 @@ node_templates:
                 self.parse(yaml),
                 inputs={'unknown_input_1': 'a', 'unknown_input_2': 'b'})
 
-        msg = str(e)
-        self.assertTrue('unknown_input_1' in msg)
-        self.assertTrue('unknown_input_2' in msg)
+        msg = str(cm.exception)
+        self.assertIn('unknown_input_1', msg)
+        self.assertIn('unknown_input_2', msg)
 
     def test_get_input_in_nested_property(self):
         yaml = """

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -190,24 +190,18 @@ node_templates:
             name: { get_input: name_i }
             name2: { get_input: [name_j, attr1, 0] }
 """
-        e = self.assertRaises(
-            MissingRequiredInputError,
-            prepare_deployment_plan,
-            self.parse(yaml),
-            inputs={'port': '8080'}
-        )
+        with self.assertRaises(MissingRequiredInputError) as cm:
+            prepare_deployment_plan(
+                self.parse(yaml), inputs={'port': '8080'})
 
         msg = str(e).split('-')[0]  # get first part of message
         self.assertTrue('name_i' in msg)
         self.assertTrue('name_j' in msg)
         self.assertFalse('port' in msg)
 
-        e = self.assertRaises(
-            MissingRequiredInputError,
-            prepare_deployment_plan,
-            self.parse(yaml),
-            inputs={}
-        )
+        with self.assertRaises(MissingRequiredInputError) as cm:
+            prepare_deployment_plan(
+                self.parse(yaml), inputs={})
 
         msg = str(e).split('-')[0]  # get first part of message
         self.assertTrue('name_j' in msg)
@@ -269,12 +263,10 @@ node_templates:
             inputs={'unknown_input_1': 'a'}
         )
 
-        e = self.assertRaises(
-            UnknownInputError,
-            prepare_deployment_plan,
-            self.parse(yaml),
-            inputs={'unknown_input_1': 'a', 'unknown_input_2': 'b'}
-        )
+        with self.assertRaises(UnknownInputError) as cm:
+            prepare_deployment_plan(
+                self.parse(yaml),
+                inputs={'unknown_input_1': 'a', 'unknown_input_2': 'b'})
 
         msg = str(e)
         self.assertTrue('unknown_input_1' in msg)

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -1012,8 +1012,8 @@ plugins:
         self.assertEquals('test_plugin', plugin1['name'])
         self.assertEquals(1, len(compute['plugins_to_install']))
         self.assertEquals(1, len(othercompute['plugins_to_install']))
-        self.assertItemsEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
-                              [plugin1, plugin2])
+        self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
+                         [plugin1, plugin2])
         self.assertEquals(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
                           [])
         self.assertEquals(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -318,11 +318,10 @@ imports:
                                                     import_type):
         main_yaml = self._create_importable_yaml_for_version_1_3_and_above(
             importable)
-        ex = self.assertRaises(
-            exceptions.DSLParsingLogicException,
-            self.parse_1_2, main_yaml)
+        with self.assertRaises(exceptions.DSLParsingLogicException) as cm:
+            self.parse_1_2(main_yaml)
         self.assertIn("Import failed: non-mergeable field: '{0}'".format(
-            import_type), str(ex))
+            import_type), str(cm.exception))
 
     def _verify_1_3_and_above_mergeable_imports(self, importable):
         main_yaml = self._create_importable_yaml_for_version_1_3_and_above(

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -1012,8 +1012,10 @@ plugins:
         self.assertEqual('test_plugin', plugin1['name'])
         self.assertEqual(1, len(compute['plugins_to_install']))
         self.assertEqual(1, len(othercompute['plugins_to_install']))
-        self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
-                         [plugin1, plugin2])
+        self.assertEqual(
+            2, len(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL]))
+        self.assertIn(plugin1, result[constants.HOST_AGENT_PLUGINS_TO_INSTALL])
+        self.assertIn(plugin2, result[constants.HOST_AGENT_PLUGINS_TO_INSTALL])
         self.assertEqual(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
                          [])
         self.assertEqual(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -69,33 +69,33 @@ def workflow_op_struct(plugin_name,
 class BaseParserApiTest(AbstractTestParser):
     def _assert_blueprint(self, result):
         node = result['nodes'][0]
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_type', node['type'])
         plugin_props = [p for p in node['plugins']
                         if p['name'] == 'test_plugin'][0]
-        self.assertEquals(11, len(plugin_props))
-        self.assertEquals('test_plugin',
+        self.assertEqual(11, len(plugin_props))
+        self.assertEqual('test_plugin',
                           plugin_props[constants.PLUGIN_NAME_KEY])
         operations = node['operations']
-        self.assertEquals(op_struct('test_plugin', 'install',
+        self.assertEqual(op_struct('test_plugin', 'install',
                                     executor='central_deployment_agent'),
                           operations['install'])
-        self.assertEquals(op_struct('test_plugin', 'install',
+        self.assertEqual(op_struct('test_plugin', 'install',
                                     executor='central_deployment_agent'),
                           operations['test_interface1.install'])
-        self.assertEquals(op_struct('test_plugin', 'terminate',
+        self.assertEqual(op_struct('test_plugin', 'terminate',
                                     executor='central_deployment_agent'),
                           operations['terminate'])
-        self.assertEquals(op_struct('test_plugin', 'terminate',
+        self.assertEqual(op_struct('test_plugin', 'terminate',
                                     executor='central_deployment_agent'),
                           operations['test_interface1.terminate'])
 
     def _assert_minimal_blueprint(self, result, expected_type='test_type'):
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_node', node['name'])
-        self.assertEquals(expected_type, node['type'])
-        self.assertEquals('val', node['properties']['key'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_node', node['name'])
+        self.assertEqual(expected_type, node['type'])
+        self.assertEqual('val', node['properties']['key'])
 
 
 class TestParserApi(BaseParserApiTest):
@@ -162,7 +162,7 @@ node_types:
             constants.PLUGIN_DISTRIBUTION_VERSION: None,
             constants.PLUGIN_DISTRIBUTION_RELEASE: None
         }]
-        self.assertEquals(parsed_plugins, expected_plugins)
+        self.assertEqual(parsed_plugins, expected_plugins)
 
     def test_type_with_interface_and_plugin_with_install_args(self):
         yaml = self.PLUGIN_WITH_INTERFACES_AND_PLUGINS_WITH_INSTALL_ARGS
@@ -184,7 +184,7 @@ node_types:
             constants.PLUGIN_DISTRIBUTION_VERSION: None,
             constants.PLUGIN_DISTRIBUTION_RELEASE: None
         }]
-        self.assertEquals(parsed_plugins, expected_plugins)
+        self.assertEqual(parsed_plugins, expected_plugins)
 
     def test_dsl_with_type_with_operation_mappings(self):
         yaml = self.create_yaml_with_imports(
@@ -219,16 +219,16 @@ plugins:
         self._assert_blueprint(result)
 
         operations = node['operations']
-        self.assertEquals(op_struct('other_test_plugin', 'start',
+        self.assertEqual(op_struct('other_test_plugin', 'start',
                                     executor='central_deployment_agent'),
                           operations['start'])
-        self.assertEquals(op_struct('other_test_plugin', 'start',
+        self.assertEqual(op_struct('other_test_plugin', 'start',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.start'])
-        self.assertEquals(op_struct('other_test_plugin', 'shutdown',
+        self.assertEqual(op_struct('other_test_plugin', 'shutdown',
                                     executor='central_deployment_agent'),
                           operations['shutdown'])
-        self.assertEquals(op_struct('other_test_plugin', 'shutdown',
+        self.assertEqual(op_struct('other_test_plugin', 'shutdown',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.shutdown'])
 
@@ -269,14 +269,14 @@ description: sample description
         result = self.parse(yaml)
         self._assert_minimal_blueprint(result)
         self.assertIn('description', result)
-        self.assertEquals('sample description', result['description'])
+        self.assertEqual('sample description', result['description'])
 
     def test_blueprint_description_field_omitted(self):
         yaml = self.MINIMAL_BLUEPRINT + self.BASIC_VERSION_SECTION_DSL_1_2
         result = self.parse(yaml)
         self._assert_minimal_blueprint(result)
         self.assertIn('description', result)
-        self.assertEquals(None, result['description'])
+        self.assertEqual(None, result['description'])
 
     def test_diamond_imports(self):
         bottom_level_yaml = self.BASIC_TYPE
@@ -375,7 +375,7 @@ node_types:
         # this will also check property "key" = "val"
         self._assert_minimal_blueprint(result)
         node = result['nodes'][0]
-        self.assertEquals('val2', node['properties']['key2'])
+        self.assertEqual('val2', node['properties']['key2'])
 
     def test_type_properties_empty_properties(self):
         yaml = """
@@ -387,11 +387,11 @@ node_types:
         properties: {}
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_node', node['name'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_node', node['name'])
+        self.assertEqual('test_type', node['type'])
 
     def test_type_properties_empty_property(self):
         yaml = self.BASIC_NODE_TEMPLATES_SECTION + """
@@ -401,12 +401,12 @@ node_types:
             key: {}
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_node', node['name'])
-        self.assertEquals('test_type', node['type'])
-        self.assertEquals('val', node['properties']['key'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_node', node['name'])
+        self.assertEqual('test_type', node['type'])
+        self.assertEqual('val', node['properties']['key'])
         # TODO: assert node-type's default and description values once
         # 'node_types' is part of the parser's output
 
@@ -419,12 +419,12 @@ node_types:
                 description: property_desc
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_node', node['name'])
-        self.assertEquals('test_type', node['type'])
-        self.assertEquals('val', node['properties']['key'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_node', node['name'])
+        self.assertEqual('test_type', node['type'])
+        self.assertEqual('val', node['properties']['key'])
         # TODO: assert type's default and description values once 'type' is
         # part of the parser's output
 
@@ -439,12 +439,12 @@ node_types:
                 type: string
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_node', node['name'])
-        self.assertEquals('test_type', node['type'])
-        self.assertEquals('val', node['properties']['key'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_node', node['name'])
+        self.assertEqual('test_type', node['type'])
+        self.assertEqual('val', node['properties']['key'])
         # TODO: assert type's default and description values once 'type' is
         # part of the parser's output
 
@@ -472,8 +472,8 @@ node_types:
         # this will also check property "key" = "val"
         self._assert_minimal_blueprint(result)
         node = result['nodes'][0]
-        self.assertEquals('val2', node['properties']['key2'])
-        self.assertEquals('val3_parent', node['properties']['key3'])
+        self.assertEqual('val2', node['properties']['key2'])
+        self.assertEqual('val3_parent', node['properties']['key3'])
 
     def test_empty_types_hierarchy_in_node(self):
         yaml = self.BASIC_NODE_TEMPLATES_SECTION + """
@@ -567,9 +567,9 @@ node_types:
         # this will also check property "key" = "val"
         self._assert_minimal_blueprint(result)
         node = result['nodes'][0]
-        self.assertEquals('val2', node['properties']['key2'])
-        self.assertEquals('val3_grandparent', node['properties']['key3'])
-        self.assertEquals('val4_parent', node['properties']['key4'])
+        self.assertEqual('val2', node['properties']['key2'])
+        self.assertEqual('val3_grandparent', node['properties']['key3'])
+        self.assertEqual('val4_parent', node['properties']['key4'])
 
     def test_type_interface_derivation(self):
         yaml = self.create_yaml_with_imports(
@@ -639,32 +639,32 @@ plugins:
         self._assert_blueprint(result)
         node = result['nodes'][0]
         operations = node['operations']
-        self.assertEquals(12, len(operations))
-        self.assertEquals(op_struct('test_plugin2', 'start',
+        self.assertEqual(12, len(operations))
+        self.assertEqual(op_struct('test_plugin2', 'start',
                                     executor='central_deployment_agent'),
                           operations['start'])
-        self.assertEquals(op_struct('test_plugin2', 'start',
+        self.assertEqual(op_struct('test_plugin2', 'start',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.start'])
-        self.assertEquals(op_struct('test_plugin2', 'stop',
+        self.assertEqual(op_struct('test_plugin2', 'stop',
                                     executor='central_deployment_agent'),
                           operations['stop'])
-        self.assertEquals(op_struct('test_plugin2', 'stop',
+        self.assertEqual(op_struct('test_plugin2', 'stop',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.stop'])
-        self.assertEquals(op_struct('test_plugin3', 'op',
+        self.assertEqual(op_struct('test_plugin3', 'op',
                                     executor='central_deployment_agent'),
                           operations['op1'])
-        self.assertEquals(op_struct('test_plugin3', 'op',
+        self.assertEqual(op_struct('test_plugin3', 'op',
                                     executor='central_deployment_agent'),
                           operations['test_interface3.op1'])
-        self.assertEquals(op_struct('test_plugin4', 'op2',
+        self.assertEqual(op_struct('test_plugin4', 'op2',
                                     executor='central_deployment_agent'),
                           operations['op2'])
-        self.assertEquals(op_struct('test_plugin4', 'op2',
+        self.assertEqual(op_struct('test_plugin4', 'op2',
                                     executor='central_deployment_agent'),
                           operations['test_interface4.op2'])
-        self.assertEquals(4, len(node['plugins']))
+        self.assertEqual(4, len(node['plugins']))
 
     def test_type_interface_recursive_derivation(self):
         yaml = self.create_yaml_with_imports(
@@ -712,20 +712,20 @@ plugins:
         self._assert_blueprint(result)
         node = result['nodes'][0]
         operations = node['operations']
-        self.assertEquals(8, len(operations))
-        self.assertEquals(op_struct('test_plugin2', 'start',
+        self.assertEqual(8, len(operations))
+        self.assertEqual(op_struct('test_plugin2', 'start',
                                     executor='central_deployment_agent'),
                           operations['start'])
-        self.assertEquals(op_struct('test_plugin2', 'start',
+        self.assertEqual(op_struct('test_plugin2', 'start',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.start'])
-        self.assertEquals(op_struct('test_plugin2', 'stop',
+        self.assertEqual(op_struct('test_plugin2', 'stop',
                                     executor='central_deployment_agent'),
                           operations['stop'])
-        self.assertEquals(op_struct('test_plugin2', 'stop',
+        self.assertEqual(op_struct('test_plugin2', 'stop',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.stop'])
-        self.assertEquals(2, len(node['plugins']))
+        self.assertEqual(2, len(node['plugins']))
 
     def test_two_explicit_interfaces_with_same_operation_name(self):
         yaml = self.create_yaml_with_imports(
@@ -756,27 +756,27 @@ plugins:
 """
         result = self.parse(yaml)
         node = result['nodes'][0]
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_type', node['type'])
         operations = node['operations']
-        self.assertEquals(op_struct('test_plugin', 'install',
+        self.assertEqual(op_struct('test_plugin', 'install',
                                     executor='central_deployment_agent'),
                           operations['test_interface1.install'])
-        self.assertEquals(op_struct('test_plugin', 'terminate',
+        self.assertEqual(op_struct('test_plugin', 'terminate',
                                     executor='central_deployment_agent'),
                           operations['terminate'])
-        self.assertEquals(op_struct('test_plugin', 'terminate',
+        self.assertEqual(op_struct('test_plugin', 'terminate',
                                     executor='central_deployment_agent'),
                           operations['test_interface1.terminate'])
-        self.assertEquals(op_struct('other_test_plugin', 'install',
+        self.assertEqual(op_struct('other_test_plugin', 'install',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.install'])
-        self.assertEquals(op_struct('other_test_plugin', 'shutdown',
+        self.assertEqual(op_struct('other_test_plugin', 'shutdown',
                                     executor='central_deployment_agent'),
                           operations['shutdown'])
-        self.assertEquals(op_struct('other_test_plugin', 'shutdown',
+        self.assertEqual(op_struct('other_test_plugin', 'shutdown',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.shutdown'])
-        self.assertEquals(6, len(operations))
+        self.assertEqual(6, len(operations))
 
     def test_relative_path_import(self):
         bottom_level_yaml = self.BASIC_TYPE
@@ -859,7 +859,7 @@ node_types:
             key: {}
             """
         result = self.parse(yaml)
-        self.assertEquals('test_node', result['nodes'][0]['host_id'])
+        self.assertEqual('test_node', result['nodes'][0]['host_id'])
 
     def test_node_host_id_field_via_relationship(self):
         yaml = """
@@ -884,8 +884,8 @@ relationships:
     cloudify.relationships.contained_in: {}
             """
         result = self.parse(yaml)
-        self.assertEquals('test_node1', result['nodes'][1]['host_id'])
-        self.assertEquals('test_node1', result['nodes'][2]['host_id'])
+        self.assertEqual('test_node1', result['nodes'][1]['host_id'])
+        self.assertEqual('test_node1', result['nodes'][2]['host_id'])
 
     def test_node_host_id_field_via_node_supertype(self):
         yaml = """
@@ -898,7 +898,7 @@ node_types:
         derived_from: cloudify.nodes.Compute
             """
         result = self.parse(yaml)
-        self.assertEquals('test_node1', result['nodes'][0]['host_id'])
+        self.assertEqual('test_node1', result['nodes'][0]['host_id'])
 
     def test_node_host_id_field_via_relationship_derived_from_inheritance(
             self):
@@ -920,7 +920,7 @@ relationships:
         derived_from: cloudify.relationships.contained_in
             """
         result = self.parse(yaml)
-        self.assertEquals('test_node1', result['nodes'][1]['host_id'])
+        self.assertEqual('test_node1', result['nodes'][1]['host_id'])
 
     def test_node_type_operation_override(self):
         yaml = """
@@ -1009,14 +1009,14 @@ plugins:
             othercompute, compute = result['nodes']
         plugin1 = compute['plugins_to_install'][0]
         plugin2 = othercompute['plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin1['name'])
-        self.assertEquals(1, len(compute['plugins_to_install']))
-        self.assertEquals(1, len(othercompute['plugins_to_install']))
+        self.assertEqual('test_plugin', plugin1['name'])
+        self.assertEqual(1, len(compute['plugins_to_install']))
+        self.assertEqual(1, len(othercompute['plugins_to_install']))
         self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
                          [plugin1, plugin2])
-        self.assertEquals(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
+        self.assertEqual(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
                           [])
-        self.assertEquals(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],
+        self.assertEqual(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],
                           [])
 
     def test_deployment_plugins_to_install_in_plan(self):
@@ -1039,12 +1039,12 @@ plugins:
 """
         result = self.parse(yaml)
         plugin = result['nodes'][0]['deployment_plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin['name'])
-        self.assertEquals(1, len(result['nodes'][0][
+        self.assertEqual('test_plugin', plugin['name'])
+        self.assertEqual(1, len(result['nodes'][0][
                                      'deployment_plugins_to_install']))
-        self.assertEquals(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
+        self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
                           [])
-        self.assertEquals(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],
+        self.assertEqual(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],
                           [])
 
     def test_workflow_plugins_to_install_in_plan(self):
@@ -1056,9 +1056,9 @@ workflows:
         workflow_plugins_to_install = result['workflow_plugins_to_install']
         self.assertEqual(1, len(workflow_plugins_to_install))
         self.assertEqual('test_plugin', workflow_plugins_to_install[0]['name'])
-        self.assertEquals(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
+        self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
                           [])
-        self.assertEquals(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
+        self.assertEqual(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
                           [])
 
     def test_executor_override_node_types(self):
@@ -1090,8 +1090,8 @@ plugins:
 """
         result = self.parse(yaml)
         plugin = result['nodes'][0]['plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin['name'])
-        self.assertEquals(1, len(result['nodes'][0]['plugins_to_install']))
+        self.assertEqual('test_plugin', plugin['name'])
+        self.assertEqual(1, len(result['nodes'][0]['plugins_to_install']))
 
     def test_executor_override_plugin_declaration(self):
         yaml = """
@@ -1114,8 +1114,8 @@ plugins:
 """
         result = self.parse(yaml)
         plugin = result['nodes'][0]['deployment_plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin['name'])
-        self.assertEquals(1, len(result['nodes'][0][
+        self.assertEqual('test_plugin', plugin['name'])
+        self.assertEqual(1, len(result['nodes'][0][
             'deployment_plugins_to_install']))
 
     def test_executor_override_type_declaration(self):
@@ -1145,8 +1145,8 @@ plugins:
 """
         result = self.parse(yaml)
         plugin = result['nodes'][0]['plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin['name'])
-        self.assertEquals(1, len(result['nodes'][0][
+        self.assertEqual('test_plugin', plugin['name'])
+        self.assertEqual(1, len(result['nodes'][0][
             'plugins_to_install']))
 
     def test_import_resources(self):
@@ -1216,11 +1216,11 @@ node_types:
             key: {}
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         self.assertFalse('host_id' in nodes[0])
-        self.assertEquals('test_node2', nodes[1]['host_id'])
+        self.assertEqual('test_node2', nodes[1]['host_id'])
 
     def test_multiple_instances(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -1228,12 +1228,12 @@ node_types:
             deploy: 2
             """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
-        self.assertEquals('val', node['properties']['key'])
-        self.assertEquals(2, node['instances']['deploy'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
+        self.assertEqual('val', node['properties']['key'])
+        self.assertEqual(2, node['instances']['deploy'])
 
     def test_import_types_combination(self):
         yaml = self.create_yaml_with_imports([self.MINIMAL_BLUEPRINT + """
@@ -1245,18 +1245,18 @@ node_types:
         """
 
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         node1 = nodes[0]
         node2 = nodes[1]
-        self.assertEquals('test_node', node1['id'])
-        self.assertEquals('test_type', node1['type'])
-        self.assertEquals('val', node1['properties']['key'])
-        # self.assertEquals(1, node1['instances']['deploy'])
-        self.assertEquals('test_node2', node2['id'])
-        self.assertEquals('test_type2', node2['type'])
-        # self.assertEquals(1, node2['instances']['deploy'])
+        self.assertEqual('test_node', node1['id'])
+        self.assertEqual('test_type', node1['type'])
+        self.assertEqual('val', node1['properties']['key'])
+        # self.assertEqual(1, node1['instances']['deploy'])
+        self.assertEqual('test_node2', node2['id'])
+        self.assertEqual('test_type2', node2['type'])
+        # self.assertEqual(1, node2['instances']['deploy'])
 
     def test_relationship_operation_mapping_with_properties_injection(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -1279,7 +1279,7 @@ plugins:
         source: dummy
 """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         relationship1 = nodes[1]['relationships'][0]
@@ -1295,7 +1295,7 @@ plugins:
 
     def test_no_workflows(self):
         result = self.parse(self.MINIMAL_BLUEPRINT)
-        self.assertEquals(result['workflows'], {})
+        self.assertEqual(result['workflows'], {})
 
     def test_empty_workflows(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -1397,12 +1397,12 @@ workflows:
         parameters: {}
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         workflow = result['workflows']['test_workflow']
-        self.assertEquals({}, workflow['parameters'])
+        self.assertEqual({}, workflow['parameters'])
 
     def test_workflow_parameters_empty_parameter(self):
         yaml = self.BLUEPRINT_WITH_INTERFACES_AND_PLUGINS + """
@@ -1413,12 +1413,12 @@ workflows:
             key: {}
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         workflow = result['workflows']['test_workflow']
-        self.assertEquals({'key': {}}, workflow['parameters'])
+        self.assertEqual({'key': {}}, workflow['parameters'])
 
     def test_workflow_parameters_parameter_with_description_only(self):
         yaml = self.BLUEPRINT_WITH_INTERFACES_AND_PLUGINS + """
@@ -1430,12 +1430,12 @@ workflows:
                 description: parameter_desc
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         workflow = result['workflows']['test_workflow']
-        self.assertEquals({'key': {'description': 'parameter_desc'}},
+        self.assertEqual({'key': {'description': 'parameter_desc'}},
                           workflow['parameters'])
 
     def test_workflow_parameters_standard_parameter(self):
@@ -1450,12 +1450,12 @@ workflows:
                 type: string
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         workflow = result['workflows']['test_workflow']
-        self.assertEquals(
+        self.assertEqual(
             {'key': {'default': 'val', 'description': 'parameter_desc',
                      'type': 'string'}},
             workflow['parameters'])
@@ -1667,13 +1667,13 @@ node_types:
 """
         result = self.parse(yaml)
         node = result['nodes'][0]
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_type', node['type'])
         operations = node['operations']
-        self.assertEquals(
+        self.assertEqual(
             op_struct('test_plugin', 'install', {'key': 'value'},
                       executor='central_deployment_agent'),
             operations['install'])
-        self.assertEquals(
+        self.assertEqual(
             op_struct('test_plugin', 'install', {'key': 'value'},
                       executor='central_deployment_agent'),
             operations['test_interface1.install'])
@@ -1710,16 +1710,16 @@ node_types:
         self._assert_blueprint(result)
 
         operations = node['operations']
-        self.assertEquals(op_struct('other_test_plugin', 'start',
+        self.assertEqual(op_struct('other_test_plugin', 'start',
                                     executor='central_deployment_agent'),
                           operations['start'])
-        self.assertEquals(op_struct('other_test_plugin', 'start',
+        self.assertEqual(op_struct('other_test_plugin', 'start',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.start'])
-        self.assertEquals(op_struct('other_test_plugin', 'shutdown',
+        self.assertEqual(op_struct('other_test_plugin', 'shutdown',
                                     executor='central_deployment_agent'),
                           operations['shutdown'])
-        self.assertEquals(op_struct('other_test_plugin', 'shutdown',
+        self.assertEqual(op_struct('other_test_plugin', 'shutdown',
                                     executor='central_deployment_agent'),
                           operations['test_interface2.shutdown'])
 
@@ -1753,9 +1753,9 @@ inputs:
     x: {}
         """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
+        self.assertEqual('test_node', node['id'])
 
     def test_property_schema_type_property(self):
         yaml = """
@@ -1848,9 +1848,9 @@ node_types:
                 type: regex
             """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
+        self.assertEqual('test_node', node['id'])
         self.assertEqual(node['properties'], {
             'boolean4': False,
             'boolean5': True,

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -74,20 +74,20 @@ class BaseParserApiTest(AbstractTestParser):
                         if p['name'] == 'test_plugin'][0]
         self.assertEqual(11, len(plugin_props))
         self.assertEqual('test_plugin',
-                          plugin_props[constants.PLUGIN_NAME_KEY])
+                         plugin_props[constants.PLUGIN_NAME_KEY])
         operations = node['operations']
         self.assertEqual(op_struct('test_plugin', 'install',
-                                    executor='central_deployment_agent'),
-                          operations['install'])
+                                   executor='central_deployment_agent'),
+                         operations['install'])
         self.assertEqual(op_struct('test_plugin', 'install',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface1.install'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface1.install'])
         self.assertEqual(op_struct('test_plugin', 'terminate',
-                                    executor='central_deployment_agent'),
-                          operations['terminate'])
+                                   executor='central_deployment_agent'),
+                         operations['terminate'])
         self.assertEqual(op_struct('test_plugin', 'terminate',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface1.terminate'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface1.terminate'])
 
     def _assert_minimal_blueprint(self, result, expected_type='test_type'):
         self.assertEqual(1, len(result['nodes']))
@@ -220,17 +220,17 @@ plugins:
 
         operations = node['operations']
         self.assertEqual(op_struct('other_test_plugin', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['start'])
+                                   executor='central_deployment_agent'),
+                         operations['start'])
         self.assertEqual(op_struct('other_test_plugin', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.start'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.start'])
         self.assertEqual(op_struct('other_test_plugin', 'shutdown',
-                                    executor='central_deployment_agent'),
-                          operations['shutdown'])
+                                   executor='central_deployment_agent'),
+                         operations['shutdown'])
         self.assertEqual(op_struct('other_test_plugin', 'shutdown',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.shutdown'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.shutdown'])
 
     def test_recursive_imports(self):
         bottom_level_yaml = self.BASIC_TYPE
@@ -641,29 +641,29 @@ plugins:
         operations = node['operations']
         self.assertEqual(12, len(operations))
         self.assertEqual(op_struct('test_plugin2', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['start'])
+                                   executor='central_deployment_agent'),
+                         operations['start'])
         self.assertEqual(op_struct('test_plugin2', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.start'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.start'])
         self.assertEqual(op_struct('test_plugin2', 'stop',
-                                    executor='central_deployment_agent'),
-                          operations['stop'])
+                                   executor='central_deployment_agent'),
+                         operations['stop'])
         self.assertEqual(op_struct('test_plugin2', 'stop',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.stop'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.stop'])
         self.assertEqual(op_struct('test_plugin3', 'op',
-                                    executor='central_deployment_agent'),
-                          operations['op1'])
+                                   executor='central_deployment_agent'),
+                         operations['op1'])
         self.assertEqual(op_struct('test_plugin3', 'op',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface3.op1'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface3.op1'])
         self.assertEqual(op_struct('test_plugin4', 'op2',
-                                    executor='central_deployment_agent'),
-                          operations['op2'])
+                                   executor='central_deployment_agent'),
+                         operations['op2'])
         self.assertEqual(op_struct('test_plugin4', 'op2',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface4.op2'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface4.op2'])
         self.assertEqual(4, len(node['plugins']))
 
     def test_type_interface_recursive_derivation(self):
@@ -714,17 +714,17 @@ plugins:
         operations = node['operations']
         self.assertEqual(8, len(operations))
         self.assertEqual(op_struct('test_plugin2', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['start'])
+                                   executor='central_deployment_agent'),
+                         operations['start'])
         self.assertEqual(op_struct('test_plugin2', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.start'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.start'])
         self.assertEqual(op_struct('test_plugin2', 'stop',
-                                    executor='central_deployment_agent'),
-                          operations['stop'])
+                                   executor='central_deployment_agent'),
+                         operations['stop'])
         self.assertEqual(op_struct('test_plugin2', 'stop',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.stop'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.stop'])
         self.assertEqual(2, len(node['plugins']))
 
     def test_two_explicit_interfaces_with_same_operation_name(self):
@@ -759,23 +759,23 @@ plugins:
         self.assertEqual('test_type', node['type'])
         operations = node['operations']
         self.assertEqual(op_struct('test_plugin', 'install',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface1.install'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface1.install'])
         self.assertEqual(op_struct('test_plugin', 'terminate',
-                                    executor='central_deployment_agent'),
-                          operations['terminate'])
+                                   executor='central_deployment_agent'),
+                         operations['terminate'])
         self.assertEqual(op_struct('test_plugin', 'terminate',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface1.terminate'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface1.terminate'])
         self.assertEqual(op_struct('other_test_plugin', 'install',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.install'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.install'])
         self.assertEqual(op_struct('other_test_plugin', 'shutdown',
-                                    executor='central_deployment_agent'),
-                          operations['shutdown'])
+                                   executor='central_deployment_agent'),
+                         operations['shutdown'])
         self.assertEqual(op_struct('other_test_plugin', 'shutdown',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.shutdown'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.shutdown'])
         self.assertEqual(6, len(operations))
 
     def test_relative_path_import(self):
@@ -1015,9 +1015,9 @@ plugins:
         self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
                          [plugin1, plugin2])
         self.assertEqual(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
-                          [])
+                         [])
         self.assertEqual(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],
-                          [])
+                         [])
 
     def test_deployment_plugins_to_install_in_plan(self):
         yaml = """
@@ -1043,9 +1043,9 @@ plugins:
         self.assertEqual(1, len(result['nodes'][0][
                                      'deployment_plugins_to_install']))
         self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
-                          [])
+                         [])
         self.assertEqual(result[constants.WORKFLOW_PLUGINS_TO_INSTALL],
-                          [])
+                         [])
 
     def test_workflow_plugins_to_install_in_plan(self):
         yaml = self.BASIC_PLUGIN + """
@@ -1057,9 +1057,9 @@ workflows:
         self.assertEqual(1, len(workflow_plugins_to_install))
         self.assertEqual('test_plugin', workflow_plugins_to_install[0]['name'])
         self.assertEqual(result[constants.HOST_AGENT_PLUGINS_TO_INSTALL],
-                          [])
+                         [])
         self.assertEqual(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL],
-                          [])
+                         [])
 
     def test_executor_override_node_types(self):
         yaml = """
@@ -1436,7 +1436,7 @@ workflows:
         self.assertEqual('test_type', node['type'])
         workflow = result['workflows']['test_workflow']
         self.assertEqual({'key': {'description': 'parameter_desc'}},
-                          workflow['parameters'])
+                         workflow['parameters'])
 
     def test_workflow_parameters_standard_parameter(self):
         yaml = self.BLUEPRINT_WITH_INTERFACES_AND_PLUGINS + """
@@ -1711,17 +1711,17 @@ node_types:
 
         operations = node['operations']
         self.assertEqual(op_struct('other_test_plugin', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['start'])
+                                   executor='central_deployment_agent'),
+                         operations['start'])
         self.assertEqual(op_struct('other_test_plugin', 'start',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.start'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.start'])
         self.assertEqual(op_struct('other_test_plugin', 'shutdown',
-                                    executor='central_deployment_agent'),
-                          operations['shutdown'])
+                                   executor='central_deployment_agent'),
+                         operations['shutdown'])
         self.assertEqual(op_struct('other_test_plugin', 'shutdown',
-                                    executor='central_deployment_agent'),
-                          operations['test_interface2.shutdown'])
+                                   executor='central_deployment_agent'),
+                         operations['test_interface2.shutdown'])
 
     def test_node_interfaces_operation_mapping(self):
         yaml = self.BASIC_PLUGIN + self.BASIC_NODE_TEMPLATES_SECTION + """

--- a/dsl_parser/tests/test_parser_logic_exceptions.py
+++ b/dsl_parser/tests/test_parser_logic_exceptions.py
@@ -290,7 +290,7 @@ node_types:
             yaml,
             ERROR_UNDEFINED_PROPERTY,
             DSLParsingLogicException)
-        self.assertEquals('key', ex.property)
+        self.assertEqual('key', ex.property)
 
     def test_node_doesnt_implement_schema_mandatory_property(self):
         yaml = self.BASIC_NODE_TEMPLATES_SECTION + self.BASIC_PLUGIN + """
@@ -302,7 +302,7 @@ node_types:
 """
         ex = self._assert_dsl_parsing_exception_error_code(
             yaml, ERROR_MISSING_PROPERTY, DSLParsingLogicException)
-        self.assertEquals('mandatory', ex.property)
+        self.assertEqual('mandatory', ex.property)
 
     def test_relationship_instance_set_non_existing_property(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -320,7 +320,7 @@ relationships:
 """
         ex = self._assert_dsl_parsing_exception_error_code(
             yaml, ERROR_UNDEFINED_PROPERTY, DSLParsingLogicException)
-        self.assertEquals('do_not_exist', ex.property)
+        self.assertEqual('do_not_exist', ex.property)
 
     def test_relationship_instance_doesnt_implement_schema_mandatory_property(self):  # NOQA
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -338,7 +338,7 @@ relationships:
 """
         ex = self._assert_dsl_parsing_exception_error_code(
             yaml, ERROR_MISSING_PROPERTY, DSLParsingLogicException)
-        self.assertEquals('should_implement', ex.property)
+        self.assertEqual('should_implement', ex.property)
 
     def test_instance_relationship_more_than_one_contained_in(self):
         yaml = self.MINIMAL_BLUEPRINT + """

--- a/dsl_parser/tests/test_plugins_to_install.py
+++ b/dsl_parser/tests/test_plugins_to_install.py
@@ -61,8 +61,8 @@ relationships:
         result = self.parse(yaml)
         node = [n for n in result['nodes'] if n['name'] == 'test_node1'][0]
         plugin = node['plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin['name'])
-        self.assertEquals(1, len(node['plugins_to_install']))
+        self.assertEqual('test_plugin', plugin['name'])
+        self.assertEqual(1, len(node['plugins_to_install']))
 
     def test_node_plugins_to_install_field_from_relationship(self):  # NOQA
         yaml = """
@@ -94,8 +94,8 @@ relationships:
         result = self.parse(yaml)
         node = [n for n in result['nodes'] if n['name'] == 'test_node1'][0]
         plugin = node['plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin['name'])
-        self.assertEquals(1, len(node['plugins_to_install']))
+        self.assertEqual('test_plugin', plugin['name'])
+        self.assertEqual(1, len(node['plugins_to_install']))
 
     def test_node_plugins_to_install_field(self):
         yaml = """
@@ -116,8 +116,8 @@ plugins:
 """
         result = self.parse(yaml)
         plugin = result['nodes'][0]['plugins_to_install'][0]
-        self.assertEquals('test_plugin', plugin['name'])
-        self.assertEquals(1, len(result['nodes'][0]['plugins_to_install']))
+        self.assertEqual('test_plugin', plugin['name'])
+        self.assertEqual(1, len(result['nodes'][0]['plugins_to_install']))
 
     def test_node_plugins_to_install_field_plugins_from_contained_nodes(self):
         # testing to ensure plugins from nodes with contained_in relationships
@@ -172,7 +172,7 @@ plugins:
 """
         result = self.parse(yaml)
 
-        self.assertEquals(4, len(result['nodes']))
+        self.assertEqual(4, len(result['nodes']))
         nodes = self._sort_result_nodes(
             result['nodes'],
             ['test_node1', 'test_node2', 'test_node3', 'test_node4'])
@@ -185,9 +185,9 @@ plugins:
             node, 'test_plugin')
         test_plugin2 = self._get_plugin_to_install_from_node(
             node, 'test_plugin2')
-        self.assertEquals('test_plugin', test_plugin['name'])
-        self.assertEquals('test_plugin2', test_plugin2['name'])
-        self.assertEquals(2, len(nodes[0]['plugins_to_install']))
+        self.assertEqual('test_plugin', test_plugin['name'])
+        self.assertEqual('test_plugin2', test_plugin2['name'])
+        self.assertEqual(2, len(nodes[0]['plugins_to_install']))
 
     def test_instance_relationships_target_node_plugins(self):
         # tests that plugins defined on instance relationships as
@@ -218,15 +218,15 @@ plugins:
         source: dummy
 """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
-        self.assertEquals('test_node2', nodes[1]['id'])
-        self.assertEquals(2, len(nodes[1]['relationships']))
+        self.assertEqual('test_node2', nodes[1]['id'])
+        self.assertEqual(2, len(nodes[1]['relationships']))
 
         relationship1 = nodes[1]['relationships'][0]
-        self.assertEquals('test_relationship', relationship1['type'])
-        self.assertEquals('test_node', relationship1['target_id'])
+        self.assertEqual('test_relationship', relationship1['type'])
+        self.assertEqual('test_node', relationship1['target_id'])
         rel1_source_ops = relationship1['source_operations']
         self.assertEqual(op_struct('test_plugin1', 'install',
                                    executor='central_deployment_agent'),
@@ -234,14 +234,14 @@ plugins:
         self.assertEqual(op_struct('test_plugin1', 'install',
                                    executor='central_deployment_agent'),
                          rel1_source_ops['test_interface1.install'])
-        self.assertEquals(2, len(rel1_source_ops))
-        self.assertEquals(8, len(relationship1))
+        self.assertEqual(2, len(rel1_source_ops))
+        self.assertEqual(8, len(relationship1))
         plugin1_def = nodes[1]['plugins'][0]
-        self.assertEquals('test_plugin1', plugin1_def['name'])
+        self.assertEqual('test_plugin1', plugin1_def['name'])
 
         relationship2 = nodes[1]['relationships'][1]
-        self.assertEquals('test_relationship', relationship2['type'])
-        self.assertEquals('test_node', relationship2['target_id'])
+        self.assertEqual('test_relationship', relationship2['type'])
+        self.assertEqual('test_node', relationship2['target_id'])
         rel2_source_ops = relationship2['target_operations']
         self.assertEqual(op_struct('test_plugin2', 'install',
                                    executor='central_deployment_agent'),
@@ -249,13 +249,13 @@ plugins:
         self.assertEqual(op_struct('test_plugin2', 'install',
                                    executor='central_deployment_agent'),
                          rel2_source_ops['test_interface1.install'])
-        self.assertEquals(2, len(rel2_source_ops))
-        self.assertEquals(8, len(relationship2))
+        self.assertEqual(2, len(rel2_source_ops))
+        self.assertEqual(8, len(relationship2))
 
         # expecting the other plugin to be under test_node rather than
         # test_node2:
         plugin2_def = nodes[0]['plugins'][0]
-        self.assertEquals('test_plugin2', plugin2_def['name'])
+        self.assertEqual('test_plugin2', plugin2_def['name'])
 
 
 class DeploymentPluginsToInstallTest(AbstractTestParser):
@@ -286,14 +286,14 @@ plugins:
         result = self.parse(yaml)
         deployment_plugins_to_install_for_node = \
             result['nodes'][0][constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(1, len(deployment_plugins_to_install_for_node))
+        self.assertEqual(1, len(deployment_plugins_to_install_for_node))
         plugin = deployment_plugins_to_install_for_node[0]
-        self.assertEquals('test_management_plugin', plugin['name'])
+        self.assertEqual('test_management_plugin', plugin['name'])
 
         # check the property on the plan is correct
         deployment_plugins_to_install_for_plan = \
             result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(1, len(deployment_plugins_to_install_for_plan))
+        self.assertEqual(1, len(deployment_plugins_to_install_for_plan))
 
     def test_one_central_overrides_host_plugin(self):
         yaml = """
@@ -316,16 +316,16 @@ plugins:
         node = result['nodes'][0]
         deployment_plugins_to_install_for_node = \
             node[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(1, len(deployment_plugins_to_install_for_node))
+        self.assertEqual(1, len(deployment_plugins_to_install_for_node))
         plugin = deployment_plugins_to_install_for_node[0]
-        self.assertEquals('test_plugin', plugin['name'])
+        self.assertEqual('test_plugin', plugin['name'])
         self.assertIsNone(node.get('plugins_to_install'))
         # check the property on the plan is correct
         deployment_plugins_to_install_for_plan = \
             result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(1, len(deployment_plugins_to_install_for_plan))
+        self.assertEqual(1, len(deployment_plugins_to_install_for_plan))
         plugin = deployment_plugins_to_install_for_plan[0]
-        self.assertEquals('test_plugin', plugin['name'])
+        self.assertEqual('test_plugin', plugin['name'])
 
     def test_node_plugins_to_install_no_host(self):
         yaml = """
@@ -345,7 +345,7 @@ plugins:
         source: dummy
 """
         result = self.parse(yaml)
-        self.assertEquals(1,
+        self.assertEqual(1,
                           len(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]))
 
     def test_same_plugin_one_two_nodes(self):
@@ -373,14 +373,14 @@ plugins:
         for node in result['nodes']:
             deployment_plugins_to_install_for_node = \
                 node[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-            self.assertEquals(1, len(deployment_plugins_to_install_for_node))
+            self.assertEqual(1, len(deployment_plugins_to_install_for_node))
             plugin = deployment_plugins_to_install_for_node[0]
-            self.assertEquals('test_management_plugin', plugin['name'])
+            self.assertEqual('test_management_plugin', plugin['name'])
 
         # check the property on the plan is correct
         deployment_plugins_to_install_for_plan = \
             result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(1, len(deployment_plugins_to_install_for_plan))
+        self.assertEqual(1, len(deployment_plugins_to_install_for_plan))
 
     def test_two_plugins_on_one_node(self):
         yaml = """
@@ -410,12 +410,12 @@ plugins:
         result = self.parse(yaml)
         deployment_plugins_to_install_for_node = \
             result['nodes'][0][constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(2, len(deployment_plugins_to_install_for_node))
+        self.assertEqual(2, len(deployment_plugins_to_install_for_node))
 
         # check the property on the plan is correct
         deployment_plugins_to_install_for_plan = \
             result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(2, len(deployment_plugins_to_install_for_plan))
+        self.assertEqual(2, len(deployment_plugins_to_install_for_plan))
 
     def test_no_operation_mapping_no_plugin(self):
         yaml = """
@@ -442,12 +442,12 @@ plugins:
         result = self.parse(yaml)
         deployment_plugins_to_install_for_node = \
             result['nodes'][0][constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(0, len(deployment_plugins_to_install_for_node))
+        self.assertEqual(0, len(deployment_plugins_to_install_for_node))
 
         # check the property on the plan is correct
         deployment_plugins_to_install_for_plan = \
             result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(0, len(deployment_plugins_to_install_for_plan))
+        self.assertEqual(0, len(deployment_plugins_to_install_for_plan))
 
     def test_two_identical_plugins_on_node(self):
         yaml = """
@@ -474,9 +474,9 @@ plugins:
         result = self.parse(yaml)
         deployment_plugins_to_install_for_node = \
             result['nodes'][0][constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(1, len(deployment_plugins_to_install_for_node))
+        self.assertEqual(1, len(deployment_plugins_to_install_for_node))
 
         # check the property on the plan is correct
         deployment_plugins_to_install_for_plan = \
             result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]
-        self.assertEquals(1, len(deployment_plugins_to_install_for_plan))
+        self.assertEqual(1, len(deployment_plugins_to_install_for_plan))

--- a/dsl_parser/tests/test_plugins_to_install.py
+++ b/dsl_parser/tests/test_plugins_to_install.py
@@ -345,8 +345,8 @@ plugins:
         source: dummy
 """
         result = self.parse(yaml)
-        self.assertEqual(1,
-                          len(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]))
+        self.assertEqual(
+            1, len(result[constants.DEPLOYMENT_PLUGINS_TO_INSTALL]))
 
     def test_same_plugin_one_two_nodes(self):
         yaml = """

--- a/dsl_parser/tests/test_relationships.py
+++ b/dsl_parser/tests/test_relationships.py
@@ -57,19 +57,20 @@ relationships:
         """
         result = self.parse(yaml)
         self._assert_blueprint(result)
-        self.assertEqual({'name': 'empty_rel', 'properties': {},
-                          'source_interfaces': {},
-                          'target_interfaces': {},
-                          'type_hierarchy': ['empty_rel']},
-                         result['relationships']['empty_rel'])
+        self.assertEqual({
+            'name': 'empty_rel', 'properties': {},
+            'source_interfaces': {},
+            'target_interfaces': {},
+            'type_hierarchy': ['empty_rel']
+        }, result['relationships']['empty_rel'])
         test_relationship = result['relationships']['test_relationship']
         self.assertEqual('test_relationship', test_relationship['name'])
         self.assertEqual(test_relationship['type_hierarchy'],
-                          ['empty_rel', 'test_relationship'])
+                         ['empty_rel', 'test_relationship'])
         result_test_interface_3 = \
             test_relationship['source_interfaces']['test_interface3']
         self.assertEqual(NO_OP,
-                          result_test_interface_3['test_interface3_op1'])
+                         result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             test_relationship['target_interfaces']['test_interface4']
         self.assertEqual(
@@ -129,7 +130,7 @@ imports:
                          result['relationships']['empty_rel'])
         test_relationship = result['relationships']['test_relationship']
         self.assertEqual('test_relationship',
-                          test_relationship['name'])
+                         test_relationship['name'])
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install',
                               inputs={},
@@ -157,7 +158,7 @@ imports:
 
         test_relationship2 = result['relationships']['test_relationship2']
         self.assertEqual('test_relationship2',
-                          test_relationship2['name'])
+                         test_relationship2['name'])
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install',
                               inputs={},
@@ -404,13 +405,13 @@ relationships:
         self.assertEqual('test_node2', nodes[1]['id'])
         self.assertEqual(2, len(nodes[1]['relationships']))
         self.assertEqual('test_relationship',
-                          nodes[1]['relationships'][0]['type'])
+                         nodes[1]['relationships'][0]['type'])
         self.assertEqual('test_relationship',
-                          nodes[1]['relationships'][1]['type'])
+                         nodes[1]['relationships'][1]['type'])
         self.assertEqual('test_node',
-                          nodes[1]['relationships'][0]['target_id'])
+                         nodes[1]['relationships'][0]['target_id'])
         self.assertEqual('test_node',
-                          nodes[1]['relationships'][1]['target_id'])
+                         nodes[1]['relationships'][1]['target_id'])
         self.assertEqual(8, len(nodes[1]['relationships'][0]))
         self.assertEqual(8, len(nodes[1]['relationships'][1]))
 
@@ -571,7 +572,7 @@ plugins:
         self.assertEqual('parent_relationship', parent_relationship['name'])
         self.assertEqual(1, len(parent_relationship['target_interfaces']))
         self.assertEqual(1, len(parent_relationship['target_interfaces']
-                                 ['test_interface3']))
+                                ['test_interface3']))
         self.assertEqual(
             {'implementation': '', 'inputs': {}, 'executor': None,
              'max_retries': None, 'retry_interval': None, 'timeout': None,
@@ -583,13 +584,13 @@ plugins:
         self.assertEqual('parent_relationship', relationship['derived_from'])
         self.assertEqual(1, len(relationship['target_interfaces']))
         self.assertEqual(1, len(relationship['target_interfaces']
-                                 ['test_interface3']))
+                                ['test_interface3']))
         self.assertEqual(
             NO_OP,
             relationship['target_interfaces']['test_interface3']['install'])
         self.assertEqual(1, len(relationship['source_interfaces']))
         self.assertEqual(2, len(relationship['source_interfaces']
-                                 ['test_interface2']))
+                                ['test_interface2']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
@@ -613,13 +614,13 @@ plugins:
         self.assertEqual('test_node', node_relationship['target_id'])
         self.assertEqual(2, len(node_relationship['target_interfaces']))
         self.assertEqual(1, len(node_relationship['target_interfaces']
-                                 ['test_interface3']))
+                                ['test_interface3']))
         self.assertEqual(
             NO_OP,
             node_relationship['target_interfaces'][
                 'test_interface3']['install'])
         self.assertEqual(1, len(node_relationship['target_interfaces']
-                                 ['test_interface1']))
+                                ['test_interface1']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
@@ -631,7 +632,7 @@ plugins:
                 'test_interface1']['install'])
         self.assertEqual(2, len(node_relationship['source_interfaces']))
         self.assertEqual(1, len(node_relationship['source_interfaces']
-                                 ['test_interface3']))
+                                ['test_interface3']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
@@ -642,7 +643,7 @@ plugins:
             node_relationship['source_interfaces'][
                 'test_interface2']['install'])
         self.assertEqual(2, len(node_relationship['source_interfaces']
-                                 ['test_interface2']))
+                                ['test_interface2']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
@@ -749,12 +750,12 @@ plugins:
         self.assertEqual('parent_relationship', parent_relationship['name'])
         self.assertEqual(1, len(parent_relationship['target_interfaces']))
         self.assertEqual(1, len(parent_relationship['target_interfaces']
-                                 ['test_interface']))
+                                ['test_interface']))
         self.assertIn('install', parent_relationship['target_interfaces']
                       ['test_interface'])
         self.assertEqual(1, len(parent_relationship['source_interfaces']))
         self.assertEqual(1, len(parent_relationship['source_interfaces']
-                                 ['test_interface']))
+                                ['test_interface']))
         self.assertIn('install2', parent_relationship[
             'source_interfaces']['test_interface'])
 
@@ -762,7 +763,7 @@ plugins:
         self.assertEqual('parent_relationship', relationship['derived_from'])
         self.assertEqual(1, len(relationship['target_interfaces']))
         self.assertEqual(2, len(relationship['target_interfaces']
-                                 ['test_interface']))
+                                ['test_interface']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
@@ -1033,7 +1034,7 @@ relationships:
         self.assertEqual('test_type', node['type'])
         relationship = result['relationships']['test_relationship']
         self.assertEqual({'key': {'description': 'property_desc'}},
-                          relationship['properties'])
+                         relationship['properties'])
 
     def test_relationship_type_properties_standard_property(self):
         yaml = self.MINIMAL_BLUEPRINT + """

--- a/dsl_parser/tests/test_relationships.py
+++ b/dsl_parser/tests/test_relationships.py
@@ -26,7 +26,7 @@ relationships: {}
         """
         result = self.parse(yaml)
         self._assert_minimal_blueprint(result)
-        self.assertEquals(0, len(result['relationships']))
+        self.assertEqual(0, len(result['relationships']))
 
     def test_empty_top_level_relationships_empty_relationship(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -63,16 +63,16 @@ relationships:
                           'type_hierarchy': ['empty_rel']},
                          result['relationships']['empty_rel'])
         test_relationship = result['relationships']['test_relationship']
-        self.assertEquals('test_relationship', test_relationship['name'])
-        self.assertEquals(test_relationship['type_hierarchy'],
+        self.assertEqual('test_relationship', test_relationship['name'])
+        self.assertEqual(test_relationship['type_hierarchy'],
                           ['empty_rel', 'test_relationship'])
         result_test_interface_3 = \
             test_relationship['source_interfaces']['test_interface3']
-        self.assertEquals(NO_OP,
+        self.assertEqual(NO_OP,
                           result_test_interface_3['test_interface3_op1'])
         result_test_interface_4 = \
             test_relationship['target_interfaces']['test_interface4']
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test_plugin.task_name',
                               inputs={},
                               executor=None,
@@ -128,7 +128,7 @@ imports:
                           'type_hierarchy': ['empty_rel']},
                          result['relationships']['empty_rel'])
         test_relationship = result['relationships']['test_relationship']
-        self.assertEquals('test_relationship',
+        self.assertEqual('test_relationship',
                           test_relationship['name'])
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install',
@@ -150,13 +150,13 @@ imports:
                               timeout_recoverable=None),
             test_relationship['source_interfaces'][
                 'test_interface2']['terminate'])
-        self.assertEquals(
+        self.assertEqual(
             2, len(test_relationship['source_interfaces'][
                        'test_interface2']))
-        self.assertEquals(6, len(test_relationship))
+        self.assertEqual(6, len(test_relationship))
 
         test_relationship2 = result['relationships']['test_relationship2']
-        self.assertEquals('test_relationship2',
+        self.assertEqual('test_relationship2',
                           test_relationship2['name'])
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install',
@@ -178,13 +178,13 @@ imports:
                               timeout_recoverable=None),
             test_relationship2['target_interfaces'][
                 'test_interface2']['terminate'])
-        self.assertEquals(
+        self.assertEqual(
             2, len(test_relationship2['target_interfaces'][
                        'test_interface2']))
-        self.assertEquals(6, len(test_relationship2))
+        self.assertEqual(6, len(test_relationship2))
 
         test_relationship3 = result['relationships']['test_relationship3']
-        self.assertEquals('test_relationship3', test_relationship3['name'])
+        self.assertEqual('test_relationship3', test_relationship3['name'])
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install',
                               inputs={},
@@ -205,10 +205,10 @@ imports:
                               timeout_recoverable=None),
             test_relationship3['target_interfaces'][
                 'test_interface2']['terminate'])
-        self.assertEquals(
+        self.assertEqual(
             2, len(test_relationship3['target_interfaces'][
                        'test_interface2']))
-        self.assertEquals(5, len(test_relationship3))
+        self.assertEqual(5, len(test_relationship3))
 
     def test_top_level_relationship_properties(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -226,14 +226,14 @@ relationships:
         result = self.parse(yaml)
         self._assert_minimal_blueprint(result)
         relationships = result['relationships']
-        self.assertEquals(1, len(relationships))
+        self.assertEqual(1, len(relationships))
         test_relationship = relationships['test_relationship']
         properties = test_relationship['properties']
         self.assertIn('without_default_value', properties)
         self.assertIn('with_simple_default_value', properties)
-        self.assertEquals({'default': 1}, properties[
+        self.assertEqual({'default': 1}, properties[
             'with_simple_default_value'])
-        self.assertEquals({'default': {'comp1': 1, 'comp2': 2}}, properties[
+        self.assertEqual({'default': {'comp1': 1, 'comp2': 2}}, properties[
             'with_object_default_value'])
 
     def test_top_level_relationship_properties_inheritance(self):
@@ -272,19 +272,19 @@ relationships:
         result = self.parse(yaml)
         self._assert_minimal_blueprint(result)
         relationships = result['relationships']
-        self.assertEquals(3, len(relationships))
+        self.assertEqual(3, len(relationships))
         r1_properties = relationships['test_relationship1']['properties']
         r2_properties = relationships['test_relationship2']['properties']
         r3_properties = relationships['test_relationship3']['properties']
-        self.assertEquals(4, len(r1_properties))
+        self.assertEqual(4, len(r1_properties))
         self.assertIn('prop1', r1_properties)
         self.assertIn('prop2', r1_properties)
         self.assertIn('prop3', r1_properties)
         self.assertIn('derived1', r1_properties)
-        self.assertEquals({'default': 'prop3_value_1'}, r1_properties['prop3'])
-        self.assertEquals({'default': 'derived1_value'}, r1_properties[
+        self.assertEqual({'default': 'prop3_value_1'}, r1_properties['prop3'])
+        self.assertEqual({'default': 'derived1_value'}, r1_properties[
             'derived1'])
-        self.assertEquals(8, len(r2_properties))
+        self.assertEqual(8, len(r2_properties))
         self.assertIn('prop1', r2_properties)
         self.assertIn('prop2', r2_properties)
         self.assertIn('prop3', r2_properties)
@@ -293,17 +293,17 @@ relationships:
         self.assertIn('prop6', r2_properties)
         self.assertIn('derived1', r2_properties)
         self.assertIn('derived2', r2_properties)
-        self.assertEquals({'default': 'prop2_value_2'}, r2_properties[
+        self.assertEqual({'default': 'prop2_value_2'}, r2_properties[
             'prop2'])
-        self.assertEquals({'default': 'prop3_value_2'}, r2_properties[
+        self.assertEqual({'default': 'prop3_value_2'}, r2_properties[
             'prop3'])
-        self.assertEquals({'default': 'prop6_value_2'}, r2_properties[
+        self.assertEqual({'default': 'prop6_value_2'}, r2_properties[
             'prop6'])
-        self.assertEquals({'default': 'derived1_value'}, r2_properties[
+        self.assertEqual({'default': 'derived1_value'}, r2_properties[
             'derived1'])
-        self.assertEquals({'default': 'derived2_value'}, r2_properties[
+        self.assertEqual({'default': 'derived2_value'}, r2_properties[
             'derived2'])
-        self.assertEquals(9, len(r3_properties))
+        self.assertEqual(9, len(r3_properties))
         self.assertIn('prop1', r3_properties)
         self.assertIn('prop2', r3_properties)
         self.assertIn('prop3', r3_properties)
@@ -313,17 +313,17 @@ relationships:
         self.assertIn('prop7', r3_properties)
         self.assertIn('derived1', r3_properties)
         self.assertIn('derived2', r3_properties)
-        self.assertEquals({'default': 'prop2_value_2'}, r3_properties[
+        self.assertEqual({'default': 'prop2_value_2'}, r3_properties[
             'prop2'])
-        self.assertEquals({'default': 'prop3_value_2'}, r3_properties[
+        self.assertEqual({'default': 'prop3_value_2'}, r3_properties[
             'prop3'])
-        self.assertEquals({'default': 'prop5_value_3'}, r3_properties[
+        self.assertEqual({'default': 'prop5_value_3'}, r3_properties[
             'prop5'])
-        self.assertEquals({'default': 'prop6_value_3'}, r3_properties[
+        self.assertEqual({'default': 'prop6_value_3'}, r3_properties[
             'prop6'])
-        self.assertEquals({'default': 'derived1_value'}, r3_properties[
+        self.assertEqual({'default': 'derived1_value'}, r3_properties[
             'derived1'])
-        self.assertEquals({'default': 'derived2_value'}, r3_properties[
+        self.assertEqual({'default': 'derived2_value'}, r3_properties[
             'derived2'])
 
     def test_instance_relationships_empty_relationships_section(self):
@@ -353,14 +353,14 @@ plugins:
         source: dummy
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
-        self.assertEquals('test_node2', nodes[1]['id'])
-        self.assertEquals(1, len(nodes[1]['relationships']))
+        self.assertEqual('test_node2', nodes[1]['id'])
+        self.assertEqual(1, len(nodes[1]['relationships']))
         relationship = nodes[1]['relationships'][0]
-        self.assertEquals('test_relationship', relationship['type'])
-        self.assertEquals('test_node', relationship['target_id'])
+        self.assertEqual('test_relationship', relationship['type'])
+        self.assertEqual('test_node', relationship['target_id'])
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
@@ -379,9 +379,9 @@ plugins:
             relationship_source_operations['test_interface1.install'])
         self.assertEqual(2, len(relationship_source_operations))
 
-        self.assertEquals(8, len(relationship))
+        self.assertEqual(8, len(relationship))
         plugin_def = nodes[1]['plugins'][0]
-        self.assertEquals('test_plugin', plugin_def['name'])
+        self.assertEqual('test_plugin', plugin_def['name'])
 
     def test_instance_relationships_duplicate_relationship(self):
         # right now, having two relationships with the same (type,target)
@@ -398,21 +398,21 @@ relationships:
     test_relationship: {}
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
-        self.assertEquals('test_node2', nodes[1]['id'])
-        self.assertEquals(2, len(nodes[1]['relationships']))
-        self.assertEquals('test_relationship',
+        self.assertEqual('test_node2', nodes[1]['id'])
+        self.assertEqual(2, len(nodes[1]['relationships']))
+        self.assertEqual('test_relationship',
                           nodes[1]['relationships'][0]['type'])
-        self.assertEquals('test_relationship',
+        self.assertEqual('test_relationship',
                           nodes[1]['relationships'][1]['type'])
-        self.assertEquals('test_node',
+        self.assertEqual('test_node',
                           nodes[1]['relationships'][0]['target_id'])
-        self.assertEquals('test_node',
+        self.assertEqual('test_node',
                           nodes[1]['relationships'][1]['target_id'])
-        self.assertEquals(8, len(nodes[1]['relationships'][0]))
-        self.assertEquals(8, len(nodes[1]['relationships'][1]))
+        self.assertEqual(8, len(nodes[1]['relationships'][0]))
+        self.assertEqual(8, len(nodes[1]['relationships'][1]))
 
     def test_instance_relationships_relationship_inheritance(self):
         # possibly 'inheritance' is the wrong term to use here,
@@ -445,12 +445,12 @@ plugins:
         source: dummy
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         relationship = nodes[1]['relationships'][0]
-        self.assertEquals('test_relationship', relationship['type'])
-        self.assertEquals('test_node', relationship['target_id'])
+        self.assertEqual('test_relationship', relationship['type'])
+        self.assertEqual('test_node', relationship['target_id'])
         self.assertEqual(
             operation_mapping(implementation='test_plugin.task_name1',
                               inputs={}, executor=None,
@@ -476,7 +476,7 @@ plugins:
         self.assertEqual(op_struct('test_plugin', 'task_name1',
                                    executor='central_deployment_agent'),
                          rel_source_ops['interface1.op1'])
-        self.assertEquals(2, len(rel_source_ops))
+        self.assertEqual(2, len(rel_source_ops))
 
         rel_target_ops = relationship['target_operations']
         self.assertEqual(op_struct('test_plugin', 'task_name2',
@@ -485,9 +485,9 @@ plugins:
         self.assertEqual(op_struct('test_plugin', 'task_name2',
                                    executor='central_deployment_agent'),
                          rel_target_ops['interface2.op2'])
-        self.assertEquals(2, len(rel_target_ops))
+        self.assertEqual(2, len(rel_target_ops))
 
-        self.assertEquals(8, len(relationship))
+        self.assertEqual(8, len(relationship))
 
     def test_instance_relationship_properties_inheritance(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -510,16 +510,16 @@ relationships:
             prop7: {}
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         relationships = result['relationships']
-        self.assertEquals(1, len(relationships))
+        self.assertEqual(1, len(relationships))
         i_properties = nodes[1]['relationships'][0]['properties']
-        self.assertEquals(3, len(i_properties))
-        self.assertEquals('prop1_value_new', i_properties['prop1'])
-        self.assertEquals('prop2_value_new', i_properties['prop2'])
-        self.assertEquals('prop7_value_new_instance', i_properties['prop7'])
+        self.assertEqual(3, len(i_properties))
+        self.assertEqual('prop1_value_new', i_properties['prop1'])
+        self.assertEqual('prop2_value_new', i_properties['prop2'])
+        self.assertEqual('prop7_value_new_instance', i_properties['prop7'])
 
     def test_relationships_and_node_recursive_inheritance(self):
         # testing for a complete inheritance path for relationships
@@ -557,38 +557,38 @@ plugins:
         source: dummy
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         node_relationship = nodes[1]['relationships'][0]
         relationship = result['relationships']['relationship']
         parent_relationship = result['relationships']['parent_relationship']
-        self.assertEquals(2, len(result['relationships']))
-        self.assertEquals(5, len(parent_relationship))
-        self.assertEquals(6, len(relationship))
-        self.assertEquals(8, len(node_relationship))
+        self.assertEqual(2, len(result['relationships']))
+        self.assertEqual(5, len(parent_relationship))
+        self.assertEqual(6, len(relationship))
+        self.assertEqual(8, len(node_relationship))
 
-        self.assertEquals('parent_relationship', parent_relationship['name'])
-        self.assertEquals(1, len(parent_relationship['target_interfaces']))
-        self.assertEquals(1, len(parent_relationship['target_interfaces']
+        self.assertEqual('parent_relationship', parent_relationship['name'])
+        self.assertEqual(1, len(parent_relationship['target_interfaces']))
+        self.assertEqual(1, len(parent_relationship['target_interfaces']
                                  ['test_interface3']))
-        self.assertEquals(
+        self.assertEqual(
             {'implementation': '', 'inputs': {}, 'executor': None,
              'max_retries': None, 'retry_interval': None, 'timeout': None,
              'timeout_recoverable': None},
             parent_relationship['target_interfaces'][
                 'test_interface3']['install'])
 
-        self.assertEquals('relationship', relationship['name'])
-        self.assertEquals('parent_relationship', relationship['derived_from'])
-        self.assertEquals(1, len(relationship['target_interfaces']))
-        self.assertEquals(1, len(relationship['target_interfaces']
+        self.assertEqual('relationship', relationship['name'])
+        self.assertEqual('parent_relationship', relationship['derived_from'])
+        self.assertEqual(1, len(relationship['target_interfaces']))
+        self.assertEqual(1, len(relationship['target_interfaces']
                                  ['test_interface3']))
-        self.assertEquals(
+        self.assertEqual(
             NO_OP,
             relationship['target_interfaces']['test_interface3']['install'])
-        self.assertEquals(1, len(relationship['source_interfaces']))
-        self.assertEquals(2, len(relationship['source_interfaces']
+        self.assertEqual(1, len(relationship['source_interfaces']))
+        self.assertEqual(2, len(relationship['source_interfaces']
                                  ['test_interface2']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
@@ -609,16 +609,16 @@ plugins:
             relationship['source_interfaces'][
                 'test_interface2']['terminate'])
 
-        self.assertEquals('relationship', node_relationship['type'])
-        self.assertEquals('test_node', node_relationship['target_id'])
-        self.assertEquals(2, len(node_relationship['target_interfaces']))
-        self.assertEquals(1, len(node_relationship['target_interfaces']
+        self.assertEqual('relationship', node_relationship['type'])
+        self.assertEqual('test_node', node_relationship['target_id'])
+        self.assertEqual(2, len(node_relationship['target_interfaces']))
+        self.assertEqual(1, len(node_relationship['target_interfaces']
                                  ['test_interface3']))
-        self.assertEquals(
+        self.assertEqual(
             NO_OP,
             node_relationship['target_interfaces'][
                 'test_interface3']['install'])
-        self.assertEquals(1, len(node_relationship['target_interfaces']
+        self.assertEqual(1, len(node_relationship['target_interfaces']
                                  ['test_interface1']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
@@ -629,10 +629,10 @@ plugins:
                               timeout_recoverable=None),
             node_relationship['target_interfaces'][
                 'test_interface1']['install'])
-        self.assertEquals(2, len(node_relationship['source_interfaces']))
-        self.assertEquals(1, len(node_relationship['source_interfaces']
+        self.assertEqual(2, len(node_relationship['source_interfaces']))
+        self.assertEqual(1, len(node_relationship['source_interfaces']
                                  ['test_interface3']))
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
                               max_retries=None,
@@ -641,9 +641,9 @@ plugins:
                               timeout_recoverable=None),
             node_relationship['source_interfaces'][
                 'test_interface2']['install'])
-        self.assertEquals(2, len(node_relationship['source_interfaces']
+        self.assertEqual(2, len(node_relationship['source_interfaces']
                                  ['test_interface2']))
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
                               executor=None,
                               max_retries=None,
@@ -652,7 +652,7 @@ plugins:
                               timeout_recoverable=None),
             node_relationship['source_interfaces'][
                 'test_interface2']['install'])
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test_plugin.terminate',
                               inputs={},
                               executor=None,
@@ -664,7 +664,7 @@ plugins:
                 'test_interface2']['terminate'])
 
         rel_source_ops = node_relationship['source_operations']
-        self.assertEquals(4, len(rel_source_ops))
+        self.assertEqual(4, len(rel_source_ops))
         self.assertEqual(op_struct('test_plugin', 'install',
                                    executor='central_deployment_agent'),
                          rel_source_ops['test_interface2.install'])
@@ -679,7 +679,7 @@ plugins:
                          rel_source_ops['test_interface2.terminate'])
 
         rel_target_ops = node_relationship['target_operations']
-        self.assertEquals(2, len(rel_target_ops))
+        self.assertEqual(2, len(rel_target_ops))
         self.assertEqual(op_struct('', '', {}),
                          rel_target_ops['test_interface3.install'])
         self.assertEqual(op_struct('test_plugin', 'install',
@@ -735,33 +735,33 @@ plugins:
         source: dummy
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         node_relationship = nodes[1]['relationships'][0]
         relationship = result['relationships']['relationship']
         parent_relationship = result['relationships']['parent_relationship']
-        self.assertEquals(2, len(result['relationships']))
-        self.assertEquals(5, len(parent_relationship))
-        self.assertEquals(6, len(relationship))
-        self.assertEquals(8, len(node_relationship))
+        self.assertEqual(2, len(result['relationships']))
+        self.assertEqual(5, len(parent_relationship))
+        self.assertEqual(6, len(relationship))
+        self.assertEqual(8, len(node_relationship))
 
-        self.assertEquals('parent_relationship', parent_relationship['name'])
-        self.assertEquals(1, len(parent_relationship['target_interfaces']))
-        self.assertEquals(1, len(parent_relationship['target_interfaces']
+        self.assertEqual('parent_relationship', parent_relationship['name'])
+        self.assertEqual(1, len(parent_relationship['target_interfaces']))
+        self.assertEqual(1, len(parent_relationship['target_interfaces']
                                  ['test_interface']))
         self.assertIn('install', parent_relationship['target_interfaces']
                       ['test_interface'])
-        self.assertEquals(1, len(parent_relationship['source_interfaces']))
-        self.assertEquals(1, len(parent_relationship['source_interfaces']
+        self.assertEqual(1, len(parent_relationship['source_interfaces']))
+        self.assertEqual(1, len(parent_relationship['source_interfaces']
                                  ['test_interface']))
         self.assertIn('install2', parent_relationship[
             'source_interfaces']['test_interface'])
 
-        self.assertEquals('relationship', relationship['name'])
-        self.assertEquals('parent_relationship', relationship['derived_from'])
-        self.assertEquals(1, len(relationship['target_interfaces']))
-        self.assertEquals(2, len(relationship['target_interfaces']
+        self.assertEqual('relationship', relationship['name'])
+        self.assertEqual('parent_relationship', relationship['derived_from'])
+        self.assertEqual(1, len(relationship['target_interfaces']))
+        self.assertEqual(2, len(relationship['target_interfaces']
                                  ['test_interface']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
@@ -780,8 +780,8 @@ plugins:
                               timeout_recoverable=None),
             relationship['target_interfaces'][
                 'test_interface']['terminate'])
-        self.assertEquals(1, len(relationship['source_interfaces']))
-        self.assertEquals(
+        self.assertEqual(1, len(relationship['source_interfaces']))
+        self.assertEqual(
             2, len(relationship['source_interfaces']['test_interface']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install', inputs={},
@@ -802,10 +802,10 @@ plugins:
             relationship['source_interfaces'][
                 'test_interface']['terminate2'])
 
-        self.assertEquals('relationship', node_relationship['type'])
-        self.assertEquals('test_node', node_relationship['target_id'])
-        self.assertEquals(1, len(node_relationship['target_interfaces']))
-        self.assertEquals(
+        self.assertEqual('relationship', node_relationship['type'])
+        self.assertEqual('test_node', node_relationship['target_id'])
+        self.assertEqual(1, len(node_relationship['target_interfaces']))
+        self.assertEqual(
             3, len(node_relationship['target_interfaces']['test_interface']))
         self.assertEqual(
             operation_mapping(implementation='test_plugin.install',
@@ -837,11 +837,11 @@ plugins:
                               timeout_recoverable=None),
             node_relationship['target_interfaces'][
                 'test_interface']['destroy'])
-        self.assertEquals(1, len(node_relationship['source_interfaces']))
-        self.assertEquals(
+        self.assertEqual(1, len(node_relationship['source_interfaces']))
+        self.assertEqual(
             3, len(node_relationship['source_interfaces'][
                        'test_interface']))
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test_plugin.install2',
                               inputs={},
                               executor=None,
@@ -860,7 +860,7 @@ plugins:
                               timeout=None,
                               timeout_recoverable=None),
             relationship['source_interfaces']['test_interface']['terminate2'])
-        self.assertEquals(
+        self.assertEqual(
             operation_mapping(implementation='test_plugin.destroy2',
                               inputs={},
                               executor=None,
@@ -890,7 +890,7 @@ plugins:
         self.assertEqual(op_struct('test_plugin', 'destroy2',
                                    executor='central_deployment_agent'),
                          rel_source_ops['test_interface.destroy2'])
-        self.assertEquals(6, len(rel_source_ops))
+        self.assertEqual(6, len(rel_source_ops))
 
         rel_target_ops = node_relationship['target_operations']
         self.assertEqual(op_struct('test_plugin', 'install',
@@ -911,7 +911,7 @@ plugins:
         self.assertEqual(op_struct('test_plugin', 'destroy1',
                                    executor='central_deployment_agent'),
                          rel_target_ops['test_interface.destroy'])
-        self.assertEquals(6, len(rel_source_ops))
+        self.assertEqual(6, len(rel_source_ops))
 
     def test_relationship_no_type_hierarchy(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -924,7 +924,7 @@ relationships:
     relationship: {}
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         relationship = nodes[1]['relationships'][0]
@@ -946,7 +946,7 @@ relationships:
         derived_from: relationship
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         relationship = nodes[1]['relationships'][0]
@@ -971,7 +971,7 @@ relationships:
         derived_from: rel2
         """
         result = self.parse(yaml)
-        self.assertEquals(2, len(result['nodes']))
+        self.assertEqual(2, len(result['nodes']))
         nodes = self._sort_result_nodes(result['nodes'], ['test_node',
                                                           'test_node2'])
         relationship = nodes[1]['relationships'][0]
@@ -996,12 +996,12 @@ relationships:
         properties: {}
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         relationship = result['relationships']['test_relationship']
-        self.assertEquals({}, relationship['properties'])
+        self.assertEqual({}, relationship['properties'])
 
     def test_relationship_type_properties_empty_property(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -1011,12 +1011,12 @@ relationships:
             key: {}
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         relationship = result['relationships']['test_relationship']
-        self.assertEquals({'key': {}}, relationship['properties'])
+        self.assertEqual({'key': {}}, relationship['properties'])
 
     def test_relationship_type_properties_property_with_description_only(self):
         yaml = self.MINIMAL_BLUEPRINT + """
@@ -1027,12 +1027,12 @@ relationships:
                 description: property_desc
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         relationship = result['relationships']['test_relationship']
-        self.assertEquals({'key': {'description': 'property_desc'}},
+        self.assertEqual({'key': {'description': 'property_desc'}},
                           relationship['properties'])
 
     def test_relationship_type_properties_standard_property(self):
@@ -1046,12 +1046,12 @@ relationships:
                 type: string
 """
         result = self.parse(yaml)
-        self.assertEquals(1, len(result['nodes']))
+        self.assertEqual(1, len(result['nodes']))
         node = result['nodes'][0]
-        self.assertEquals('test_node', node['id'])
-        self.assertEquals('test_type', node['type'])
+        self.assertEqual('test_node', node['id'])
+        self.assertEqual('test_type', node['type'])
         relationship = result['relationships']['test_relationship']
-        self.assertEquals(
+        self.assertEqual(
             {'key': {'default': 'val', 'description': 'property_desc',
                      'type': 'string'}},
             relationship['properties'])
@@ -1104,7 +1104,7 @@ node_templates:
         relationships = parsed['relationships']
         relationship = relationships[
             'cloudify.relationships.depends_on_lifecycle_operation']
-        self.assertEquals(
+        self.assertEqual(
             {'operation':
                 {'default': 'precreate',
                  'type': 'string'}},
@@ -1192,7 +1192,7 @@ relationships:
         """
         parsed = self.parse(yaml)
         relationships = parsed['relationships']
-        self.assertEquals(1, len(relationships))
+        self.assertEqual(1, len(relationships))
         test_relationship = relationships['test_relationship']
         properties = test_relationship['properties']
         self.assertEqual(1, properties['integer']['default'])

--- a/dsl_parser/tests/test_relationships_overloading.py
+++ b/dsl_parser/tests/test_relationships_overloading.py
@@ -22,7 +22,7 @@ class TestRelationshipsOverloading(AbstractTestParser):
     def verify_relationships(self, relationships, expected_rels):
         source_rels = [(rel['target_id'], rel['type'])
                        for rel in relationships]
-        self.assertEqual(source_rels, expected_rels)
+        self.assertEqual(set(source_rels), set(expected_rels))
 
     def validate_expected_relationships(self, main_yaml,
                                         test_node_name,
@@ -568,12 +568,11 @@ imports:
     -   test--{1}
 """.format(import_file_name, side_import_file_name)
 
-        self.validate_expected_relationships(
-            main_yaml,
-            'test--test_node',
-            [('test--other_node', 'cloudify.relationships.depends_on'),
-             ('test--other_node', 'cloudify.relationships.depends_on'),
-             ('test--some_node', 'cloudify.relationships.depends_on')])
+        self.validate_expected_relationships(main_yaml, 'test--test_node', [
+            ('test--other_node', 'cloudify.relationships.depends_on'),
+            ('test--other_node', 'cloudify.relationships.depends_on'),
+            ('test--some_node', 'cloudify.relationships.depends_on'),
+        ])
 
     def test_side_import_not_expending_relationships_failure(self):
         side_blueprint = """

--- a/dsl_parser/tests/test_relationships_overloading.py
+++ b/dsl_parser/tests/test_relationships_overloading.py
@@ -22,7 +22,7 @@ class TestRelationshipsOverloading(AbstractTestParser):
     def verify_relationships(self, relationships, expected_rels):
         source_rels = [(rel['target_id'], rel['type'])
                        for rel in relationships]
-        self.assertItemsEqual(source_rels, expected_rels)
+        self.assertEqual(source_rels, expected_rels)
 
     def validate_expected_relationships(self, main_yaml,
                                         test_node_name,

--- a/dsl_parser/tests/test_yaml_anchors.py
+++ b/dsl_parser/tests/test_yaml_anchors.py
@@ -58,8 +58,8 @@ node_templates:
         }
 
         for node, expected_value in expected_node_properties.items():
-            self.assertEqual(expected_value,
-                              self._get_node_properties(parsed_plan, node))
+            self.assertEqual(
+                expected_value, self._get_node_properties(parsed_plan, node))
 
     def test_anchors_override(self):
         bp_yaml = """
@@ -98,4 +98,4 @@ node_templates:
 
         for node_id, expected_value in expected_node_properties.items():
             self.assertEqual(expected_value,
-                              self._get_node_properties(parsed_plan, node_id))
+                             self._get_node_properties(parsed_plan, node_id))

--- a/dsl_parser/tests/test_yaml_anchors.py
+++ b/dsl_parser/tests/test_yaml_anchors.py
@@ -58,7 +58,7 @@ node_templates:
         }
 
         for node, expected_value in expected_node_properties.items():
-            self.assertEquals(expected_value,
+            self.assertEqual(expected_value,
                               self._get_node_properties(parsed_plan, node))
 
     def test_anchors_override(self):
@@ -97,5 +97,5 @@ node_templates:
         }
 
         for node_id, expected_value in expected_node_properties.items():
-            self.assertEquals(expected_value,
+            self.assertEqual(expected_value,
                               self._get_node_properties(parsed_plan, node_id))


### PR DESCRIPTION
This converts all teststools stuff into unittest stuff.
(pytest-way, if we want, can come later)

Those are mostly bulk changes, so look at each commit separately.