### PR TITLE
RD-4408 Declare instance drift/status counts on deployment

### DIFF
--- a/cloudify_rest_client/deployments.py
+++ b/cloudify_rest_client/deployments.py
@@ -223,6 +223,16 @@ class Deployment(dict):
     def scaling_groups(self):
         return self.get('scaling_groups')
 
+    @property
+    def unavailable_instances(self):
+        """Amount of instances that failed their status check."""
+        return self.get('unavailable_instances')
+
+    @property
+    def drifted_instances(self):
+        """Amount of instances that have configuration drift."""
+        return self.get('drifted_instances')
+
 
 class Workflow(dict):
 

--- a/cloudify_rest_client/nodes.py
+++ b/cloudify_rest_client/nodes.py
@@ -117,18 +117,12 @@ class Node(dict):
 
     @property
     def unavailable_instances(self):
-        """Amount of instances that failed their status check.
-
-        This is only available when querying with _instance_counts
-        """
+        """Amount of instances that failed their status check."""
         return self.get('unavailable_instances')
 
     @property
     def drifted_instances(self):
-        """Amount of instances that have configuration drift.
-
-        This is only available when querying with _instance_counts
-        """
+        """Amount of instances that have configuration drift."""
         return self.get('drifted_instances')
 
     @property
@@ -225,10 +219,6 @@ class NodesClient(object):
         :param kwargs: Optional filter fields. for a list of available fields
                see the REST service's models.DeploymentNode.fields
         :param evaluate_functions: Evaluate intrinsic functions
-        :param _instance_counts: Include node-instance counts in each node,
-                                 adding unavailable_instances and
-                                 drifted_instances to the response. Only
-                                 available when filtering by deployment_id.
         :return: Nodes.
         :rtype: list
         """


### PR DESCRIPTION
Also, the _instance_counts param is no longer necessary