### PR TITLE
RD-4280 Keep evaluating functions until got result

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -17,7 +17,6 @@ import abc
 import collections
 import pkg_resources
 import json
-from copy import copy
 
 from functools import wraps
 
@@ -1301,18 +1300,7 @@ def _get_property_value(node_name,
     def evaluate_property_value(v):
         if not handler.runtime_only_evaluation:
             return v
-        evaluated_value = v
-        ctx = copy(context)
-        while True:
-            func = parse(evaluated_value, context=ctx, path=context_path)
-            if not isinstance(func, Function):
-                break
-            previous_evaluated_value = evaluated_value
-            evaluated_value = func.evaluate(handler)
-            ctx = func.context
-            if previous_evaluated_value == evaluated_value:
-                break
-        return evaluated_value
+        return handler(v, None, context, context_path)
 
     value = properties
     for p in property_path:

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -1493,6 +1493,10 @@ class _EvaluationHandler(object):
     def evaluate_function(self, func):
         return func.evaluate(self)
 
+    @property
+    def runtime_only_evaluation(self):
+        return False
+
 
 class _PlanEvaluationHandler(_EvaluationHandler):
     def __init__(self, plan, runtime_only_evaluation):
@@ -1532,6 +1536,10 @@ class _PlanEvaluationHandler(_EvaluationHandler):
     def get_consumers(self, prop):
         raise exceptions.FunctionEvaluationError(
             "`get_consumers` should be evaluated at runtime only")
+
+    @property
+    def runtime_only_evaluation(self):
+        return self._runtime_only_evaluation
 
 
 class _RuntimeEvaluationHandler(_EvaluationHandler):
@@ -1615,6 +1623,10 @@ class _RuntimeEvaluationHandler(_EvaluationHandler):
 
     def get_consumers(self, prop):
         return self._storage.get_consumers(prop)
+
+    @property
+    def runtime_only_evaluation(self):
+        return True
 
 
 def plan_evaluation_handler(plan, runtime_only_evaluation=False):

--- a/dsl_parser/tests/test_get_attribute.py
+++ b/dsl_parser/tests/test_get_attribute.py
@@ -91,6 +91,52 @@ node_templates:
         assertion(webserver_node['relationships'][0]['source_operations'])
         assertion(webserver_node['relationships'][0]['target_operations'])
 
+    def test_simple_nested_evaluation(self):
+        storage = self.mock_evaluation_storage(
+            node_instances=[{
+                'id': 'x',
+                'node_id': 'x'
+            }],
+            nodes=[{
+                'id': 'x',
+                'properties': {
+                    'a': [1, 2, 3, 4],
+                    'b': {'get_attribute': ['x', 'a']},
+                    'c': {'get_attribute': ['x', 'b']},
+                    'd': {'get_attribute': ['x', 'c']}
+                }
+            }]
+        )
+        capabilities = {
+            'a2': {'value': {'get_attribute': ['x', 'a', 2]}},
+            'd2': {'value': {'get_attribute': ['x', 'd', 2]}},
+        }
+        evaluated = functions.evaluate_capabilities(capabilities, storage)
+        assert evaluated['a2'] == evaluated['d2'] == 3
+
+    def test_nested_evaluation(self):
+        storage = self.mock_evaluation_storage(
+            node_instances=[{
+                'id': 'x',
+                'node_id': 'x'
+            }],
+            nodes=[{
+                'id': 'x',
+                'properties': {
+                    'a': [1, 2, 3, 4],
+                    'b': {'get_attribute': ['x', 'a']},
+                    'c': {'get_attribute': ['x', 'b']},
+                    'd': {'get_attribute': ['x', 'c']}
+                }
+            }]
+        )
+        capabilities = {
+            'five': {'value': [0, {'get_attribute': ['x', 'a', 0]},
+                               2, {'get_attribute': ['x', 'd', 2]}, 4]},
+        }
+        evaluated = functions.evaluate_capabilities(capabilities, storage)
+        assert evaluated['five'] == [0, 1, 2, 3, 4]
+
 
 class TestEvaluateFunctions(AbstractTestParser):
 


### PR DESCRIPTION
Instead of substituting evaluated values with possibly another level of
intrinsic functions (and mistakenly breaking the indexation), let's
evaluate intrinsic functions "da capo al fine" (until we get actual
values).