### PR TITLE
RD-4115, RD-4116, RD-4282 `deployment_id` data type

### DIFF
--- a/cloudify_rest_client/inter_deployment_dependencies.py
+++ b/cloudify_rest_client/inter_deployment_dependencies.py
@@ -118,7 +118,6 @@ class InterDeploymentDependencyClient(object):
          dependencies descriptions, but without a source_deployment(_id).
         :return: a list of created InterDeploymentDependencies IDs.
         """
-        # from celery.contrib import rdb; rdb.set_trace()  # noqa
         response = self.api.put(
             '/deployments/{0}/inter-deployment-dependencies'.format(
                 source_deployment_id),

--- a/dsl_parser/constants.py
+++ b/dsl_parser/constants.py
@@ -96,7 +96,7 @@ RESOLVER_IMPLEMENTATION_KEY = 'implementation'
 RESLOVER_PARAMETERS_KEY = 'parameters'
 
 USER_PRIMITIVE_TYPES = ['string', 'integer', 'float', 'boolean', 'list',
-                        'dict', 'regex', 'secret']
+                        'dict', 'regex', 'secret', 'deployment_id']
 PLUGIN_DSL_KEYS_NOT_FROM_YAML = ['blueprint_labels', 'labels', 'resource_tags']
 PLUGIN_DSL_KEYS_READ_FROM_DB = PLUGIN_DSL_KEYS_NOT_FROM_YAML
 PLUGIN_DSL_KEYS_ADD_VALUES_NODE = ['blueprint_labels', 'labels']

--- a/dsl_parser/tests/namespace/test_functions.py
+++ b/dsl_parser/tests/namespace/test_functions.py
@@ -1006,7 +1006,8 @@ imports:
     -   {0}--{1}
 """.format('test', import_file_name)
 
-        plan = prepare_deployment_plan(self.parse(main_yaml), self.get_secret)
+        plan = prepare_deployment_plan(self.parse(main_yaml),
+                                       get_secret_method=self.get_secret)
         self.assertEqual(
             {'get_secret': 'secret'},
             plan[constants.OUTPUTS]['test--port']['value'])
@@ -1247,7 +1248,7 @@ node_templates:
     type: my.node.type
 """
         plan = prepare_deployment_plan(self.parse(blueprint_yaml),
-                                       self.get_secret)
+                                       get_secret_method=self.get_secret)
         self.assertEqual(
             {'get_secret': 'test_base_url'},
             plan[constants.INPUTS].get('test_config').get('base_url')
@@ -1345,7 +1346,7 @@ node_templates:
         username: Benoit
 """
         plan = prepare_deployment_plan(self.parse(blueprint_yaml),
-                                       self.get_secret)
+                                       get_secret_method=self.get_secret)
         self.assertEqual(1, len(plan[constants.NODES]))
         plan_properties = plan[constants.NODES][0][constants.PROPERTIES]
         self.assertEqual(
@@ -1451,7 +1452,7 @@ node_templates:
     type: my.node.type
 """
         plan = prepare_deployment_plan(self.parse(blueprint_yaml),
-                                       self.get_secret)
+                                       get_secret_method=self.get_secret)
         self.assertEqual(1, len(plan[constants.NODES]))
         plan_properties = plan[constants.NODES][0][constants.PROPERTIES]
         self.assertEqual(

--- a/dsl_parser/tests/test_get_secret.py
+++ b/dsl_parser/tests/test_get_secret.py
@@ -144,7 +144,8 @@ node_templates:
                             inputs:
                                 a: { get_secret: target_op_secret_id }
 """
-        parsed = prepare_deployment_plan(self.parse(yaml), self.get_secret)
+        parsed = prepare_deployment_plan(self.parse(yaml),
+                                         get_secret_method=self.get_secret)
         webserver_node = None
         for node in parsed.node_templates:
             if node['id'] == 'webserver':
@@ -165,7 +166,7 @@ node_templates:
     def test_validate_secrets_all_valid(self):
         get_secret_mock = Mock(return_value='secret_value')
         parsed = prepare_deployment_plan(self.parse_1_3(self.secrets_yaml),
-                                         get_secret_mock)
+                                         get_secret_method=get_secret_mock)
         self.assertTrue(get_secret_mock.called)
         self.assertFalse(hasattr(parsed, 'secrets'))
 
@@ -183,7 +184,7 @@ node_templates:
                                expected_message,
                                prepare_deployment_plan,
                                self.parse_1_3(self.secrets_yaml),
-                               get_secret_not_found)
+                               get_secret_method=get_secret_not_found)
 
     def test_validate_secrets_unexpected_exception(self):
         get_secret_exception = Mock(side_effect=TypeError)
@@ -207,7 +208,7 @@ node_templates:
                                expected_message,
                                prepare_deployment_plan,
                                self.parse_1_3(self.secrets_yaml),
-                               fake_get_secret)
+                               get_secret_method=fake_get_secret)
 
     def test_validate_secrets_without_secrets(self):
         no_secrets_yaml = """
@@ -248,7 +249,7 @@ node_templates:
 """
         get_secret_mock = Mock(return_value='secret_value')
         parsed = prepare_deployment_plan(self.parse_1_3(no_secrets_yaml),
-                                         get_secret_mock)
+                                         get_secret_method=get_secret_mock)
         self.assertFalse(get_secret_mock.called)
         self.assertFalse(hasattr(parsed, 'secrets'))
 
@@ -296,7 +297,7 @@ node_templates:
             property: { get_secret: secret }
 """
         parsed = prepare_deployment_plan(self.parse_1_3(yaml),
-                                         self.get_secret)
+                                         get_secret_method=self.get_secret)
         node = self.get_node_by_name(parsed, 'node')
         self.assertEqual({'get_secret': 'secret'},
                          node['properties']['property'])
@@ -348,7 +349,8 @@ outputs:
         get_secret_not_found = Mock(side_effect=NotFoundException)
         with self.assertRaisesRegex(exceptions.UnknownSecretError,
                                     "Required secret.*missing_secret.*"):
-            prepare_deployment_plan(parsed, get_secret_not_found)
+            prepare_deployment_plan(parsed,
+                                    get_secret_method=get_secret_not_found)
 
     def test_get_secret_not_json_parseable(self):
         payload = {

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -861,21 +861,6 @@ inputs:
                                     r'should have a default value: \'ip\''):
             self.parse(yaml)
 
-    def test_input_secret(self):
-        yaml = """
-tosca_definitions_version: cloudify_dsl_1_3
-inputs:
-    foo:
-        type: secret
-        default: "blah-blah-blah"
-"""
-        parsed = self.parse(yaml)
-        self.assertEqual(1, len(parsed[consts.INPUTS]))
-        self.assertEqual(
-            'secret', parsed[consts.INPUTS]['foo'][consts.TYPE])
-        self.assertEqual(
-            'blah-blah-blah', parsed[consts.INPUTS]['foo'][consts.DEFAULT])
-
 
 class TestInputsConstraints(AbstractTestParser):
     def test_constraints_successful(self):

--- a/dsl_parser/tests/test_outputs.py
+++ b/dsl_parser/tests/test_outputs.py
@@ -139,7 +139,8 @@ outputs:
         self.assertTrue(isinstance(func, functions.GetSecret))
         self.assertEqual('secret_key', func.secret_id)
         storage = self.mock_evaluation_storage()
-        prepared = prepare_deployment_plan(parsed, storage.get_secret)
+        prepared = prepare_deployment_plan(
+            parsed, get_secret_method=storage.get_secret)
         self.assertEqual(parsed['outputs'], prepared['outputs'])
 
     def test_invalid_nested_get_attribute(self):
@@ -215,7 +216,7 @@ outputs:
             instances, nodes, capabilities={'dep_1': {'cap_a': 'value_a_1'}})
 
         parsed = prepare_deployment_plan(self.parse_1_1(yaml),
-                                         storage.get_secret)
+                                         get_secret_method=storage.get_secret)
         concatenated = parsed['outputs']['concatenated']['value']['concat']
         assertion(concatenated)
 

--- a/dsl_parser/tests/test_register_function.py
+++ b/dsl_parser/tests/test_register_function.py
@@ -80,7 +80,8 @@ outputs:
             node_instances, nodes,
             capabilities={'dep_1': {'cap_a': 'value_a_1'}})
 
-        parsed = prepare_deployment_plan(self.parse(yaml), storage.get_secret)
+        parsed = prepare_deployment_plan(self.parse(yaml),
+                                         get_secret_method=storage.get_secret)
 
         outputs = parsed['outputs']
         self.assertEqual('FIRST', outputs['output1']['value'])

--- a/dsl_parser/utils.py
+++ b/dsl_parser/utils.py
@@ -199,7 +199,7 @@ def parse_value(
     elif type_name == 'boolean':
         if isinstance(value, bool):
             return value
-    elif type_name in ('string', 'secret'):
+    elif type_name in ('string', 'secret', 'deployment_id'):
         return value
     elif type_name == 'regex':
         if isinstance(value, text_type):


### PR DESCRIPTION
The new data type `deployment_id` refers to deployments existing in the
system.  A valid input of that type is going to guarantee that given
deployment exists (possibly for a different tenant though).

Moreover a new `filter` constraints is added which might enforce
deployments to be associated with given tenants, have specific labels
or have display_names follow some pattern.