### PR TITLE
RD-5091 Heal: default healthy/unhealthy based on how it was called

### DIFF
--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -695,8 +695,7 @@ class TestHealOperation(testtools.TestCase):
                    for invocation in invocations
                    if invocation.get('operation')
                    == 'cloudify.interfaces.lifecycle.heal') == \
-               {'node1', 'node2', 'node4', 'node6',
-                'node6_contained', 'node8_contained', }
+               {'node2', 'node8_contained'}
 
 
 def update_test_workflow(ctx, node_instance_id, **kwargs):


### PR DESCRIPTION
Heal now has two modes of operation: if we do target a single instance,
then it is assumed to be unhealthy unless proven otherwise (this is
back-compat with pre-6.4).
And if we don't target an instance, but run heal on the whole
deployment, then nodes are considered healthy, unless proven failing.
This is so that we don't blindly run heal (or reinstall) on all nodes.

Also update the test to work that way: only node2 and node8_contained,
in that blueprint, are explicitly failing. Others, eg. node1, don't
even have a check_status defined, so there's no need to heal them.