### PR TITLE
revert pin aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ else:
         'pika==1.1.0',
         'requests>=2.27.1,<3.0.0',
         'fasteners==0.17.3',
-        'aiohttp==3.8.1',
+        'aiohttp==3.7.4',
     ]
     pyyaml_version = '6.0'
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ else:
         'pika==1.1.0',
         'requests>=2.27.1,<3.0.0',
         'fasteners==0.17.3',
-        'aiohttp==3.7.4',
+        'aiohttp==3.7.4.post0',
     ]
     pyyaml_version = '6.0'
 


### PR DESCRIPTION
revert pin aiohttp to latest py3.6 supporting version
See here: https://github.com/cloudify-cosmo/cloudify-common/pull/905
aiohttp 3.8.1 hasn't fixed the Deque import issue yet (fixed in not-yet-released 3.9), so they basically don't support Python 3.6 currently