### PR TITLE
Remove strong typing from async client

### DIFF
--- a/cloudify_async_client/client.py
+++ b/cloudify_async_client/client.py
@@ -4,11 +4,6 @@ import aiohttp
 
 
 class CloudifyAsyncClient:
-    host: str
-    port: int
-    protocol: str
-    headers: dict
-    cert: str
 
     def __init__(self, **kwargs):
         self.host = kwargs.pop('host', 'localhost')


### PR DESCRIPTION
Strong typing is a new feature in Python. This has caused syntax error with some of our agents which use older Python versions that don't support it:

> `[2021-10-24T23:38:55.578Z] 2021-10-24 23:38:50 URL:https://192.168.42.224:53333/resources/packages/agents/ubuntu-xenial-agent.tar.gz [11661752/11661752] -> "/tmp/tmp.Wd0ppqQ81c/agent.tar.gz" [1]
> [2021-10-24T23:38:55.578Z] Traceback (most recent call last):
> [2021-10-24T23:38:55.578Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/bin/cfy-agent", line 8, in <module>
> [2021-10-24T23:38:55.578Z]     from cloudify_agent.shell.main import main
> [2021-10-24T23:38:55.578Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/lib/python3.5/site-packages/cloudify_agent/shell/main.py", line 22, in <module>
> [2021-10-24T23:38:55.578Z]     from cloudify_agent.api.utils import (
> [2021-10-24T23:38:55.578Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/lib/python3.5/site-packages/cloudify_agent/api/utils.py", line 31, in <module>
> [2021-10-24T23:38:55.578Z]     from cloudify.cluster import CloudifyClusterClient
> [2021-10-24T23:38:55.578Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/lib/python3.5/site-packages/cloudify/cluster.py", line 24, in <module>
> [2021-10-24T23:38:55.578Z]     from cloudify_rest_client import CloudifyClient
> [2021-10-24T23:38:55.578Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/lib/python3.5/site-packages/cloudify_rest_client/__init__.py", line 19, in <module>
> [2021-10-24T23:38:55.578Z]     from cloudify_rest_client.client import CloudifyClient  # noqa
> [2021-10-24T23:38:55.578Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/lib/python3.5/site-packages/cloudify_rest_client/client.py", line 85, in <module>
> [2021-10-24T23:38:55.579Z]     from cloudify_async_client.audit_log import AuditLogAsyncClient
> [2021-10-24T23:38:55.579Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/lib/python3.5/site-packages/cloudify_async_client/__init__.py", line 1, in <module>
> [2021-10-24T23:38:55.579Z]     from cloudify_async_client.client import CloudifyAsyncClient  # noqa
> [2021-10-24T23:38:55.579Z]   File "/opt/cloudify-agent-6.3.0-.dev1/vm_nd9wnf/env/lib/python3.5/site-packages/cloudify_async_client/client.py", line 7
> [2021-10-24T23:38:55.579Z]     host: str
> [2021-10-24T23:38:55.579Z]         ^
> [2021-10-24T23:38:55.579Z] SyntaxError: invalid syntax