### PR TITLE
RD-3229 allow changing context when evaluating functions

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -402,6 +402,10 @@ class GetAttribute(Function):
                 return '<ERROR: {0}>'.format(e)
 
         node = handler.get_node(node_instance['node_id'])
+        if self.context.get('self') and \
+                self.context['self'] != node_instance['id']:
+            self.context = self.context.copy()
+            self.context['self'] = node_instance['id']
         value = _get_attribute_from_node_instance(
             node_instance, node, self.attribute_path, self.path)
         return value

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -340,6 +340,10 @@ class GetProperty(Function):
                 node = handler.get_node(target_node)
         else:
             node = handler.get_node(self.node_name)
+            # we're getting a different node - switch the context to that, so
+            # that the EvaluationHandler can use the new node as the context,
+            # in case there's another get_property call in the result
+            self.context = node
         self._get_property_value(node)
         return node
 
@@ -1216,6 +1220,7 @@ class _EvaluationHandler(object):
                 break
             previous_evaluated_value = evaluated_value
             evaluated_value = self.evaluate_function(func)
+            context = func.context
             if scanned and previous_evaluated_value == evaluated_value:
                 break
             scanned = True

--- a/dsl_parser/tests/test_functions.py
+++ b/dsl_parser/tests/test_functions.py
@@ -825,6 +825,38 @@ node_templates:
             plan_node, self.mock_evaluation_storage(nodes=plan['nodes']))
         self.assertEqual(node['properties']['a'], 'secret2')
 
+    def test_context_switching(self):
+        """get_property calling get_property that has SELF, uses the new node
+
+        x.properties.x references y.properties.y - but y.properties.y calls
+        SELF.z - check that the SELF is then resolved to the y node indeed,
+        not to the x node
+        """
+        yaml = """
+node_types:
+  type1:
+    properties:
+      x: {}
+  type2:
+    properties:
+      y:
+        default: {get_property: [SELF, z]}
+      z:
+        default: 5
+node_templates:
+  x:
+    type: type1
+    properties:
+      x: {get_property: [y, y]}
+  y:
+    type: type2
+"""
+        plan = prepare_deployment_plan(self.parse(yaml))
+        x_node = self.get_node_by_name(plan, 'x')
+        y_node = self.get_node_by_name(plan, 'y')
+        self.assertEqual(y_node['properties']['y'], 5)
+        self.assertEqual(x_node['properties']['x'], 5)
+
 
 class TestGetAttribute(AbstractTestParser):
 

--- a/dsl_parser/tests/test_get_attribute.py
+++ b/dsl_parser/tests/test_get_attribute.py
@@ -362,6 +362,60 @@ class TestEvaluateFunctions(AbstractTestParser):
         self.assertEqual(payload['c'], 'c_val')
         self.assertEqual(payload['d'], 'd_val')
 
+    def test_fallback_context_switching(self):
+        node_instances = [
+            {
+                'id': 'x_1',
+                'node_id': 'x',
+                'runtime_properties': {}
+            },
+            {
+                'id': 'y_1',
+                'node_id': 'y',
+                'runtime_properties': {}
+            },
+
+        ]
+        nodes = [
+            {
+                'id': 'x',
+                'properties': {
+                    'x': {'get_attribute': ['y', 'y']},
+                }
+            },
+            {
+                'id': 'y',
+                'properties': {
+                    'y': {'get_attribute': ['SELF', 'z']},
+                    'z': 5
+                }
+            }
+        ]
+        storage = self.mock_evaluation_storage(node_instances, nodes)
+        payload_y = {
+            'y': {'get_attribute': ['y', 'y']},
+        }
+        context_y = {
+            'self': 'y_1',
+            'source': 'y_1',
+            'target': 'y_1'
+        }
+
+        functions.evaluate_functions(payload_y, context_y, storage)
+        self.assertEqual(payload_y['y'], 5)
+
+        payload_x = {
+            'x': {'get_attribute': ['x', 'x']},
+        }
+        context_x = {
+            'self': 'x_1',
+            'source': 'x_1',
+            'target': 'x_1'
+        }
+
+        functions.evaluate_functions(payload_x, context_x, storage)
+        self.assertEqual(payload_x['x'], 5)
+
     def test_process_attributes_no_value(self):
         node_instances = [{
             'id': 'node_1',


### PR DESCRIPTION
For both get_property and get_attribute. See commit messages.