### PR TITLE
Add a few magic methods to CloudifyWorkflowNode/Instance

### DIFF
--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -235,6 +235,12 @@ class CloudifyWorkflowNodeInstance(object):
         self._logger = None
 
     def __eq__(self, other):
+        """Compare node instances
+
+        A node instance is always going to be equal with itself, even if it
+        was fetched multiple times, and it was mutated by the user.
+        This allows storing node instances in sets, and as dict keys.
+        """
         if not isinstance(other, self.__class__):
             return False
         return self.id == other.id

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -234,6 +234,21 @@ class CloudifyWorkflowNodeInstance(object):
 
         self._logger = None
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __repr__(self):
+        return '<{0} {1} ({2})>'.format(
+            self.__class__.__name__,
+            self.id,
+            self.state,
+        )
+
     def set_state(self, state):
         """Set the node-instance state
 
@@ -381,6 +396,12 @@ class CloudifyWorkflowNode(object):
                 self.ctx, self, nodes_and_instances, relationship))
             for relationship in node.relationships)
         self._node_instances = {}
+
+    def __repr__(self):
+        return '<{0} {1})>'.format(
+            self.__class__.__name__,
+            self.id,
+        )
 
     @property
     def id(self):


### PR DESCRIPTION
- the repr is just nice, duh
- NodeInstance is already put into sets, so it very much SHOULD have
  a hash+eq. It doesn't currently, which makes it break when some
  instances are from before a `wctx.refresh_node_instances()` and
  some are from after (then they compare not equal, which is... less
  than useful)