### PR TITLE
RD-4096 Update: delegate to the new workflow

### DIFF
--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -21,10 +21,8 @@ from datetime import datetime
 from cloudify import constants, utils
 from cloudify.decorators import workflow
 from cloudify.plugins import lifecycle
-from cloudify.manager import get_rest_client
 from cloudify.workflows.tasks_graph import make_or_get_graph
 from cloudify.workflows.tasks import HandlerResult, TASK_SUCCEEDED
-from cloudify.utils import add_plugins_to_install, add_plugins_to_uninstall
 
 
 @workflow(resumable=True)
@@ -937,143 +935,11 @@ def check_drift(ctx, *args, **kwargs):
 
 
 @workflow
-def update(ctx,
-           update_id,
-           added_instance_ids,
-           added_target_instances_ids,
-           removed_instance_ids,
-           remove_target_instance_ids,
-           modified_entity_ids,
-           extended_instance_ids,
-           extend_target_instance_ids,
-           reduced_instance_ids,
-           reduce_target_instance_ids,
-           skip_install,
-           skip_uninstall,
-           ignore_failure=False,
-           install_first=False,
-           node_instances_to_reinstall=None,
-           central_plugins_to_install=None,
-           central_plugins_to_uninstall=None,
-           update_plugins=True):
-    node_instances_to_reinstall = node_instances_to_reinstall or []
-    instances_by_change = {
-        'added_instances': (added_instance_ids, []),
-        'added_target_instances_ids': (added_target_instances_ids, []),
-        'removed_instances': (removed_instance_ids, []),
-        'remove_target_instance_ids': (remove_target_instance_ids, []),
-        'extended_and_target_instances':
-            (extended_instance_ids + extend_target_instance_ids, []),
-        'reduced_and_target_instances':
-            (reduced_instance_ids + reduce_target_instance_ids, []),
-    }
-    for instance in ctx.node_instances:
-        instance_holders = [instance_holder
-                            for _, (changed_ids, instance_holder)
-                            in instances_by_change.items()
-                            if instance.id in changed_ids]
-        for instance_holder in instance_holders:
-            instance_holder.append(instance)
-
-    graph = ctx.graph_mode()
-    to_install = set(instances_by_change['added_instances'][1])
-    to_uninstall = set(instances_by_change['removed_instances'][1])
-
-    def _install():
-        def _install_nodes():
-            if skip_install:
-                return
-            # Adding nodes or node instances should be based on modified
-            # instances
-            lifecycle.install_node_instances(
-                graph=graph,
-                node_instances=to_install,
-                related_nodes=set(
-                    instances_by_change['added_target_instances_ids'][1])
-            )
-
-            # This one as well.
-            lifecycle.execute_establish_relationships(
-                graph=graph,
-                node_instances=set(
-                    instances_by_change['extended_and_target_instances'][1]),
-                modified_relationship_ids=modified_entity_ids['relationship']
-            )
-
-        _install_nodes()
-        _install_plugins_on_agent()
-
-    def _uninstall():
-        def _uninstall_nodes():
-            if skip_uninstall:
-                return
-            lifecycle.execute_unlink_relationships(
-                graph=graph,
-                node_instances=set(
-                    instances_by_change['reduced_and_target_instances'][1]),
-                modified_relationship_ids=modified_entity_ids['relationship']
-            )
-
-            lifecycle.uninstall_node_instances(
-                graph=graph,
-                node_instances=to_uninstall,
-                ignore_failure=ignore_failure,
-                related_nodes=set(
-                    instances_by_change['remove_target_instance_ids'][1])
-            )
-
-        _uninstall_nodes()
-        _uninstall_plugins_on_agent()
-
-    def _reinstall():
-        subgraph = set([])
-        for node_instance_id in node_instances_to_reinstall:
-            subgraph |= ctx.get_node_instance(
-                node_instance_id).get_contained_subgraph()
-        subgraph -= to_uninstall
-        intact_nodes = set(ctx.node_instances) - subgraph - to_uninstall
-        for n in subgraph:
-            for r in n._relationship_instances:
-                if r in removed_instance_ids:
-                    n._relationship_instances.pop(r)
-        lifecycle.reinstall_node_instances(graph=graph,
-                                           node_instances=subgraph,
-                                           related_nodes=intact_nodes,
-                                           ignore_failure=ignore_failure)
-
-    def _uninstall_plugins_on_agent():
-        if not update_plugins:
-            return
-        _handle_plugin_after_update(
-            ctx, modified_entity_ids['plugin'], 'remove')
-
-    def _install_plugins_on_agent():
-        if not update_plugins:
-            return
-        _handle_plugin_after_update(
-            ctx, modified_entity_ids['plugin'], 'add')
-
-    def _update_central_plugins():
-        if not update_plugins:
-            return
-        sequence = graph.sequence()
-        add_plugins_to_uninstall(ctx, central_plugins_to_uninstall, sequence)
-        add_plugins_to_install(ctx, central_plugins_to_install, sequence)
-        graph.execute()
-
-    if install_first:
-        _install()
-        _uninstall()
-    else:
-        _uninstall()
-        _install()
-    _reinstall()
-
-    _update_central_plugins()
-
-    # Finalize the commit (i.e. remove relationships or nodes)
-    client = get_rest_client()
-    client.deployment_updates.finalize_commit(update_id)
+def update(ctx, *args, **kwargs):
+    from cloudify_system_workflows.deployment_update.workflow import (
+        update_deployment
+    )
+    return update_deployment(ctx, *args, **kwargs)
 
 
 @workflow(resumable=True)

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -22,7 +22,6 @@ import mock
 import testtools
 
 from cloudify import exceptions
-from cloudify.plugins import lifecycle
 from cloudify.decorators import operation
 from cloudify.test_utils import workflow_test
 from cloudify.workflows.workflow_context import (Modification,
@@ -532,51 +531,6 @@ class TestSubgraphWorkflowLogic(testtools.TestCase):
             invocations = instance.runtime_properties.get('invocations', [])
             all_invocations += invocations
         self.assertEqual(4, len(all_invocations))
-
-
-def mock_uninstall(graph, node_instances, ignore_failure, related_nodes=None):
-    raise RuntimeError('Test - ignore_failure is: ' + str(ignore_failure))
-
-
-class TestUpdateIgnoreFailure(testtools.TestCase):
-
-    def __init__(self, *args, **kwargs):
-        super(TestUpdateIgnoreFailure, self).__init__(*args, **kwargs)
-        self.original_uninstall = lifecycle.uninstall_node_instances
-
-    def setUp(self):
-        super(TestUpdateIgnoreFailure, self).setUp()
-        lifecycle.uninstall_node_instances = mock_uninstall
-
-    def tearDown(self):
-        lifecycle.uninstall_node_instances = self.original_uninstall
-        super(TestUpdateIgnoreFailure, self).tearDown()
-
-    @workflow_test(path.join(
-        'resources', 'blueprints', 'test-blueprint-ignore-failure.yaml'))
-    def test_update_ignore_failure_false(self, env):
-        try:
-            env.execute('update', parameters={
-                'ignore_failure': False,
-                'modified_entity_ids': {'relationship': ''}
-            })
-        except RuntimeError as e:
-            self.assertEqual('Test - ignore_failure is: False', str(e))
-        else:
-            fail()
-
-    @workflow_test(path.join(
-        'resources', 'blueprints', 'test-blueprint-ignore-failure.yaml'))
-    def test_update_ignore_failure_true(self, env):
-        try:
-            env.execute('update', parameters={
-                'ignore_failure': True,
-                'modified_entity_ids': {'relationship': ''}
-            })
-        except RuntimeError as e:
-            self.assertEqual('Test - ignore_failure is: True', str(e))
-        else:
-            fail()
 
 
 class TestRelationshipOrderInLifecycleWorkflows(testtools.TestCase):


### PR DESCRIPTION
Normally, blueprints are going to use the builtin update workflow
(the one in cloudify_system_workflows);  but old (6.2 and earlier)
blueprints still have the update workflow defined in the yaml, and
those point to this function;  so, let's make this function just call
the builtin one.

Also, remove those tests, because this workflow doesn't live here
anymore.