### PR TITLE
workflow_ctx.resume: remove invalid comment

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -463,8 +463,6 @@ class _WorkflowContextBase(object):
             handler = remote_ctx_handler_cls(self)
 
         self._internal = CloudifyWorkflowContextInternal(self, handler)
-        # is this execution being resumed? set to True if at the beginning
-        # of handling the execution, the status was already STARTED
         self.resume = ctx.get('resume', False)
         # all amqp Handler instances used by this workflow
         self.amqp_handlers = set()


### PR DESCRIPTION
we don't set it "if at the beginning..." blabla. We now just set it
as passed-in from the restservice. (since #886)