### PR TITLE
Pin aiothhp==3.7.4.post0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ else:
     install_requires += ['pika==1.1.0', 'requests>=2.25.0,<3.0.0', ]
 
 if sys.version_info[:2] >= (3, 6):
-    install_requires += ['aiohttp>=3.7.4.post0,<4.0.0']
+    install_requires += ['aiohttp==3.7.4.post0']
 
 try:
     from collections import OrderedDict  # NOQA


### PR DESCRIPTION
This is required since aiohttp 3.8.0 handles type hinting more strictly:
https://github.com/aio-libs/aiohttp/pull/5267/files
which leads to the following error:

```
> `
> [2021-11-01T08:31:48.662Z]     import aiohttp
> [2021-11-01T08:31:48.662Z] py3env/lib/python3.6/site-packages/aiohttp/__init__.py:6: in <module>
> [2021-11-01T08:31:48.662Z]     from .client import (
> [2021-11-01T08:31:48.662Z] py3env/lib/python3.6/site-packages/aiohttp/client.py:36: in <module>
> [2021-11-01T08:31:48.662Z]     from . import hdrs, http, payload
> [2021-11-01T08:31:48.662Z] py3env/lib/python3.6/site-packages/aiohttp/http.py:7: in <module>
> [2021-11-01T08:31:48.662Z]     from .http_parser import (
> [2021-11-01T08:31:48.662Z] py3env/lib/python3.6/site-packages/aiohttp/http_parser.py:41: in <module>
> [2021-11-01T08:31:48.662Z]     from .streams import EMPTY_PAYLOAD, StreamReader
> [2021-11-01T08:31:48.662Z] py3env/lib/python3.6/site-packages/aiohttp/streams.py:4: in <module>
> [2021-11-01T08:31:48.662Z]     from typing import Awaitable, Callable, Deque, Generic, List, Optional, Tuple, TypeVar
> [2021-11-01T08:31:48.662Z] E   ImportError: cannot import name 'Deque'
> `
```

Looks like they will fix it in the next release, then we can revert this pin:
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/streams.py