### PR TITLE
Pin requests to 2.25 for python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if sys.version_info[:3] < (2, 7, 9):
 elif sys.version_info[:2] < (3, 6):
     install_requires += [
         'pika==1.1.0',
-        'requests>=2.27.1,<3.0.0',
+        'requests==2.25.1',
         'fasteners==0.16.3',
     ]
     pyyaml_version = '5.4.1'


### PR DESCRIPTION
Requests 2.26+ drops support for python 3.5, making our ubuntu 16 agent build fail 