### PR TITLE
dsl-parser: default Plan with an empty schema

### DIFF
--- a/dsl_parser/models.py
+++ b/dsl_parser/models.py
@@ -35,6 +35,20 @@ class Version(dict):
 class Plan(dict):
 
     def __init__(self, plan):
+        self.update(
+            inputs={},
+            outputs={},
+            nodes=[],
+            scaling_groups={},
+            workflows={},
+            policy_types={},
+            policy_triggers={},
+            description=None,
+            groups={},
+            capabilities={},
+            resource_tags=None,
+            labels={},
+        )
         self.update(plan)
 
     @property


### PR DESCRIPTION
It's not longer just a dict! This allows creating a plan from `{}`
and the structure will be there.