### PR TITLE
CloudifyWorkflowRelationship: expose .type

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -167,6 +167,11 @@ class CloudifyWorkflowRelationship(object):
         self._relationship = relationship
 
     @property
+    def type(self):
+        """The type of this relationship"""
+        return self._relationship.get('type')
+
+    @property
     def target_id(self):
         """The relationship target node id"""
         return self._relationship.get('target_id')


### PR DESCRIPTION
The new dep-update uses this, so just expose this as an attribute.

This fixes the NewTestDeploymentUpdateAddition::test_add_relationship
inte-test