### PR TITLE
RD-3739 Add ctx.operation.relationship to the context

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -1080,6 +1080,10 @@ class OperationContext(object):
         """The maximum number of retries the operation can have."""
         return self._operation_context.get('max_retries')
 
+    @property
+    def interface(self):
+        return self._operation_context.get('interface')
+
     def retry(self, message=None, retry_after=None):
         """Specifies that this operation should be retried.
 

--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -1081,8 +1081,8 @@ class OperationContext(object):
         return self._operation_context.get('max_retries')
 
     @property
-    def interface(self):
-        return self._operation_context.get('interface')
+    def relationship(self):
+        return self._operation_context.get('relationship')
 
     def retry(self, message=None, retry_after=None):
         """Specifies that this operation should be retried.

--- a/cloudify/tests/resources/blueprints/relationship_context.yaml
+++ b/cloudify/tests/resources/blueprints/relationship_context.yaml
@@ -32,8 +32,8 @@ relationships:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_relationships
                 assert_capabilities:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_capabilities
-                assert_interfaces:
-                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_interfaces
+                assert_operations:
+                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_operations
 
         target_interfaces:
             test:
@@ -45,8 +45,8 @@ relationships:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_relationships
                 assert_capabilities:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_capabilities
-                assert_interfaces:
-                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_interfaces
+                assert_operations:
+                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_operations
 
     cloudify.relationships.contained_in2:
         derived_from: cloudify.relationships.contained_in
@@ -70,8 +70,8 @@ node_types:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_immutable_properties
                 assert_capabilities:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_capabilities
-                assert_interfaces:
-                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_interfaces
+                assert_operations:
+                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_operations
                 asset_2_hops:
                     implementation: mock.cloudify.tests.test_ctx_relationships.asset_2_hops
         properties:

--- a/cloudify/tests/resources/blueprints/relationship_context.yaml
+++ b/cloudify/tests/resources/blueprints/relationship_context.yaml
@@ -32,6 +32,8 @@ relationships:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_relationships
                 assert_capabilities:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_capabilities
+                assert_interfaces:
+                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_interfaces
 
         target_interfaces:
             test:
@@ -43,6 +45,8 @@ relationships:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_relationships
                 assert_capabilities:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_capabilities
+                assert_interfaces:
+                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_interfaces
 
     cloudify.relationships.contained_in2:
         derived_from: cloudify.relationships.contained_in
@@ -66,6 +70,8 @@ node_types:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_immutable_properties
                 assert_capabilities:
                     implementation: mock.cloudify.tests.test_ctx_relationships.assert_capabilities
+                assert_interfaces:
+                    implementation: mock.cloudify.tests.test_ctx_relationships.assert_interfaces
                 asset_2_hops:
                     implementation: mock.cloudify.tests.test_ctx_relationships.asset_2_hops
         properties:
@@ -91,4 +97,3 @@ workflows:
         mapping: mock.cloudify.tests.test_ctx_relationships.execute_task
         parameters:
             task: {}
-

--- a/cloudify/tests/test_ctx_relationships.py
+++ b/cloudify/tests/test_ctx_relationships.py
@@ -224,14 +224,14 @@ class TestContextRelationship(testtools.TestCase):
         self._assert_node2_rel(instance.runtime_properties['result'])
 
     @workflow_test(context_blueprint_path)
-    def test_source_interfaces(self, cfy_local):
+    def test_source_relationship(self, cfy_local):
         with warnings.catch_warnings(record=True):
-            self._run(cfy_local, 'assert_interfaces', 'source')
+            self._run(cfy_local, 'assert_operations', 'source')
 
     @workflow_test(context_blueprint_path)
-    def test_target_interfaces(self, cfy_local):
+    def test_target_relationship(self, cfy_local):
         with warnings.catch_warnings(record=True):
-            self._run(cfy_local, 'assert_interfaces', 'target')
+            self._run(cfy_local, 'assert_operations', 'target')
 
     def _run(self, cfy_local, op, rel, node='node1', kwargs=None):
         kwargs = kwargs or {}
@@ -391,6 +391,6 @@ def asset_2_hops(**_):
 
 
 @operation
-def assert_interfaces(rel=None, **_):
-    iface = operation_ctx.operation.interface
+def assert_operations(rel=None, **_):
+    iface = operation_ctx.operation.relationship
     assert iface == rel

--- a/cloudify/tests/test_ctx_relationships.py
+++ b/cloudify/tests/test_ctx_relationships.py
@@ -223,6 +223,16 @@ class TestContextRelationship(testtools.TestCase):
         instance = [i for i in node_instances if i.node_id == 'node1'][0]
         self._assert_node2_rel(instance.runtime_properties['result'])
 
+    @workflow_test(context_blueprint_path)
+    def test_source_interfaces(self, cfy_local):
+        with warnings.catch_warnings(record=True):
+            self._run(cfy_local, 'assert_interfaces', 'source')
+
+    @workflow_test(context_blueprint_path)
+    def test_target_interfaces(self, cfy_local):
+        with warnings.catch_warnings(record=True):
+            self._run(cfy_local, 'assert_interfaces', 'target')
+
     def _run(self, cfy_local, op, rel, node='node1', kwargs=None):
         kwargs = kwargs or {}
         cfy_local.execute('execute_operation',
@@ -378,3 +388,9 @@ def asset_2_hops(**_):
         for relationship2 in relationship.target.instance.relationships:
             result.append(_extract_relationship(relationship2))
     operation_ctx.instance.runtime_properties['result'] = result
+
+
+@operation
+def assert_interfaces(rel=None, **_):
+    iface = operation_ctx.operation.interface
+    assert iface == rel

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -664,6 +664,9 @@ class _WorkflowContextBase(object):
                 'node_name': related_node_instance.node_id,
                 'is_target': related_node_instance.id in relationships
             }
+            node_context['operation']['interface'] = \
+                'source' if related_node_instance.id in relationships \
+                else 'target'
 
         final_kwargs = self._merge_dicts(merged_from=kwargs,
                                          merged_into=operation_properties,

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -664,7 +664,7 @@ class _WorkflowContextBase(object):
                 'node_name': related_node_instance.node_id,
                 'is_target': related_node_instance.id in relationships
             }
-            node_context['operation']['interface'] = \
+            node_context['operation']['relationship'] = \
                 'source' if related_node_instance.id in relationships \
                 else 'target'
 


### PR DESCRIPTION
The parameter is set for relationships and is either 'target' or
'source'.