### PR TITLE
RD-3559 Allow inputs other than string for string_{lower,upper}

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -1123,24 +1123,35 @@ class StringReplace(Function, ValidateArgumentMixin):
         self.haystack = None
         self.needle = None
         self.replacement = None
+        self.count = None
         super(StringReplace, self).__init__(*args, **kwargs)
 
     def parse_args(self, args):
-        if not isinstance(args, list) or len(args) != 3:
+        if not isinstance(args, list) or not 3 <= len(args) <= 4:
             raise exceptions.FunctionValidationError(
-                self.name, 'should be called with exactly three parameters')
+                self.name, 'should be called with three or four parameters')
         self.haystack, self.needle, self.replacement = \
             args[0], args[1], args[2]
+        if len(args) > 3:
+            self.count = args[3]
 
     def validate(self, plan):
         self._validate_argument('haystack', validation_only=True)
         self._validate_argument('needle', validation_only=True)
         self._validate_argument('replacement', validation_only=True)
+        if self.count is not None:
+            self._validate_argument('count',
+                                    argument_type=int,
+                                    validation_only=True)
 
     def evaluate(self, handler):
         self._validate_argument('haystack')
         self._validate_argument('needle')
         self._validate_argument('replacement')
+        if self.count is not None:
+            self._validate_argument('count', argument_type=int)
+            return self.haystack.replace(self.needle, self.replacement,
+                                         self.count)
         return self.haystack.replace(self.needle, self.replacement)
 
 

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -1187,11 +1187,6 @@ class StringLower(Function, ValidateArgumentMixin):
         super(StringLower, self).__init__(*args, **kwargs)
 
     def parse_args(self, args):
-        if not isinstance(args, text_type):
-            raise exceptions.FunctionValidationError(
-                "{0} function should be called with exactly one parameter: "
-                "a string to be made lowercase"
-                .format(self.name))
         self.input = args
 
     def validate(self, plan):
@@ -1209,11 +1204,6 @@ class StringUpper(Function, ValidateArgumentMixin):
         super(StringUpper, self).__init__(*args, **kwargs)
 
     def parse_args(self, args):
-        if not isinstance(args, text_type):
-            raise exceptions.FunctionValidationError(
-                "{0} function should be called with exactly one parameter: "
-                "a string to be made uppercase"
-                .format(self.name))
         self.input = args
 
     def validate(self, plan):

--- a/dsl_parser/tests/test_functions.py
+++ b/dsl_parser/tests/test_functions.py
@@ -2028,13 +2028,42 @@ deployment_settings:
         display_name = plan['deployment_settings']['display_name']
         assert display_name == 'Quick racoon jumps'
 
-    def test_invalid_number_of_params(self):
+    def test_correct_with_count(self):
         yaml = """
 deployment_settings:
-    display_name: {string_replace: ['Quick fox jumps', 'fox', 'racoon', 'hen']}
+    display_name:
+        string_replace:
+            - "Buzz fox is the best fox in the fox town"
+            - "fox"
+            - "dog"
+            - 2
+        """
+        plan = prepare_deployment_plan(self.parse(yaml))
+        display_name = plan['deployment_settings']['display_name']
+        assert display_name == 'Buzz dog is the best dog in the fox town'
+
+    def test_invalid_param_type(self):
+        yaml = """
+deployment_settings:
+    display_name:
+        string_replace:
+            - "Quick fox jumps"
+            - "fox"
+            - "racoon"
+            - "hen"
         """
         with self.assertRaisesRegex(exceptions.FunctionValidationError,
-                                    'string_replace.*exactly three'):
+                                    r"string_replace.*count.*should be of "
+                                    r"type.*'int'"):
+            prepare_deployment_plan(self.parse(yaml))
+
+    def test_invalid_param_number(self):
+        yaml = """
+deployment_settings:
+    display_name: { string_replace: [ "Quick fox jumps", "fox" ] }
+        """
+        with self.assertRaisesRegex(exceptions.FunctionValidationError,
+                                    "string_replace.*three or four"):
             prepare_deployment_plan(self.parse(yaml))
 
 


### PR DESCRIPTION
... it's basically to let string_lower and string_upper opearte on other
intrinsic functions like:

```
string_lower: { get_property: [x, some_string] }
```