### PR TITLE
RD-3435 More deployment details in context

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -335,6 +335,11 @@ class NodeContext(EntityContext):
         self._get_node_if_needed()
         return self._node.type_hierarchy
 
+    @property
+    def number_of_instances(self):
+        self._get_node_if_needed()
+        return self._node.number_of_instances
+
 
 class NodeInstanceContext(EntityContext):
     def __init__(self, *args, **kwargs):
@@ -345,6 +350,7 @@ class NodeInstanceContext(EntityContext):
         self._node_instance = None
         self._host_ip = None
         self._relationships = None
+        self._scaling_groups = []
 
     def _get_node_instance(self):
         self._node_instance = self._endpoint.get_node_instance(self.id)
@@ -375,6 +381,11 @@ class NodeInstanceContext(EntityContext):
         """
         self._get_node_instance_if_needed()
         return self._node_instance.runtime_properties
+
+    @property
+    def scaling_groups(self):
+        self._get_node_instance_if_needed()
+        return self._node_instance.scaling_groups
 
     @runtime_properties.setter
     def runtime_properties(self, new_properties):

--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -39,7 +39,8 @@ class NodeInstance(object):
                  version=None,
                  host_id=None,
                  relationships=None,
-                 index=None):
+                 index=None,
+                 scaling_groups=None):
         self.id = node_instance_id
         self._node_id = node_id
         self._runtime_properties = \
@@ -49,6 +50,7 @@ class NodeInstance(object):
         self._host_id = host_id
         self._relationships = relationships
         self._index = index
+        self._scaling_groups = scaling_groups
 
     def get(self, key):
         return self._runtime_properties.get(key)
@@ -123,6 +125,10 @@ class NodeInstance(object):
     @property
     def index(self):
         return self._index
+
+    @property
+    def scaling_groups(self):
+        return self._scaling_groups
 
 
 def get_rest_client(tenant=None, api_token=None):
@@ -389,7 +395,8 @@ def get_node_instance(node_instance_id, evaluate_functions=False, client=None):
                         version=instance.version,
                         host_id=instance.host_id,
                         relationships=instance.relationships,
-                        index=instance.index)
+                        index=instance.index,
+                        scaling_groups=instance.scaling_groups)
 
 
 def update_node_instance(node_instance, client=None):

--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -128,7 +128,7 @@ class NodeInstance(object):
 
     @property
     def scaling_groups(self):
-        return self._scaling_groups
+        return {g['id']: g['name'] for g in self._scaling_groups}
 
 
 def get_rest_client(tenant=None, api_token=None):


### PR DESCRIPTION
Make two more attributes available in the workflow context:
* `ctx.node.number_of_instances`,
* `ctx.instance.scaling_groups`.