### PR TITLE
Add ListResponse.one()

### DIFF
--- a/cloudify_rest_client/responses.py
+++ b/cloudify_rest_client/responses.py
@@ -77,6 +77,20 @@ class ListResponse(object):
             raise TypeError('cmp is not supported. Use key instead.')
         return self.items.sort(key=key, reverse=reverse)
 
+    def one(self):
+        """Return the only item in this list; error if there isn't just one.
+
+        It is often the case that the caller knows there's only one item
+        in the results; instead of doing result[0], use result.one().
+        Then, in case there's more results, an error will be thrown for
+        the failing assumption, rather than silently continuing, which
+        could lead to subtle bugs.
+        """
+        if len(self) != 1:
+            raise ValueError(
+                'Called one() on a list with {0} items'.format(len(self)))
+        return self[0]
+
 
 class DeletedResponse(object):
     """

--- a/cloudify_rest_client/tests/test_responses.py
+++ b/cloudify_rest_client/tests/test_responses.py
@@ -1,0 +1,36 @@
+import pytest
+
+from cloudify_rest_client.responses import ListResponse
+
+
+def test_listresponse_interface():
+    items = [1, 2, 3]
+    lr = ListResponse(items, metadata={})
+
+    assert list(lr) == items
+
+    for ix, value in enumerate(items):
+        assert lr[ix] == value
+
+    assert len(lr) == len(items)
+
+
+def test_listresponse_sort():
+    items = [3, 1, 2]
+    lr = ListResponse(items, metadata={})
+
+    with pytest.raises(TypeError):
+        lr.sort(cmp=lambda x, y: x < y)
+
+    lr.sort()
+    assert list(lr) == sorted(items)
+
+
+def test_listresponse_one():
+    with pytest.raises(ValueError):
+        ListResponse([], metadata={}).one()
+
+    with pytest.raises(ValueError):
+        ListResponse([1, 2, 3], metadata={}).one()
+
+    assert ListResponse([42], metadata={}).one() == 42


### PR DESCRIPTION
Inspired by sqlalchemy. I find that we often do response[0], but this
is better in that there's no way to forget the check.