### PR TITLE
RD-6152 Constraints `error_message` attribute

### DIFF
--- a/dsl_parser/constraints.py
+++ b/dsl_parser/constraints.py
@@ -98,12 +98,12 @@ class Constraint(object):
     # accepts at it's initialization/definition.
     constraint_data_type = None
 
-    def __init__(self, args, **kwargs):
+    def __init__(self, args, error_message=None):
         """
         :param args: the constraint arguments.
         """
         self.args = args
-        self.error_message = kwargs.pop('error_message', None)
+        self.error_message = error_message
 
     def predicate(self, value):
         """Value compliance hook.

--- a/dsl_parser/framework/elements.py
+++ b/dsl_parser/framework/elements.py
@@ -204,7 +204,7 @@ class Element(object):
     def sibling(self, element_type):
         return self.parent().child(element_type)
 
-    def validate_version(self, version, min_version):
+    def validate_version(self, version, min_version, error_msg=None):
         if self.initial_value is not None and version < min_version:
             if self.name == 'type':
                 dsl_node = "type '{0}'".format(self.initial_value)
@@ -212,6 +212,7 @@ class Element(object):
                 dsl_node = self.name
             raise exceptions.DSLParsingLogicException(
                 exceptions.ERROR_CODE_DSL_DEFINITIONS_VERSION_MISMATCH,
+                error_msg or
                 '{0} not supported in version {1}, it was added in {2}'.format(
                     dsl_node,
                     _version.version_description(version),

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -1106,7 +1106,6 @@ inputs:
               error_message: The value should be either `hi` or `ab`
             - max_length: 2
 """
-        # self.parse(yaml)
         with self.assertRaises(ConstraintException) as ctx:
             self.parse(yaml)
         assert str(ctx.exception) == 'Value lorem ipsum of input x is ' + \

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -1066,6 +1066,52 @@ node_templates: {}
                           self.parse,
                           yaml)
 
+    def test_input_pattern_error_message_old_dsl(self):
+        yaml = """
+tosca_definitions_version: cloudify_dsl_1_4
+inputs:
+    x:
+        default: hi
+        constraints:
+            - pattern: '(hi)|(ab)'
+              error_message: The `x` input should be either `hi` or `ab`
+            - max_length: 2
+"""
+        self.assertRaises(DSLParsingLogicException,
+                          self.parse,
+                          yaml)
+
+    def test_input_pattern_error_message_parsing(self):
+        yaml = """
+tosca_definitions_version: cloudify_dsl_1_5
+inputs:
+    x:
+        default: hi
+        constraints:
+            - pattern: '(hi)|(ab)'
+              error_message: The `x` input should be either `hi` or `ab`
+            - max_length: 2
+"""
+        self.parse(yaml)
+
+    def test_input_pattern_error_message_content(self):
+        yaml = """
+tosca_definitions_version: cloudify_dsl_1_5
+inputs:
+    x:
+        default: hi
+        default: lorem ipsum
+        constraints:
+            - pattern: '(hi)|(ab)'
+              error_message: The value should be either `hi` or `ab`
+            - max_length: 2
+"""
+        # self.parse(yaml)
+        with self.assertRaises(ConstraintException) as ctx:
+            self.parse(yaml)
+        assert str(ctx.exception) == 'Value lorem ipsum of input x is ' + \
+               'invalid. The value should be either `hi` or `ab`'
+
 
 class TestInputsTypeValidation(AbstractTestParser):
     def test_input_default_value_data_type_validation_successful(self):


### PR DESCRIPTION
The new `error_message` constraints attribute is used for describing
a constraint-not-met exception.

Example:
```yaml
inputs:
  location:
    type: string
    display_label: Location
    default: https://github.com/cloudify-community/tf-source/archive/refs/heads/main.zip
    constraints:
      - pattern: ^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$
        error_message: The value must be a URL.  The Url must start with http or https
  percent:
    type: integer
    constraints:
      - greater_or_equal: 0
        error_message: The value must be greater or equal to 0
      - less_than: 100
        error_message: The value must be less than 100
```

---

Requires `>=cloudify_dsl_1_5`.