### PR TITLE
RD-5218 Allow the `resource_tags` in DSL 1.3

### DIFF
--- a/dsl_parser/elements/misc.py
+++ b/dsl_parser/elements/misc.py
@@ -227,4 +227,4 @@ class ResourceTags(DictElement):
 
     def validate(self, version, validate_version):
         if validate_version:
-            self.validate_version(version, (1, 4))
+            self.validate_version(version, (1, 3))

--- a/dsl_parser/tests/test_resource_tags.py
+++ b/dsl_parser/tests/test_resource_tags.py
@@ -10,11 +10,11 @@ resource_tags:
     foo: bar
     """
 
-    def test_parse_1_3(self):
+    def test_parse_1_2(self):
         with pytest.raises(exceptions.DSLParsingLogicException,
-                           match='^resource_tags not.*cloudify_dsl_1_3'):
-            self.parse_1_3(ResourceTagsTest.YAML)
+                           match='^resource_tags not.*cloudify_dsl_1_2'):
+            self.parse_1_2(ResourceTagsTest.YAML)
 
-    def test_parse_1_4(self):
-        parsed = self.parse_1_4(ResourceTagsTest.YAML)
+    def test_parse_1_3(self):
+        parsed = self.parse_1_3(ResourceTagsTest.YAML)
         assert parsed['resource_tags'] == {'foo': 'bar'}


### PR DESCRIPTION
Because we introduced them in Cloudify 6.2.x (so it's mostly BC)