### PR TITLE
RD-5232 Print the server-side cause of `CloudifyClientError`

### DIFF
--- a/cloudify_rest_client/exceptions.py
+++ b/cloudify_rest_client/exceptions.py
@@ -28,10 +28,9 @@ class CloudifyClientError(Exception):
     def __str__(self):
         message = self._message
         if self.server_traceback:
-            traceback_list = \
-                [line for line in self.server_traceback.split('\n') if line]
-            if traceback_list:
-                message = '{0} ({1})'.format(self._message, traceback_list[-1])
+            _, _, last_line = self.server_traceback.strip().rpartition('\n')
+            if last_line:
+                message = '{0} ({1})'.format(self._message, last_line)
         if self.status_code != -1:
             return '{0}: {1}'.format(self.status_code, message)
         return message

--- a/cloudify_rest_client/exceptions.py
+++ b/cloudify_rest_client/exceptions.py
@@ -26,9 +26,15 @@ class CloudifyClientError(Exception):
         self._message = message
 
     def __str__(self):
+        message = self._message
+        if self.server_traceback:
+            traceback_list = \
+                [line for line in self.server_traceback.split('\n') if line]
+            if traceback_list:
+                message = '{0} ({1})'.format(self._message, traceback_list[-1])
         if self.status_code != -1:
-            return '{0}: {1}'.format(self.status_code, self._message)
-        return self._message
+            return '{0}: {1}'.format(self.status_code, message)
+        return message
 
 
 class DeploymentEnvironmentCreationInProgressError(CloudifyClientError):

--- a/cloudify_rest_client/tests/test_exceptions.py
+++ b/cloudify_rest_client/tests/test_exceptions.py
@@ -1,0 +1,27 @@
+# import pytest
+#
+from cloudify_rest_client.exceptions import CloudifyClientError
+#
+
+
+def test_exception_no_traceback_nor_code():
+    ex = CloudifyClientError('Error message')
+    assert str(ex) == 'Error message'
+
+
+def test_exception_no_traceback_with_code():
+    ex = CloudifyClientError('Error message', status_code=123)
+    assert str(ex) == '123: Error message'
+
+
+def test_exception_with_traceback_no_code():
+    ex = CloudifyClientError('Error message',
+                             server_traceback='This\nis\nsome error\n')
+    assert str(ex) == 'Error message (some error)'
+
+
+def test_exception_with_traceback_and_code():
+    ex = CloudifyClientError('Error message',
+                             server_traceback='This\nis\nsome error\n',
+                             status_code=234)
+    assert str(ex) == '234: Error message (some error)'


### PR DESCRIPTION
This way we get slightly more informative, but not too verbose, `CloudifyClientError`s