### PR TITLE
RD-3095 Include a traceback in the "workflow failed" message

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -280,7 +280,7 @@ class WorkflowHandler(TaskHandler):
                 self._workflow_succeeded()
             return result
         except exceptions.WorkflowFailed as e:
-            self._workflow_failed(e)
+            self._workflow_failed(e, traceback.format_exc())
             raise
         except BaseException as e:
             self._workflow_failed(e, traceback.format_exc())


### PR DESCRIPTION
This ports #884 to 6.2.0

This is not perfect yet, because the traceback could be better.
But have _some_ traceback, at all