### PR TITLE
RD-4280 Combine arguments of recursive functions

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -645,7 +645,26 @@ def _get_attribute_from_node_instance(ni, node, attribute_path, path, fn_name):
                                     path,
                                     raise_if_not_found=False,
                                     func_name=fn_name)
+        if isinstance(value, list):
+            value = _merge_function_args(value)
+
     return value
+
+
+def _merge_function_args(items):
+    for index, item in enumerate(items):
+        if is_function(item):
+            break
+    else:
+        return items
+    item = items[index]
+    f_name = list(item.keys())[0]
+    f_args = item[f_name]
+    f_args.extend(items[index+1:])
+    del items[index+1:]
+    if len(items) == 1:
+        return items[0]
+    return items
 
 
 def _validate_no_functions_in_args(node_name, attribute_path, path, name,

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -652,6 +652,15 @@ def _get_attribute_from_node_instance(ni, node, attribute_path, path, fn_name):
 
 
 def _merge_function_args(items):
+    # In case of `items` being a list of values and intrinsic function calls,
+    # e.g.: ['a', {'get_attribute': ['b', 'c']}, 'd', 'e'] contains a list
+    # where the second item is a function call.  This function will transform
+    # it into ['a', {'get_attribute': ['b', 'c', 'd', 'e']}].  For
+    # [{'get_attribute': ['a']}, 'b'] it will produce just
+    # {'get_attribute': ['a', 'b']}.  And in case there are more functions
+    # among `items`, only the first gets the remaining parameters merged:
+    # [{'get_attribute': ['a']}, 'b', {'get_attribute': ['c']}] becomes
+    # {'get_attribute': ['a', 'b', {'get_attribute': ['c']}]}
     f_index = None
     for index, item in enumerate(items):
         if is_function(item):

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -645,9 +645,9 @@ def _get_attribute_from_node_instance(ni, node, attribute_path, path, fn_name):
                                     path,
                                     raise_if_not_found=False,
                                     func_name=fn_name)
-        if isinstance(value, list):
-            value = _merge_function_args(value)
 
+    if isinstance(value, list):
+        value = _merge_function_args(value)
     return value
 
 

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -652,16 +652,18 @@ def _get_attribute_from_node_instance(ni, node, attribute_path, path, fn_name):
 
 
 def _merge_function_args(items):
+    f_index = None
     for index, item in enumerate(items):
         if is_function(item):
+            f_index = index
             break
-    else:
+    if f_index is None:
         return items
-    item = items[index]
+    item = items[f_index]
     f_name = list(item.keys())[0]
     f_args = item[f_name]
-    f_args.extend(items[index+1:])
-    del items[index+1:]
+    f_args.extend(items[f_index+1:])
+    del items[f_index+1:]
     if len(items) == 1:
         return items[0]
     return items

--- a/dsl_parser/tests/test_helper_functions.py
+++ b/dsl_parser/tests/test_helper_functions.py
@@ -1,0 +1,35 @@
+import unittest
+
+from dsl_parser.functions import _merge_function_args
+
+
+class TestGetAttributeHelperFunctions(unittest.TestCase):
+    def test_merge_function_args_simple(self):
+        assert _merge_function_args([]) == []
+        assert _merge_function_args(['a', 'b', 'c']) == ['a', 'b', 'c']
+
+    def test_merge_function_args_one_function(self):
+        assert _merge_function_args(
+            [{'get_input': ['test_tmp', 'a']}, 'b', 'c']
+        ) == {'get_input': ['test_tmp', 'a', 'b', 'c']}
+        assert _merge_function_args(
+            ['a', {'get_attribute': ['test_tmp', 'b']}, 'c']
+        ) == ['a', {'get_attribute': ['test_tmp', 'b', 'c']}]
+        assert _merge_function_args(
+            ['a', 'b', {'get_capability': ['test_tmp', 'c']}]
+        ) == ['a', 'b', {'get_capability': ['test_tmp', 'c']}]
+
+    def test_merge_function_args_two_functions(self):
+        assert _merge_function_args(
+            [{'get_attribute': ['test_tmp', 'a']}, 'b',
+             {'get_attribute': ['test_tmp', 'c']}]
+        ) == {'get_attribute': [
+            'test_tmp', 'a', 'b', {'get_attribute': ['test_tmp', 'c']}
+        ]}
+        assert _merge_function_args(
+            [{'get_input': ['test_tmp', 'a']}, 'b', 'c',
+             {'get_attribute': ['test_tmp', 'd']}, 'e', 'f', 'g']
+        ) == {'get_input': [
+            'test_tmp', 'a', 'b', 'c',
+            {'get_attribute': ['test_tmp', 'd']}, 'e', 'f', 'g'
+        ]}


### PR DESCRIPTION
There are cases, where one attribute refers another, for example:

```
node_templates:
  test_tmp:
    type: tmp
    properties:
      a: [1,2,3,4]
      b: {get_attribute: [test_tmp, a]}
```

In this case getting n-th node of `b` property should give the same
result as getting the n-th node of `a` property.  In other words these
two should be equal:

```
capabilities:
  a0:
    value: {get_attribute: [test_tmp, a, 0]}
  b0:
    value: {get_attribute: [test_tmp, b, 0]}
```

This patch makes DSL parser work exactly like that by merging
_remaining_ parameters with the ones passed to intrinsic functions.
This way for `b0` we'll be truly getting value of
`{get_attribute: [test_tmp, a, 0]}` instead of
`[{get_attribute: [test_tmp, a]}, 0]`.