### PR TITLE
RD-6285 install: allow filtering node-instances 

### DIFF
--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -26,11 +26,20 @@ from cloudify.workflows.tasks import HandlerResult, TASK_SUCCEEDED
 
 
 @workflow(resumable=True)
-def install(ctx, **kwargs):
+def install(ctx, node_ids=None, node_instance_ids=None, type_names=None,
+            **kwargs):
     """Default install workflow"""
+    filtered_node_instances = set(_filter_node_instances(
+        ctx=ctx,
+        node_ids=node_ids,
+        node_instance_ids=node_instance_ids,
+        type_names=type_names))
+
     lifecycle.install_node_instances(
         graph=ctx.graph_mode(),
-        node_instances=set(ctx.node_instances))
+        node_instances=filtered_node_instances,
+        related_nodes=set(ctx.node_instances) - filtered_node_instances,
+    )
 
 
 @workflow(resumable=True)

--- a/cloudify/test_utils/local_workflow_decorator.py
+++ b/cloudify/test_utils/local_workflow_decorator.py
@@ -248,7 +248,6 @@ class WorkflowTestDecorator(object):
                 with open(temp_blueprint_path, 'w') as f:
                     f.write(self.blueprint_content)
 
-
         # Updating the test_method_name (if not manually set)
         if self.init_args and not self.init_args.get('name'):
             self.init_args['name'] = test_method_name

--- a/cloudify/tests/resources/blueprints/minimal_types.yaml
+++ b/cloudify/tests/resources/blueprints/minimal_types.yaml
@@ -92,6 +92,13 @@ workflows:
   install:
     mapping: default_workflows.cloudify.plugins.workflows.install
     is_cascading: false
+    parameters:
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
 
   uninstall:
     mapping: default_workflows.cloudify.plugins.workflows.uninstall

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -140,6 +140,7 @@ class TestInstallWorkflowFiltering(LifecycleBaseTest):
                         properties:
                             default_instances: 2
     """
+
     @workflow_test(
         blueprint,
         resources_to_copy=['resources/blueprints/minimal_types.yaml'],
@@ -205,6 +206,7 @@ class TestInstallWorkflowFiltering(LifecycleBaseTest):
                 assert inst.state == 'started'
             else:
                 assert inst.state != 'started'
+
     @workflow_test(
         blueprint,
         resources_to_copy=['resources/blueprints/minimal_types.yaml'],

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -336,7 +336,7 @@ class NodeContextTests(unittest.TestCase):
         os.path.dirname(os.path.realpath(__file__)),
         "resources/blueprints/test-context-node.yaml")
 
-    @workflow_test(blueprint_path=test_blueprint_path)
+    @workflow_test(test_blueprint_path)
     def test_node_type(self, cfy_local):
         cfy_local.execute('execute_operation', parameters={
             'operation': 'test.interface.create',


### PR DESCRIPTION
In the install workflow, expose parameters that allow installing only a subset of a deployment. This is the same method we use in `execute_operation` (and so, `start`, `stop`, ...).

Also some test utils improvement first, so I recommend reading commits separately.