### PR TITLE
RD-4612 restclient: drift/status flags

### DIFF
--- a/cloudify_rest_client/node_instances.py
+++ b/cloudify_rest_client/node_instances.py
@@ -108,6 +108,30 @@ class NodeInstance(dict):
         """
         return self.get('index')
 
+    @property
+    def is_status_check_ok(self):
+        """Has the last status check for this NI succeeded?
+
+        This examines the result of the most recent check_status call
+        on this node instance, and returns whether the call succeeded.
+
+        If the result is missing, the result is succeeded.
+        """
+        return self.get('is_status_check_ok', True)
+
+    @property
+    def has_configuration_drift(self):
+        """Has this NI's configuration drifted?
+
+        This examines the result of the most recent check_drift call
+        on this node instance, and returns whether there was any configuration
+        drift reported.
+
+        The instance is drifted if either the instance itself, or any of its
+        relationships have drifted.
+        """
+        return self.get('has_configuration_drift', False)
+
 
 class NodeInstancesClient(object):
 

--- a/cloudify_rest_client/nodes.py
+++ b/cloudify_rest_client/nodes.py
@@ -116,6 +116,22 @@ class Node(dict):
                                               in self else None
 
     @property
+    def unavailable_instances(self):
+        """Amount of instances that failed their status check.
+
+        This is only available when querying with _instance_counts
+        """
+        return self.get('unavailable_instances')
+
+    @property
+    def drifted_instances(self):
+        """Amount of instances that have configuration drift.
+
+        This is only available when querying with _instance_counts
+        """
+        return self.get('drifted_instances')
+
+    @property
     def host_id(self):
         """
         :return: The id of the node instance which hosts this node.
@@ -209,6 +225,10 @@ class NodesClient(object):
         :param kwargs: Optional filter fields. for a list of available fields
                see the REST service's models.DeploymentNode.fields
         :param evaluate_functions: Evaluate intrinsic functions
+        :param _instance_counts: Include node-instance counts in each node,
+                                 adding unavailable_instances and
+                                 drifted_instances to the response. Only
+                                 available when filtering by deployment_id.
         :return: Nodes.
         :rtype: list
         """


### PR DESCRIPTION
Drifted/status-unavailable flags for node-instances and nodes.