### PR TITLE
RD-4466 Heal: declare the `ignore_failure` param

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -50,12 +50,14 @@ def heal_node_instances(
     graph,
     node_instances,
     related_nodes=None,
-    name_prefix=''
+    name_prefix='',
+    ignore_failure=False,
 ):
     processor = LifecycleProcessor(graph=graph,
                                    node_instances=node_instances,
                                    related_nodes=related_nodes,
-                                   name_prefix=name_prefix)
+                                   name_prefix=name_prefix,
+                                   ignore_failure=ignore_failure,)
     processor.heal()
 
 


### PR DESCRIPTION
Similar to how other lifecycle methods have it.