### PR TITLE
RD-3272 workflow-ctx: don't break on None relationships

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -212,12 +212,13 @@ class CloudifyWorkflowNodeInstance(object):
         self._node_instance = node_instance
         # Directly contained node instances. Filled in the context's __init__()
         self._contained_instances = []
-        self._relationship_instances = OrderedDict(
-            (relationship_instance['target_id'],
-                CloudifyWorkflowRelationshipInstance(
-                    self.ctx, self, nodes_and_instances,
-                    relationship_instance))
-            for relationship_instance in node_instance.relationships)
+        self._relationship_instances = OrderedDict()
+        for relationship in node_instance.relationships:
+            target_id = relationship['target_id']
+            rel_instance = CloudifyWorkflowRelationshipInstance(
+                self.ctx, self, nodes_and_instances, relationship)
+            if rel_instance.relationship is not None:
+                self._relationship_instances[target_id] = rel_instance
 
         # adding the node instance to the node instances map
         node._node_instances[self.id] = self


### PR DESCRIPTION
Relationships in principle shouldn't be None, but if they happen to
be inserted like that, don't just break in a weird place in the
code, just treat it as nonexistent.