### PR TITLE
RD-3229 allow changing context when evaluating functions

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -339,6 +339,10 @@ class GetProperty(Function):
                 node = handler.get_node(target_node)
         else:
             node = handler.get_node(self.node_name)
+            # we're getting a different node - switch the context to that, so
+            # that the EvaluationHandler can use the new node as the context,
+            # in case there's another get_property call in the result
+            self.context = node
         self._get_property_value(node)
         return node
 
@@ -451,6 +455,11 @@ class GetAttribute(Function):
                                         self.attribute_path,
                                         self.path,
                                         raise_if_not_found=False)
+
+            if self.context.get('self') and \
+                    self.context['self'] != node_instance['id']:
+                self.context = self.context.copy()
+                self.context['self'] = node_instance['id']
         return value
 
     def _resolve_node_instance_by_name(self, handler):
@@ -945,6 +954,7 @@ class _EvaluationHandler(object):
                 break
             previous_evaluated_value = evaluated_value
             evaluated_value = self.evaluate_function(func)
+            context = func.context
             if scanned and previous_evaluated_value == evaluated_value:
                 break
             scanned = True

--- a/dsl_parser/tests/test_get_attribute.py
+++ b/dsl_parser/tests/test_get_attribute.py
@@ -351,6 +351,60 @@ class TestEvaluateFunctions(AbstractTestParser):
         self.assertEqual(payload['c'], 'c_val')
         self.assertEqual(payload['d'], 'd_val')
 
+    def test_fallback_context_switching(self):
+        node_instances = [
+            {
+                'id': 'x_1',
+                'node_id': 'x',
+                'runtime_properties': {}
+            },
+            {
+                'id': 'y_1',
+                'node_id': 'y',
+                'runtime_properties': {}
+            },
+
+        ]
+        nodes = [
+            {
+                'id': 'x',
+                'properties': {
+                    'x': {'get_attribute': ['y', 'y']},
+                }
+            },
+            {
+                'id': 'y',
+                'properties': {
+                    'y': {'get_attribute': ['SELF', 'z']},
+                    'z': 5
+                }
+            }
+        ]
+        storage = self._mock_evaluation_storage(node_instances, nodes)
+        payload_y = {
+            'y': {'get_attribute': ['y', 'y']},
+        }
+        context_y = {
+            'self': 'y_1',
+            'source': 'y_1',
+            'target': 'y_1'
+        }
+
+        functions.evaluate_functions(payload_y, context_y, storage)
+        self.assertEqual(payload_y['y'], 5)
+
+        payload_x = {
+            'x': {'get_attribute': ['x', 'x']},
+        }
+        context_x = {
+            'self': 'x_1',
+            'source': 'x_1',
+            'target': 'x_1'
+        }
+
+        functions.evaluate_functions(payload_x, context_x, storage)
+        self.assertEqual(payload_x['x'], 5)
+
     def test_process_attributes_no_value(self):
         node_instances = [{
             'id': 'node_1',


### PR DESCRIPTION
This ports #890 to 5.2.7

* RD-3229 When evaluating functions, also allow changing the context

get_property must be allowed to change the context for the evaluation,
because when we hit a `SELF` in the path, now we're potentially running
in the context of another node!

So, for each function, not only update the currently-evaluated-value,
but also update the current context to what the function thinks it
should be.
And get_property thinks the context should be whatever node we actually
got.

The test & its docstring shows an example.

* same for get_attribute

switch SELF if it changed (for get_attr, the context is a dict that
contains self/source/target, and self can well change)