### PR TITLE
RD-4466 Define "update" flow in LifecycleProcessor

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -59,6 +59,19 @@ def heal_node_instances(
     processor.heal()
 
 
+def update_node_instances(
+    graph,
+    node_instances,
+    related_nodes=None,
+    name_prefix=''
+):
+    processor = LifecycleProcessor(graph=graph,
+                                   node_instances=node_instances,
+                                   related_nodes=related_nodes,
+                                   name_prefix=name_prefix)
+    processor.update()
+
+
 def reinstall_node_instances(graph,
                              node_instances,
                              ignore_failure,
@@ -163,6 +176,14 @@ class LifecycleProcessor(object):
             graph_finisher_func=self._finish_heal)
         graph.execute()
 
+    def update(self):
+        graph = self._process_node_instances(
+            workflow_ctx,
+            name=self._name_prefix + 'update',
+            node_instance_subgraph_func=update_node_instance_subgraph,
+            graph_finisher_func=self._finish_update)
+        graph.execute()
+
     def _update_resumed_install(self, graph):
         """Update a resumed install graph to cleanup first.
 
@@ -232,6 +253,14 @@ class LifecycleProcessor(object):
             install=False)
 
     def _finish_heal(self, graph, subgraphs):
+        self._add_dependencies(
+            graph=graph,
+            subgraphs=subgraphs,
+            instances=self.node_instances,
+            install=True,
+        )
+
+    def _finish_update(self, graph, subgraphs):
         self._add_dependencies(
             graph=graph,
             subgraphs=subgraphs,
@@ -1251,4 +1280,61 @@ def heal_node_instance_subgraph(instance, graph, **kwargs):
     subgraph.info['instance_id'] = instance.id
     subgraph.on_success = _on_heal_success
     subgraph.on_failure = _on_failure
+
+
+def _on_update_success(task):
+    instance_id = task.info['instance_id']
+    workflow_context = task.workflow_context
+    ni = workflow_context.get_node_instance(instance_id)
+    system_properties = ni.system_properties or {}
+    system_properties['configuration_drift'] = None
+    workflow_context.update_node_instance(
+        instance_id,
+        force=True,
+        system_properties=system_properties
+    )
+    return workflow_tasks.HandlerResult.cont()
+
+
+def _on_update_failure(task):
+    instance_id = task.info['instance_id']
+    workflow_context = task.workflow_context
+    ni = workflow_context.get_node_instance(instance_id)
+    system_properties = ni.system_properties or {}
+    system_properties['update_failed'] = workflow_context.execution_id
+    workflow_context.update_node_instance(
+        instance_id,
+        force=True,
+        system_properties=system_properties,
+    )
+    return workflow_tasks.HandlerResult.ignore()
+
+
+def update_node_instance_subgraph(instance, graph, **kwargs):
+    """Make a subgraph of updating a single node instance.
+
+    Runs all the update-related operations.
+    The success callback clears configuration_drift: it is assumed that
+    an update operation does removes all drift.
+    The failure callback just notes that the update did fail, so that the
+    workflow can reinstall the node-instance.
+    """
+    subgraph = graph.subgraph('update_{0}'.format(instance.id))
+    sequence = subgraph.sequence()
+    sequence.add(
+        instance.send_event('Updating node instance'),
+        instance.execute_operation('cloudify.interfaces.lifecycle.preupdate'),
+        instance.execute_operation('cloudify.interfaces.lifecycle.update'),
+        instance.execute_operation('cloudify.interfaces.lifecycle.postupdate'),
+        instance.execute_operation(
+            'cloudify.interfaces.lifecycle.update_config'),
+        instance.execute_operation(
+            'cloudify.interfaces.lifecycle.update_apply'),
+        instance.execute_operation(
+            'cloudify.interfaces.lifecycle.update_postapply'),
+        instance.send_event('Node instance updated'),
+    )
+    subgraph.info['instance_id'] = instance.id
+    subgraph.on_success = _on_update_success
+    subgraph.on_failure = _on_update_failure
     return subgraph

--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -1242,7 +1242,7 @@ def _on_heal_success(task):
     return workflow_tasks.HandlerResult.cont()
 
 
-def _on_failure(task):
+def _on_heal_failure(task):
     """Heal failure callback - mark the node as having failed a heal
 
     We mark the node that a heal was attempted and failed, so that we know
@@ -1279,7 +1279,8 @@ def heal_node_instance_subgraph(instance, graph, **kwargs):
     )
     subgraph.info['instance_id'] = instance.id
     subgraph.on_success = _on_heal_success
-    subgraph.on_failure = _on_failure
+    subgraph.on_failure = _on_heal_failure
+    return subgraph
 
 
 def _on_update_success(task):

--- a/cloudify/tests/resources/blueprints/test-update-operation.yaml
+++ b/cloudify/tests/resources/blueprints/test-update-operation.yaml
@@ -1,0 +1,33 @@
+tosca_definitions_version: cloudify_dsl_1_4
+
+imports:
+  - minimal_types.yaml
+
+plugins:
+  p:
+    executor: central_deployment_agent
+    install: false
+
+node_types:
+  type1: {}
+
+workflows:
+  test_update:
+    mapping: p.cloudify.tests.test_builtin_workflows.update_test_workflow
+    parameters:
+      node_instance_id:
+        type: node_instance
+
+node_templates:
+  node1:
+    type: type1
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create: p.cloudify.tests.test_builtin_workflows.node_operation
+        update: p.cloudify.tests.test_builtin_workflows.node_operation
+
+  node2:
+    type: type1
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        update: p.cloudify.tests.test_builtin_workflows.fail_op

--- a/cloudify/workflows/local.py
+++ b/cloudify/workflows/local.py
@@ -560,7 +560,7 @@ class _Storage(ABC):
             'plan': deployment_plan,
             'nodes': {n.id: n for n in nodes},
             'created_at': datetime.utcnow(),
-            'inputs': inputs,
+            'inputs': inputs or {},
             'workflows': workflows,
             'scaling_groups': deployment_plan['scaling_groups'],
         }


### PR DESCRIPTION
For calling all the `update` interfaces, add a method that'll create
the subgraphs and establish relationships on them.
This is very similar to the `heal` flow, too.