### PR TITLE
RD-3973 Stick to PyYAML==5.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,12 @@ if sys.version_info[:3] < (2, 7, 9):
         'requests==2.19.1',
         'fasteners==0.16.3',
     ]
-    pyyaml_version = '5.4.1'
 elif sys.version_info[:2] < (3, 6):
     install_requires += [
         'pika==1.1.0',
         'requests==2.25.1',
         'fasteners==0.16.3',
     ]
-    pyyaml_version = '5.4.1'
 else:
     install_requires += [
         'pika==1.1.0',
@@ -47,7 +45,6 @@ else:
         'fasteners==0.17.3',
         'aiohttp==3.7.4.post0',
     ]
-    pyyaml_version = '6.0'
 
 try:
     from collections import OrderedDict  # NOQA
@@ -90,7 +87,7 @@ setup(
         # for running workflows (in the mgmtworker and the cli), as opposed
         # to eg. just executing operations (in the agent)
         'dispatcher': [
-            'PyYAML=={0}'.format(pyyaml_version),
+            'PyYAML==5.4.1',
             'networkx==1.11',
         ],
         # this is just a hack to allow running unittests on py26.


### PR DESCRIPTION
... because 6.0 is not back compatible making `yaml.load` fail e.g.
here: https://github.com/cloudify-cosmo/cloudify-manager/blob/05a768667f185afeef4d96db2f244493925ee806/rest-service/manager_rest/upload_manager.py#L896