### PR TITLE
test_operation_retry: don't wait 3 seconds in the test

### DIFF
--- a/cloudify/tests/test_operation_retry.py
+++ b/cloudify/tests/test_operation_retry.py
@@ -81,8 +81,7 @@ def node_operation_retry(ctx, **kwargs):
             'is {1}'.format(expected_max_retries, ctx.operation.max_retries))
     ctx.instance.runtime_properties['counter'] = counter + 1
     if ctx.operation.retry_number < ctx.operation.max_retries:
-        return ctx.operation.retry(message='Operation will be retried',
-                                   retry_after=3)
+        return ctx.operation.retry(message='Operation will be retried')
 
 
 @decorators.workflow


### PR DESCRIPTION
no reason to just sleep for 3 seconds. The tests themselves do pass
`task_retry_interval=0`, but #845 made it so that the retry_after
passed into ctx.operation.retry() is actually not ignored. So it
made tests just sleep for no reason. So let's not.