### PR TITLE
Workflow context: handle empty nodes/instances

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -904,9 +904,9 @@ class WorkflowNodesAndInstancesContainer(object):
         self.workflow_context = workflow_context
         self._nodes = None
         self._node_instances = None
-        if raw_nodes:
+        if raw_nodes is not None:
             self._load_nodes(raw_nodes)
-        if raw_instances:
+        if raw_instances is not None:
             self._load_instances(raw_instances)
 
     def _load_nodes(self, raw_nodes):


### PR DESCRIPTION
"Load" the nodes&instances also when they're empty, so that
`self._nodes` is an empty dict rather than None, so that accessing
`.nodes` is still possible and doesn't throw a TypeError, even if
there's no nodes.