### PR TITLE
RD-5599 Return the "latest" plugin*.yaml in case dsl_version is not provided

### DIFF
--- a/dsl_parser/import_resolver/default_import_resolver.py
+++ b/dsl_parser/import_resolver/default_import_resolver.py
@@ -179,3 +179,7 @@ class DefaultImportResolver(AbstractImportResolver):
         for yaml_file in yaml_files:
             if not re.search(r"_\d_\d+\.yaml$", yaml_file):
                 return [yaml_file]
+
+        # If dsl_version is not provided, return the last yaml_file
+        if not dsl_version:
+            return [sorted(yaml_files)[-1]]


### PR DESCRIPTION
This fixes broken `manager_rest.test.infrastructure.test_resolver_with_catalog_support.TestPluginParseWithResolver testMethod=test_fetch_plugin_yaml_matching_dsl_version` test and also `Resolver.fetch_import` for plugins in general in case `dsl_version` is not provided.

This scenario (unknown `dsl_version`) should rather not happen in real-life scenario.