### PR TITLE
RD-3675 Default version to 0

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -914,7 +914,7 @@ class _WorkflowContextBase(object):
     def update_node_instance(
         self,
         node_instance_id,
-        version=None,
+        version=0,
         state=None,
         runtime_properties=None,
         system_properties=None,


### PR DESCRIPTION
None is an invalid default, because the restservice checks the type.