### PR TITLE
RD-429 Do not require `resource_id` for external resources

### DIFF
--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -2520,12 +2520,7 @@ node_templates:
         assert node_properties['use_external_resource'] is False
         assert node_properties['foo'] == 'bar'
 
-        with self.assertRaises(exceptions.DSLParsingLogicException) as cm:
-            self.parse(yaml.format(
-                use_external_resource=True, foo='bar'
-            ))
-        assert "External node" in str(cm.exception)
-        assert "mandatory 'resource_id'" in str(cm.exception)
+        self.parse(yaml.format(use_external_resource=True, foo='bar'))
 
     def test_default_use_external_resource(self):
         yaml = """

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -2556,12 +2556,7 @@ node_templates:
         assert node_properties['resource_id'] == 'id-123'
         assert node_properties['foo'] == ''
 
-        with self.assertRaises(exceptions.DSLParsingLogicException) as cm:
-            self.parse(yaml.format(
-                resource_id='""', foo='bar'
-            ))
-        assert "External node" in str(cm.exception)
-        assert "mandatory 'resource_id'" in str(cm.exception)
+        self.parse(yaml.format(resource_id='""', foo='bar'))
 
     def test_use_external_resource_no_intrinsic_functions(self):
         yaml = """

--- a/dsl_parser/utils.py
+++ b/dsl_parser/utils.py
@@ -154,12 +154,6 @@ def _merge_flattened_schema_and_instance_properties(
                 exceptions.ERROR_INTRINSIC_FUNCTION_NOT_PERMITTED,
                 "Only boolean values are allowed for `use_external_resource` "
                 "property, don't use intrinsic functions.")
-        resource_id = merged_properties.get('resource_id')
-        if not resource_id:
-            raise exceptions.DSLParsingLogicException(
-                exceptions.ERROR_MISSING_PROPERTY,
-                "External node '{0}' does not provide a value for mandatory "
-                "'resource_id' property".format(node_name))
 
     result = {}
     for key, property_schema in schema_properties.items():


### PR DESCRIPTION
... because some plugins don't.

https://cloudifysource.atlassian.net/browse/RD-429?focusedCommentId=76279