### PR TITLE
RD-4617 Allow overriding workflows

### DIFF
--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -643,6 +643,14 @@ def _extend_node_template(from_dict_holder, to_dict_holder):
                 to_dict_holder.value[key_holder])
 
 
+def _merge_workflows(key_holder, key_name, to_dict_holder, from_dict_holder):
+    source = from_dict_holder.value
+    target = to_dict_holder.value
+    for key in from_dict_holder.value:
+        if key not in target:
+            target[key] = source[key]
+
+
 def _merge_into_dict_or_throw_on_duplicate(from_dict_holder,
                                            to_dict_holder,
                                            key_name,
@@ -673,6 +681,13 @@ def _merge_into_dict_or_throw_on_duplicate(from_dict_holder,
         elif key_name in constants.PLUGIN_DSL_KEYS_READ_FROM_DB:
             # Allow blueprint_labels, labels and resource_tags to be merged
             continue
+        elif key_name == constants.WORKFLOWS:
+            _merge_workflows(
+                key_holder,
+                key_name,
+                to_dict_holder.value[key_holder],
+                value_holder,
+            )
         else:
             raise exceptions.DSLParsingLogicException(
                 4, "Import failed: Could not merge '{0}' due to conflict "

--- a/dsl_parser/tests/test_parser_api.py
+++ b/dsl_parser/tests/test_parser_api.py
@@ -1735,6 +1735,35 @@ node_types:
                       executor='central_deployment_agent'),
             operations['test_interface1.install'])
 
+    def test_merge_workflow_imports(self):
+        imported_yaml = """
+workflows:
+    wf1:
+        mapping: file:///dev/null
+        availability_rules:
+            available: true
+"""
+        import_file_name = self.make_yaml_file(imported_yaml)
+
+        main_yaml = self.BASIC_VERSION_SECTION_DSL_1_4 + """
+imports:
+    -   {0}
+plugins:
+    plug1:
+        executor: central_deployment_agent
+        install: false
+workflows:
+    wf1:
+        mapping: plug1.plug.operation
+""".format(import_file_name)
+        parsed_yaml = self.parse(main_yaml)
+        wfs = parsed_yaml['workflows']
+        assert 'wf1' in wfs
+        wf = wfs['wf1']
+        assert wf['operation'] == 'plug.operation'
+        assert 'availability_rules' in wf
+        assert wf['availability_rules'] == {'available': True}
+
     def test_merge_plugins_and_interfaces_imports(self):
         yaml = self.create_yaml_with_imports(
             [self.BASIC_NODE_TEMPLATES_SECTION, self.BASIC_PLUGIN]) + """


### PR DESCRIPTION
A shallow merge of workflow settings. Allows overriding availability,
most notably. But also other things!

Before, attempting to override a workflow used to be just an error