### PR TITLE
RD-5217 Modify how plugin.yaml-s are looked up

### DIFF
--- a/dsl_parser/import_resolver/default_import_resolver.py
+++ b/dsl_parser/import_resolver/default_import_resolver.py
@@ -15,6 +15,7 @@
 
 import glob
 import os
+import re
 
 from dsl_parser.exceptions import DSLParsingLogicException
 from dsl_parser.import_resolver.abstract_import_resolver \
@@ -164,9 +165,17 @@ class DefaultImportResolver(AbstractImportResolver):
     @staticmethod
     def _plugin_yamls_for_dsl_version(plugin_path, dsl_version):
         yaml_files = glob.glob(os.path.join(plugin_path, '*.yaml'))
-        if len(yaml_files) > 1 and dsl_version:
-            yaml_files = [
-                yaml_file for yaml_file in yaml_files
-                if '{0}.yaml'.format(dsl_version) in yaml_file
-            ]
-        return yaml_files
+        if len(yaml_files) <= 1:
+            return yaml_files
+
+        if dsl_version:
+            # If file exists, return *{dsl_version}.yaml name
+            result = [yaml_file for yaml_file in yaml_files
+                      if '{0}.yaml'.format(dsl_version) in yaml_file]
+            if result:
+                return result
+
+        # Return the first file that does not match *_\d_\d+\.yaml pattern
+        for yaml_file in yaml_files:
+            if not re.match(r"_\d_\d+\.yaml$", yaml_file):
+                return [yaml_file]

--- a/dsl_parser/tests/test_deafult_import_resolver.py
+++ b/dsl_parser/tests/test_deafult_import_resolver.py
@@ -200,6 +200,41 @@ class TestDefaultResolver(unittest.TestCase):
             partial_err_msg="Unable to open import url {0}"
             .format(ILLEGAL_URL))
 
+    def test_plugin_yamls_for_dsl_version(self):
+        r = DefaultImportResolver()
+        with mock.patch('glob.glob',
+                        return_value=['plugin.yaml']):
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', None) \
+                   == ['plugin.yaml']
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_3') \
+                   == ['plugin.yaml']
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_4') \
+                   == ['plugin.yaml']
+        with mock.patch('glob.glob',
+                        return_value=['plugin.yaml', 'plugin_1_1.yaml']):
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', None) \
+                   == ['plugin.yaml']
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_1') \
+                   == ['plugin_1_1.yaml']
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_4') \
+                   == ['plugin.yaml']
+        with mock.patch('glob.glob',
+                        return_value=['plugin_1_2.yaml', 'plugin_1_3.yaml']):
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', None) \
+                   != []
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_2') \
+                   == ['plugin_1_2.yaml']
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_3') \
+                   == ['plugin_1_3.yaml']
+        with mock.patch('glob.glob',
+                        return_value=['plugin.yaml', 'plugin_1_1.yaml']):
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', None) \
+                   == ['plugin.yaml']
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_3') \
+                   == ['plugin.yaml']
+            assert r._plugin_yamls_for_dsl_version('plugin.yaml', '_1_4') \
+                   == ['plugin.yaml']
+
     def _test_default_resolver(self, import_url, rules,
                                expected_urls_to_resolve=[],
                                expected_failure=False,


### PR DESCRIPTION
In case `dsl_version` was provided but `*{dsl_version}.yaml` does not
exist, default to the first `*.yaml` file which does not match
`*_\d_\d+.yaml` pattern.