### PR TITLE
RD-5505 Show apply_async errors in workflow tracebacks

### DIFF
--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -47,7 +47,7 @@ class NodeInstance(object):
         self._runtime_properties[key] = value
 
     def delete(self, key):
-        del(self._runtime_properties[key])
+        del self._runtime_properties[key]
 
     __setitem__ = put
 

--- a/cloudify/tests/test_node_state.py
+++ b/cloudify/tests/test_node_state.py
@@ -80,7 +80,7 @@ class NodeStateTest(testtools.TestCase):
         node = NodeInstance('instance_id', 'node_id')
         node.put('key', 'value')
         self.assertEquals('value', node.get('key'))
-        del(node['key'])
+        del node['key']
         self.assertNotIn('key', node)
 
     def test_delete_nonexistent_property(self):
@@ -91,7 +91,7 @@ class NodeStateTest(testtools.TestCase):
         node = NodeInstance('instance_id', 'node_id',
                             runtime_properties={'preexisting-key': 'val'})
         self.assertFalse(node.dirty)
-        del(node['preexisting-key'])
+        del node['preexisting-key']
         self.assertTrue(node.dirty)
 
     def test_setting_runtime_properties(self):

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -141,7 +141,6 @@ class WorkflowTask(object):
         self.on_success = on_success
         self.on_failure = on_failure
         self.info = info
-        self.error = None
         self.total_retries = total_retries
         self.retry_interval = retry_interval
         self.timeout = timeout
@@ -160,6 +159,11 @@ class WorkflowTask(object):
 
         # ID of the task that is being retried by this task
         self.retried_task = None
+
+        # error is a dict as returned by serialize_known_exception:
+        # for remote tasks it is set when the AMQP dispatcher receives a
+        # task error response
+        self.error = None
 
     @classmethod
     def restore(cls, ctx, graph, task_descr):

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -38,6 +38,7 @@ from cloudify.constants import (
 )
 from cloudify.state import workflow_ctx, current_workflow_ctx
 from cloudify.utils import get_func, uuid4
+from cloudify.error_handling import serialize_known_exception
 # imported for backwards compat:
 from cloudify.constants import TASK_RESPONSE_SENT, INSPECT_TIMEOUT  # noqa
 
@@ -518,6 +519,7 @@ class RemoteWorkflowTask(WorkflowTask):
                     self, self._task_target, self._task_queue)
         except (exceptions.NonRecoverableError,
                 exceptions.RecoverableError) as e:
+            self.error = serialize_known_exception(e)
             self.set_state(TASK_FAILED)
             self.async_result.result = e
         return self.async_result

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -144,11 +144,15 @@ class TaskDependencyGraphErrors(object):
                 self._errors[0].task_name,
                 self._errors[0].error_causes,
             )
-        message = '{0}\nTraceback of {1} (most recent call last):\n{2}'.format(
-            message,
-            self._errors[0].task_name,
-            self._errors[0].traceback,
-        )
+        if self._errors[0].traceback:
+            message = (
+                '{0}\nTraceback of {1} (most recent call last):\n{2}'
+                .format(
+                    message,
+                    self._errors[0].task_name,
+                    self._errors[0].traceback,
+                )
+            )
         return WorkflowFailed(
             message,
             # a task failed, not the workflow function itself: no need to

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -62,8 +62,17 @@ def _task_error_causes_short(task):
     if not hasattr(task, 'error') or not isinstance(task.error, dict):
         return ''
     error_parts = []
-    for c in task.error.get('known_exception_type_kwargs', {}).get('causes'):
+    causes = task.error.get('known_exception_type_kwargs', {}).get('causes')
+    for c in causes:
         error_parts.append('{0} `{1}`'.format(c['type'], c['message']))
+    if not causes:
+        # no known causes - just show the exception directly
+        error_parts.append(
+            '{0} `{1}`'.format(
+                task.error['exception_type'],
+                task.error['message']
+            )
+        )
     return '\n'.join(error_parts)
 
 

--- a/dsl_parser/tests/test_data_types.py
+++ b/dsl_parser/tests/test_data_types.py
@@ -100,7 +100,8 @@ data_types:
             yaml, ERROR_UNDEFINED_PROPERTY, DSLParsingLogicException)
 
     def test_unknown_type_in_datatype(self):
-        yaml = self.BASIC_VERSION_SECTION_DSL_1_2 + self.MINIMAL_BLUEPRINT + """
+        yaml = self.BASIC_VERSION_SECTION_DSL_1_2 + \
+            self.MINIMAL_BLUEPRINT + """
 data_types:
     pair_type:
         properties:
@@ -319,7 +320,8 @@ data_types:
         self.parse_1_2(yaml)
 
     def test_nested_type_error_in_default(self):
-        yaml = self.BASIC_VERSION_SECTION_DSL_1_2 + self.MINIMAL_BLUEPRINT + """
+        yaml = self.BASIC_VERSION_SECTION_DSL_1_2 + \
+            self.MINIMAL_BLUEPRINT + """
 data_types:
     a:
         properties:
@@ -654,7 +656,8 @@ node_templates:
         self.assertEqual(node['properties']['a']['b'], 'b_override')
 
     def test_version_check(self):
-        yaml = self.BASIC_VERSION_SECTION_DSL_1_1 + self.MINIMAL_BLUEPRINT + """
+        yaml = self.BASIC_VERSION_SECTION_DSL_1_1 + \
+            self.MINIMAL_BLUEPRINT + """
 data_types:
     a:
         properties:


### PR DESCRIPTION
Errors thrown inside apply_async itself (such as "agent missing")
used to be just hidden. Now, let's show them.