### PR TITLE
RD-5883 Plugin installer: replace virtualenv with venv

### DIFF
--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -147,12 +147,7 @@ def _make_virtualenv(path):
     able to import libraries from the current venv, but libraries
     installed directly will have precedence.
     """
-    runner.run([
-        sys.executable, '-m', 'virtualenv',
-        '--no-download',
-        '--no-pip', '--no-wheel', '--no-setuptools',
-        path
-    ])
+    runner.run([sys.executable, '-m', 'venv', '--without-pip', path])
     _link_virtualenv(path)
 
 


### PR DESCRIPTION
Use the stdlib one instead. Nice!
Those flags don't exist with venv, they're just the default (with venv, you can just add `--upgrade`).