### PR TITLE
RD-4788 Allow import of earlier DSL versions

### DIFF
--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -452,8 +452,8 @@ def _validate_version(dsl_version,
                       parsed_imported_dsl_holder):
     version_key_holder, version_value_holder = parsed_imported_dsl_holder\
         .get_item(_version.VERSION)
-    # Don't accept importing a file which uses greater DSL version
-    if version_value_holder and version_value_holder.value > dsl_version:
+    if version_value_holder and \
+            not _can_import_version(dsl_version, version_value_holder.value):
         raise exceptions.DSLParsingLogicException(
             28, "An import uses a different "
                 "tosca_definitions_version than the one defined in "
@@ -463,6 +463,12 @@ def _validate_version(dsl_version,
                 .format(dsl_version,
                         import_url,
                         version_value_holder.value))
+
+
+def _can_import_version(version_orig, version_imported):
+    """Accept importing a file which uses equal or earlier DSL version."""
+    return _version.SUPPORTED_VERSIONS.index(version_orig) >= \
+        _version.SUPPORTED_VERSIONS.index(version_imported)
 
 
 def _mark_key_value_holder_items(value_holder, field_name, field_value):

--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -452,7 +452,8 @@ def _validate_version(dsl_version,
                       parsed_imported_dsl_holder):
     version_key_holder, version_value_holder = parsed_imported_dsl_holder\
         .get_item(_version.VERSION)
-    if version_value_holder and version_value_holder.value != dsl_version:
+    # Don't accept importing a file which uses greater DSL version
+    if version_value_holder and version_value_holder.value > dsl_version:
         raise exceptions.DSLParsingLogicException(
             28, "An import uses a different "
                 "tosca_definitions_version than the one defined in "

--- a/dsl_parser/tests/test_parser_logic_exceptions.py
+++ b/dsl_parser/tests/test_parser_logic_exceptions.py
@@ -555,9 +555,9 @@ imports:
         self._assert_dsl_parsing_exception_error_code(
             yaml, 27, DSLParsingLogicException, dsl_parse)
 
-    def test_mismatching_version_in_import(self):
+    def test_mismatching_version_in_import_newer(self):
         imported_yaml = """
-tosca_definitions_version: cloudify_1_1
+tosca_definitions_version: cloudify_dsl_1_1
     """
         imported_yaml_filename = self.make_yaml_file(imported_yaml)
         yaml = """
@@ -568,6 +568,19 @@ imports:
 
         self._assert_dsl_parsing_exception_error_code(
             yaml, 28, DSLParsingLogicException, dsl_parse)
+
+    def test_mismatching_version_in_import_older(self):
+        imported_yaml = """
+    tosca_definitions_version: cloudify_dsl_1_1
+        """
+        imported_yaml_filename = self.make_yaml_file(imported_yaml)
+        yaml = """
+imports:
+    -   {0}""".format(imported_yaml_filename) + \
+               self.BASIC_VERSION_SECTION_DSL_1_2 + \
+               self.MINIMAL_BLUEPRINT
+
+        self.parse(yaml)
 
     def test_unsupported_version(self):
         yaml = """


### PR DESCRIPTION
Allow importing files which use earlier version of DSL than the
blueprint.  One can use `cloudify_dsl_1_3` types.yaml in
a `cloudify_dsl_1_4` blueprint.