### PR TITLE
RD-4328 Allow filtering graphs by just execution-id

### DIFF
--- a/cloudify_rest_client/operations.py
+++ b/cloudify_rest_client/operations.py
@@ -142,8 +142,10 @@ class TasksGraphClient(object):
         self._uri_prefix = 'tasks_graphs'
         self._wrapper_cls = TasksGraph
 
-    def list(self, execution_id, name):
-        params = {'execution_id': execution_id, 'name': name}
+    def list(self, execution_id, name=None):
+        params = {'execution_id': execution_id}
+        if name:
+            params['name'] = name
         response = self.api.get('/{self._uri_prefix}'.format(self=self),
                                 params=params)
         return ListResponse(


### PR DESCRIPTION
The name is not required anymore