### PR TITLE
RD-4711 Allow default `deployment_id` value for workflow parameters

### DIFF
--- a/dsl_parser/constraints.py
+++ b/dsl_parser/constraints.py
@@ -397,6 +397,7 @@ def validate_input_value(input_name, input_constraints, input_value,
             'constraints.'.format(input_value, input_name))
 
     if type_name in TYPES_WHICH_REQUIRE_DEPLOYMENT_ID_CONSTRAINT \
+            and not value_getter.has_deployment_id() \
             and 'deployment_id' not in {c.name for c in input_constraints}:
         raise exceptions.ConstraintException(
             "Input '{0}' of type '{1}' lacks 'deployment_id' constraint."


### PR DESCRIPTION
In case a `deployment_id` can be retrieved from the context (e.g. when
running a workflow on a given deployment), don't require it to be
present in the constraints for data-based data types which require
`deployment_id` constraint.