### PR TITLE
RD-4623 Non-graph execs: handle errors same as graph execs

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -333,6 +333,9 @@ class WorkflowHandler(TaskHandler):
             try:
                 workflow_output = self.func(*self.args, **self.kwargs)
                 result = {'result': workflow_output}
+                if not self.ctx.internal.graph_mode:
+                    for workflow_task in self.ctx.internal.task_graph.tasks:
+                        workflow_task.async_result.get()
             except api.ExecutionCancelled:
                 result = {'result': api.EXECUTION_CANCELLED_RESULT}
                 return result
@@ -340,9 +343,6 @@ class WorkflowHandler(TaskHandler):
                 err = _WorkflowFuncError(workflow_ex, traceback.format_exc())
                 result = {'error': err}
                 return result
-            if not self.ctx.internal.graph_mode:
-                for workflow_task in self.ctx.internal.task_graph.tasks:
-                    workflow_task.async_result.get()
             return result
 
     def _workflow_started(self):


### PR DESCRIPTION
Well this needs to go under all the `except`s, same as the regular
func call.

FWIW this is about workflows that create operations but not in the
context of a graph.
As in, yes, it is allowed to do, like
```python
def workflow(ctx):
    instance = ctx.node_instances[0]
    instance.execute_operation('foo.bar')
```
And that operation WILL be awaited-for, in just these lines I'm moving.
So let's handle errors in them.