### PR TITLE
RD-3221 Workflow is resumed based on the .resume flag

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -202,11 +202,6 @@ class WorkflowHandler(TaskHandler):
         tenant = self.ctx._context['tenant'].get('original_name',
                                                  self.ctx.tenant_name)
         rest = get_rest_client(tenant=tenant)
-        execution = rest.executions.get(self.ctx.execution_id,
-                                        _include=['status'])
-        if execution.status == Execution.STARTED:
-            self.ctx.resume = True
-
         try:
             try:
                 self._workflow_started()

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -465,7 +465,7 @@ class _WorkflowContextBase(object):
         self._internal = CloudifyWorkflowContextInternal(self, handler)
         # is this execution being resumed? set to True if at the beginning
         # of handling the execution, the status was already STARTED
-        self.resume = False
+        self.resume = ctx.get('resume', False)
         # all amqp Handler instances used by this workflow
         self.amqp_handlers = set()
 


### PR DESCRIPTION
...not based on the prior state. We set that flag explicitly, so let's
use it, instead of basing this on some additional thing (in this case,
the execution state)