### PR TITLE
rest-client: declare ni.system_properties

### DIFF
--- a/cloudify_rest_client/node_instances.py
+++ b/cloudify_rest_client/node_instances.py
@@ -72,6 +72,13 @@ class NodeInstance(dict):
         return self.get('runtime_properties')
 
     @property
+    def system_properties(self):
+        """
+        :return: The system properties of the node instance.
+        """
+        return self.get('system_properties')
+
+    @property
     def state(self):
         """
         :return: The current state of the node instance.


### PR DESCRIPTION
Just declare that field. It exists, no reason not to expose it on the
rest client objects.