### PR TITLE
RD-5674 Python 3.10 compatibility

### DIFF
--- a/cloudify/ctx_wrappers/ctx-py.py
+++ b/cloudify/ctx_wrappers/ctx-py.py
@@ -4,7 +4,7 @@ import sys
 import json
 import shlex
 import subprocess
-from collections import MutableMapping, Mapping
+from collections.abc import MutableMapping, Mapping
 
 
 def check_output(*popenargs, **kwargs):

--- a/cloudify/proxy/server.py
+++ b/cloudify/proxy/server.py
@@ -15,11 +15,11 @@
 
 import traceback
 import re
-import collections
 import json
 import queue
 import threading
 import socket
+from collections.abc import MutableMapping
 from io import StringIO
 from wsgiref.simple_server import WSGIServer, WSGIRequestHandler
 from wsgiref.simple_server import make_server as make_wsgi_server
@@ -156,7 +156,7 @@ def process_ctx_request(ctx, args):
         desugared_attr = _desugar_attr(current, arg)
         if desugared_attr:
             current = getattr(current, desugared_attr)
-        elif isinstance(current, collections.MutableMapping):
+        elif isinstance(current, MutableMapping):
             key = arg
             path_dict = PathDictAccess(current)
             if index + 1 == num_args:
@@ -173,7 +173,7 @@ def process_ctx_request(ctx, args):
         elif callable(current):
             kwargs = {}
             remaining_args = args[index:]
-            if isinstance(remaining_args[-1], collections.MutableMapping):
+            if isinstance(remaining_args[-1], MutableMapping):
                 kwargs = remaining_args[-1]
                 remaining_args = remaining_args[:-1]
             current = current(*remaining_args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     'retrying==1.3.3',
     'proxy_tools==0.1.0',
     'bottle==0.12.19',
-    'jinja2==2.11.3',
+    'jinja2>3,<4',
     'requests_toolbelt==0.9.1',
     'wagon>0.10',
     'pytz==2021.3'


### PR DESCRIPTION
- bump jinja2 version
- correct import path for the collections ABCs

(both 3.6 and 3.10 compatible)