### PR TITLE
RD-3675 Add the check_status workflow

### DIFF
--- a/cloudify/tests/resources/blueprints/minimal_types.yaml
+++ b/cloudify/tests/resources/blueprints/minimal_types.yaml
@@ -293,3 +293,6 @@ workflows:
         type: boolean
         description: >
           Whether rollback to resolved state or full uninstall.
+
+  check_status:
+    mapping: default_workflows.cloudify.plugins.workflows.check_status

--- a/cloudify/tests/resources/blueprints/test-check-status.yaml
+++ b/cloudify/tests/resources/blueprints/test-check-status.yaml
@@ -1,0 +1,26 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - minimal_types.yaml
+
+plugins:
+    mock:
+        executor: central_deployment_agent
+        install: false
+
+node_templates:
+  node_failing:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.validation:
+        check_status: mock.cloudify.tests.test_builtin_workflows.fail_op
+  node_passing:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.validation:
+        check_status: mock.cloudify.tests.test_builtin_workflows.node_operation
+  node_undefined:
+    type: cloudify.nodes.Root
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: node_failing

--- a/cloudify/workflows/local.py
+++ b/cloudify/workflows/local.py
@@ -237,6 +237,7 @@ def _prepare_nodes_and_instances(nodes, node_instances, ignored_modules):
     for node_instance in node_instances:
         node_instance['version'] = 0
         node_instance['runtime_properties'] = {}
+        node_instance['system_properties'] = {}
         node_instance['node_id'] = node_instance['name']
         if 'relationships' not in node_instance:
             node_instance['relationships'] = []
@@ -401,10 +402,13 @@ class _Storage(object):
                              node_instance_id,
                              version,
                              runtime_properties=None,
-                             state=None):
+                             system_properties=None,
+                             state=None,
+                             relationships=None,
+                             force=False):
         with self._lock(node_instance_id):
             instance = self.get_node_instance(node_instance_id)
-            if state is None and version != instance['version']:
+            if not force and state is None and version != instance['version']:
                 raise StorageConflictError('version {0} does not match '
                                            'current version of '
                                            'node instance {1} which is {2}'
@@ -415,6 +419,8 @@ class _Storage(object):
                 instance['version'] += 1
             if runtime_properties is not None:
                 instance['runtime_properties'] = runtime_properties
+            if system_properties is not None:
+                instance['system_properties'] = system_properties
             if state is not None:
                 instance['state'] = state
             self._store_instance(instance)

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -373,10 +373,14 @@ class TaskDependencyGraph(object):
         if handler_result.action == tasks.HandlerResult.HANDLER_FAIL:
             if isinstance(task, SubgraphTask) and task.failed_task:
                 task = task.failed_task
-            message = "Task failed '{0}': {1} ".format(
-                task.name, _task_error_causes_text(task))
+            message = "Task failed '{0}'".format(task.name)
+            causes_text = _task_error_causes_text(task)
+            if causes_text:
+                message = '{0}: {1}'.format(message, causes_text)
             if result and not isinstance(result, tasks.HandlerResult):
-                message = '{0} -> {1}'.format(message, result)
+                result = str(result)
+                if result:
+                    message = '{0} -> {1}'.format(message, result)
             if self._error is None:
                 self._error = WorkflowFailed(message)
                 self._error_time = time.time()

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1624,7 +1624,6 @@ class LocalCloudifyWorkflowContextHandler(CloudifyWorkflowContextHandler):
         return self.storage.update_node_instance(*args, **kwargs)
 
 
-
 class Modification(object):
 
     def __init__(self, workflow_ctx, modification):

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -908,6 +908,26 @@ class _WorkflowContextBase(object):
             execution_id = self.execution_id
         return self.internal.handler.get_execution(execution_id)
 
+    def update_node_instance(
+        self,
+        node_instance_id,
+        version=None,
+        state=None,
+        runtime_properties=None,
+        system_properties=None,
+        relationships=None,
+        force=False,
+    ):
+        return self.internal.handler.update_node_instance(
+            node_instance_id=node_instance_id,
+            version=version,
+            state=state,
+            runtime_properties=runtime_properties,
+            system_properties=system_properties,
+            relationships=relationships,
+            force=force,
+        )
+
 
 class WorkflowNodesAndInstancesContainer(object):
     def __init__(self, workflow_context, raw_nodes=None, raw_instances=None):
@@ -1273,6 +1293,18 @@ class CloudifyWorkflowContextHandler(object):
     def get_plugin(self, plugin_spec):
         raise NotImplementedError('Implemented by subclasses')
 
+    def update_node_instance(
+        self,
+        node_instance_id,
+        version,
+        state=None,
+        runtime_properties=None,
+        system_properties=None,
+        relationships=None,
+        force=False,
+    ):
+        raise NotImplementedError('Implemented by subclasses')
+
 
 class RemoteContextHandler(CloudifyWorkflowContextHandler):
     def __init__(self, *args, **kwargs):
@@ -1280,6 +1312,7 @@ class RemoteContextHandler(CloudifyWorkflowContextHandler):
         self._rest_client = None
         self._dispatcher = TaskDispatcher(self.workflow_ctx)
         self._plugins_cache = {}
+        self._bootstrap_context = None
 
     @property
     def rest_client(self):
@@ -1293,7 +1326,9 @@ class RemoteContextHandler(CloudifyWorkflowContextHandler):
 
     @property
     def bootstrap_context(self):
-        return get_bootstrap_context()
+        if self._bootstrap_context is None:
+            self._bootstrap_context = get_bootstrap_context()
+        return self._bootstrap_context
 
     def get_send_task_event_func(self, task):
         return events.send_task_event_func_remote
@@ -1420,6 +1455,9 @@ class RemoteContextHandler(CloudifyWorkflowContextHandler):
                 plugin['tenant_name'] = managed_plugins[0]['tenant_name']
             self._plugins_cache[key] = plugin
         return self._plugins_cache[key]
+
+    def update_node_instance(self, *args, **kwargs):
+        return self.rest_client.node_instances.update(*args, **kwargs)
 
 
 class RemoteCloudifyWorkflowContextHandler(RemoteContextHandler):
@@ -1581,6 +1619,10 @@ class LocalCloudifyWorkflowContextHandler(CloudifyWorkflowContextHandler):
 
     def get_plugin(self, plugin):
         return plugin
+
+    def update_node_instance(self, *args, **kwargs):
+        return self.storage.update_node_instance(*args, **kwargs)
+
 
 
 class Modification(object):

--- a/cloudify_rest_client/node_instances.py
+++ b/cloudify_rest_client/node_instances.py
@@ -146,6 +146,7 @@ class NodeInstancesClient(object):
                node_instance_id,
                state=None,
                runtime_properties=None,
+               system_properties=None,
                version=1,
                force=False,
                relationships=None):
@@ -155,6 +156,8 @@ class NodeInstancesClient(object):
         :param node_instance_id: The identifier of the node instance to update.
         :param state: The updated state.
         :param runtime_properties: The updated runtime properties.
+        :param system_properties: Like runtime_properties, but only managed
+            by Cloudify itself internally.
         :param version: Current version value of this node instance in
          Cloudify's storage (used for optimistic locking).
         :param force: ignore the version check - use with caution
@@ -169,6 +172,8 @@ class NodeInstancesClient(object):
         data = {'version': version}
         if runtime_properties is not None:
             data['runtime_properties'] = runtime_properties
+        if system_properties is not None:
+            data['system_properties'] = system_properties
         if state is not None:
             data['state'] = state
         if relationships is not None:


### PR DESCRIPTION
The workflow is simple enough, but do see commits separately.
Anyway, it's very similar to execute_operation, but it will only run
the one specific task, and it will also store the results in
system_properties.

For now, the results are just the boolean "ok". We'll be adding more
data in there soon.