### PR TITLE
RD-3748 Pass tenant_name when creating IDDs

### DIFF
--- a/cloudify/deployment_dependencies.py
+++ b/cloudify/deployment_dependencies.py
@@ -19,6 +19,7 @@ TARGET_DEPLOYMENT = 'target_deployment'
 TARGET_DEPLOYMENT_FUNC = 'target_deployment_func'
 EXTERNAL_SOURCE = 'external_source'
 EXTERNAL_TARGET = 'external_target'
+TENANT_NAME = 'tenant_name'
 
 
 def create_deployment_dependency(dependency_creator,
@@ -26,7 +27,8 @@ def create_deployment_dependency(dependency_creator,
                                  target_deployment=None,
                                  target_deployment_func=None,
                                  external_source=None,
-                                 external_target=None):
+                                 external_target=None,
+                                 tenant_name=None):
     dependency = {
         DEPENDENCY_CREATOR: dependency_creator,
     }
@@ -40,6 +42,8 @@ def create_deployment_dependency(dependency_creator,
         dependency[EXTERNAL_SOURCE] = external_source
     if external_target:
         dependency[EXTERNAL_TARGET] = external_target
+    if tenant_name:
+        dependency[TENANT_NAME] = tenant_name
     return dependency
 
 

--- a/cloudify_rest_client/inter_deployment_dependencies.py
+++ b/cloudify_rest_client/inter_deployment_dependencies.py
@@ -132,7 +132,7 @@ class InterDeploymentDependencyClient(object):
 
     def delete(self, dependency_creator, source_deployment, target_deployment,
                is_component_deletion=False, external_source=None,
-               external_target=None):
+               external_target=None, tenant_name=None):
         """Deletes an inter-deployment dependency.
 
         :param dependency_creator: a string representing the entity that
@@ -151,13 +151,16 @@ class InterDeploymentDependencyClient(object):
         :param external_target: if the source deployment uses an external
         resource as target, pass here a JSON containing the target deployment
         metadata, i.e. deployment name, tenant name, and the manager host(s).
+        :param tenant_name: name of a tenant that's going to be used to look
+        for source/target deployments.
         :return: an InterDeploymentDependency object.
         """
         data = create_deployment_dependency(dependency_creator,
                                             source_deployment,
                                             target_deployment,
                                             external_source=external_source,
-                                            external_target=external_target)
+                                            external_target=external_target,
+                                            tenant_name=tenant_name)
         data['is_component_deletion'] = is_component_deletion
         self.api.delete('/{self._uri_prefix}'.format(self=self), data=data)
 

--- a/cloudify_rest_client/inter_deployment_dependencies.py
+++ b/cloudify_rest_client/inter_deployment_dependencies.py
@@ -62,7 +62,7 @@ class InterDeploymentDependencyClient(object):
 
     def create(self, dependency_creator, source_deployment, target_deployment,
                external_source=None, external_target=None,
-               target_deployment_func=None):
+               target_deployment_func=None, tenant_name=None):
         """Creates an inter-deployment dependency.
 
         :param dependency_creator: a string representing the entity that
@@ -80,6 +80,8 @@ class InterDeploymentDependencyClient(object):
         metadata, i.e. deployment name, tenant name, and the manager host(s).
         :param target_deployment_func: a function used to determine the target
         deployment.
+        :param tenant_name: name of a tenant that's going to be used to look
+        for source/target deployments.
         :return: an InterDeploymentDependency object.
         """
         data = create_deployment_dependency(dependency_creator,
@@ -87,7 +89,8 @@ class InterDeploymentDependencyClient(object):
                                             target_deployment,
                                             target_deployment_func,
                                             external_source,
-                                            external_target)
+                                            external_target,
+                                            tenant_name)
         response = self.api.put(
             '/{self._uri_prefix}'.format(self=self), data=data)
         return self._wrapper_cls(response)
@@ -118,7 +121,6 @@ class InterDeploymentDependencyClient(object):
          dependencies descriptions, but without a source_deployment(_id).
         :return: a list of created InterDeploymentDependencies IDs.
         """
-        # from celery.contrib import rdb; rdb.set_trace()  # noqa
         response = self.api.put(
             '/deployments/{0}/inter-deployment-dependencies'.format(
                 source_deployment_id),


### PR DESCRIPTION
... because of times when multiple tenants use the same deployment_id
for different deployment and we should be able to find out which one
should be used.