### PR TITLE
RD-4466 dep-update: also run relationship operations

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -1353,7 +1353,8 @@ def update_node_instance_subgraph(instance, graph, **kwargs):
     source_drifts = system_props.get(
         'source_relationships_configuration_drift', {})
     for relationship in instance.relationships:
-        target_instance = workflow_ctx.get_node_instance(relationship.target_id)
+        target_instance = workflow_ctx.get_node_instance(
+            relationship.target_id)
         target_drifts = target_instance.system_properties.get(
             'target_relationships_configuration_drift', {})
         if relationship.target_id in source_drifts:

--- a/cloudify/tests/resources/blueprints/test-update-operation.yaml
+++ b/cloudify/tests/resources/blueprints/test-update-operation.yaml
@@ -31,3 +31,15 @@ node_templates:
     interfaces:
       cloudify.interfaces.lifecycle:
         update: p.cloudify.tests.test_builtin_workflows.fail_op
+
+  node3:
+    type: type1
+    relationships:
+      - target: node1
+        type: cloudify.relationships.depends_on
+        source_interfaces:
+          cloudify.interfaces.relationship_lifecycle:
+            update_establish: p.cloudify.tests.test_builtin_workflows.source_operation
+        target_interfaces:
+          cloudify.interfaces.relationship_lifecycle:
+            update_establish: p.cloudify.tests.test_builtin_workflows.target_operation

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -93,9 +93,27 @@ class CloudifyWorkflowRelationshipInstance(object):
         self._relationship = node_instance.node.get_relationship(
             relationship_instance['target_name'])
 
+    def __repr__(self):
+        return '<{0} {1}->{2} ({3})>'.format(
+            self.__class__.__name__,
+            self.source_id,
+            self.target_id,
+            self.type,
+        )
+
+    @property
+    def type(self):
+        """The relationship type"""
+        return self._relationship_instance.get('type')
+
+    @property
+    def source_id(self):
+        """The relationship source node-instance id"""
+        return self.node_instance.id
+
     @property
     def target_id(self):
-        """The relationship target node id"""
+        """The relationship target node-instance id"""
         return self._relationship_instance.get('target_id')
 
     @property


### PR DESCRIPTION
The update subgraph now examines the drifts, and not only runs our
own operations, but also relationship operations as well