### PR TITLE
local workflows: threadsafe access to _instance_locks

### DIFF
--- a/cloudify/workflows/local.py
+++ b/cloudify/workflows/local.py
@@ -347,11 +347,10 @@ class DeploymentStorage(object):
     @contextmanager
     def _lock(self, instance_id):
         with self._main_instances_lock:
-            if instance_id not in self._instance_locks:
+            instance_lock = self._instance_locks.get(instance_id)
+            if instance_lock is None:
                 instance_lock = threading.RLock()
                 self._instance_locks[instance_id] = instance_lock
-            else:
-                instance_lock = self._instance_locks[instance_id]
         with instance_lock:
             yield
 


### PR DESCRIPTION
This is a WeakValueDict! 2-step access like `if not in d` + `d[]`
can fail, because the value might get evicted between those calls.
And yes, I've seen it happen.

Instead, only one `.get`