### PR TITLE
RD-5109 Remove unnecessary stub subgraphs

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -243,6 +243,7 @@ class LifecycleProcessor(object):
                 'stub_{0}'.format(instance.id))
 
         graph_finisher_func(self.graph, subgraphs)
+        self.graph.optimize()
         return self.graph
 
     def _finish_install(self, graph, subgraphs):


### PR DESCRIPTION
Adding an optimize method to the tasks graph, which will remove all
the empty tasks from the graph.

Currently, let's only run this optimization in the "lifecycle"
workflows. Users are free to run it as they see fit.

Also, in the future, we might come up with more "optimizations".
This impl. right now is pretty straightforward, but feel free to later
rewrite it as something more complex.