### PR TITLE
Stay on the safe side creating `DeploymentScalingGroup`s

### DIFF
--- a/cloudify_rest_client/deployments.py
+++ b/cloudify_rest_client/deployments.py
@@ -21,7 +21,7 @@ class Deployment(dict):
         if 'scaling_groups' in self and self['scaling_groups']:
             self['scaling_groups'] = {
                 name: DeploymentScalingGroup({
-                        'deployment_id': deployment['id'],
+                        'deployment_id': self.id,
                         'name': name,
                         'members': spec['members'],
                         'properties': spec['properties']})


### PR DESCRIPTION
It's not always deployments come with `ID` already set, let's use
`self.id` getter then and circumvent the problem.

Also that should not cause any harm as `DeploymentScalingGroup`s do not
require a non-null `deployment_id`.