### PR TITLE
RD-5524 Plugin resolver: use re.search, not re.match

### DIFF
--- a/dsl_parser/import_resolver/default_import_resolver.py
+++ b/dsl_parser/import_resolver/default_import_resolver.py
@@ -177,5 +177,5 @@ class DefaultImportResolver(AbstractImportResolver):
 
         # Return the first file that does not match *_\d_\d+\.yaml pattern
         for yaml_file in yaml_files:
-            if not re.match(r"_\d_\d+\.yaml$", yaml_file):
+            if not re.search(r"_\d_\d+\.yaml$", yaml_file):
                 return [yaml_file]


### PR DESCRIPTION
re.match matches at the beginning of the string! Attempting to match
something at the end is futile. That's what we have `re.search` for.