### PR TITLE
RD-3435 More deployment details in context

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -283,6 +283,14 @@ class DeploymentContext(EntityContext):
     def runtime_only_evaluation(self):
         return self._context.get('runtime_only_evaluation')
 
+    @property
+    def display_name(self):
+        return self._context.get('deployment_display_name')
+
+    @property
+    def creator(self):
+        return self._context.get('deployment_creator')
+
 
 class NodeContext(EntityContext):
 

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -987,7 +987,9 @@ class CloudifyWorkflowContext(_WorkflowContextBase):
         )._build_cloudify_context(*args)
         context.update({
             'blueprint_id': self.blueprint.id,
-            'deployment_id': self.deployment.id
+            'deployment_id': self.deployment.id,
+            'deployment_display_name': self.deployment.display_name,
+            'deployment_creator': self.deployment.creator,
         })
         return context
 


### PR DESCRIPTION
Make two more attributes available in the workflow context:
* `ctx.deployment.display_name`,
* `ctx.deployment.creator`.