### PR TITLE
RD-4035 Only mark operations as stored, if they were really stored

### DIFF
--- a/cloudify/tests/test_task_serialize.py
+++ b/cloudify/tests/test_task_serialize.py
@@ -88,12 +88,6 @@ class TestSerialize(TestCase):
             'execution_token': 'mock_token'
         })
 
-    def test_marks_as_stored(self):
-        task = _make_remote_task()
-        self.assertFalse(task.stored)
-        task.dump()
-        self.assertTrue(task.stored)
-
     def test_handler_serialize_func(self):
         task = _make_remote_task()
         task.on_success = _on_success_func

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -238,7 +238,6 @@ class WorkflowTask(object):
                 'Cannot deserialize: {0!r}'.format(data))
 
     def dump(self):
-        self.stored = True
         return {
             'id': self.id,
             'name': self.name,

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -215,6 +215,8 @@ class TaskDependencyGraph(object):
         if stored_graph:
             self.id = stored_graph['id']
             self._stored = True
+            for task in self._tasks.values():
+                task.stored = True
 
     @property
     def tasks(self):
@@ -377,11 +379,12 @@ class TaskDependencyGraph(object):
         elif handler_result.action == tasks.HandlerResult.HANDLER_RETRY:
             new_task = handler_result.retried_task
             if self.id is not None:
-                self.ctx.store_operation(
+                stored = self.ctx.store_operation(
                     new_task,
                     [dep.id for dep in self._dependencies[task]],
                     self.id)
-                new_task.stored = True
+                if stored:
+                    new_task.stored = True
             self.add_task(new_task)
             for dependency in self._dependencies[task]:
                 self.add_dependency(new_task, self.get_task(dependency))

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -1533,7 +1533,7 @@ class RemoteContextHandler(CloudifyWorkflowContextHandler):
 
     def store_operation(self, graph_id, dependencies,
                         id, name, type, parameters, **kwargs):
-        self.rest_client.operations.create(
+        return self.rest_client.operations.create(
             operation_id=id,
             graph_id=graph_id,
             name=name,


### PR DESCRIPTION
Local workflows don't store operation, so they shouldn't mark
operations as stored.

If operations are flagged as stored, then they don't emit state-update
events (because the restservice automatically inserts those events)