### PR TITLE
RD-6287 Declare a `reinstall` workflow

### DIFF
--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -59,6 +59,23 @@ def uninstall(ctx, ignore_failure=False, node_ids=None, node_instance_ids=None,
         ignore_failure=ignore_failure)
 
 
+@workflow(resumable=True)
+def reinstall(ctx, ignore_failure=False, node_ids=None, node_instance_ids=None,
+              type_names=None, **kwargs):
+    """Default reinstall workflow"""
+    filtered_node_instances = set(_filter_node_instances(
+        ctx=ctx,
+        node_ids=node_ids,
+        node_instance_ids=node_instance_ids,
+        type_names=type_names))
+
+    lifecycle.reinstall_node_instances(
+        graph=ctx.graph_mode(),
+        node_instances=filtered_node_instances,
+        related_nodes=set(ctx.node_instances) - filtered_node_instances,
+        ignore_failure=ignore_failure)
+
+
 def _find_instances_to_heal(instances, healthy_instances):
     """Examine instances, deciding which should be healed, or reinstalled.
 

--- a/cloudify/tests/resources/blueprints/minimal_types.yaml
+++ b/cloudify/tests/resources/blueprints/minimal_types.yaml
@@ -114,6 +114,20 @@ workflows:
       node_instance_ids:
         default: []
 
+  reinstall:
+    mapping: default_workflows.cloudify.plugins.workflows.reinstall
+    is_cascading: false
+    parameters:
+      ignore_failure:
+        default: false
+        type: boolean
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
   start:
     mapping: default_workflows.cloudify.plugins.workflows.start
     is_cascading: false

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -326,6 +326,7 @@ class TestInstallWorkflowFiltering(LifecycleBaseTest):
             else:
                 assert inst.state != 'started'
 
+
 class TestReinstallWorkflow(LifecycleBaseTest):
     blueprint = """
         tosca_definitions_version: cloudify_dsl_1_3
@@ -342,7 +343,7 @@ class TestReinstallWorkflow(LifecycleBaseTest):
                 type: t1
             n2:
                 type: t1
-    """
+    """  # NOQA
 
     def _invocations(self, cfy_local, node_instance_id):
         instance = cfy_local.storage.get_node_instance(node_instance_id)

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -326,6 +326,92 @@ class TestInstallWorkflowFiltering(LifecycleBaseTest):
             else:
                 assert inst.state != 'started'
 
+class TestReinstallWorkflow(LifecycleBaseTest):
+    blueprint = """
+        tosca_definitions_version: cloudify_dsl_1_3
+        imports: [minimal_types.yaml]
+        node_types:
+            t1:
+                derived_from: cloudify.nodes.Root
+                interfaces:
+                    cloudify.interfaces.lifecycle:
+                        create: default_workflows.cloudify.tests.test_builtin_workflows.node_operation
+                        delete: default_workflows.cloudify.tests.test_builtin_workflows.node_operation
+        node_templates:
+            n1:
+                type: t1
+            n2:
+                type: t1
+    """
+
+    def _invocations(self, cfy_local, node_instance_id):
+        instance = cfy_local.storage.get_node_instance(node_instance_id)
+        return instance.runtime_properties['invocations']
+
+    @workflow_test(
+        blueprint,
+        resources_to_copy=['resources/blueprints/minimal_types.yaml'],
+    )
+    def test_reinstall_all(self, cfy_local):
+        cfy_local.execute('install')
+        cfy_local.execute('reinstall')
+        instances = cfy_local.storage.get_node_instances()
+        assert len(instances) == 2
+        for instance in instances:
+            invocations = self._invocations(cfy_local, instance.id)
+            assert [inv['operation'] for inv in invocations] == [
+                # first, the ndoe was installed...
+                'cloudify.interfaces.lifecycle.create',
+                # ...and then reinstalled
+                'cloudify.interfaces.lifecycle.delete',
+                'cloudify.interfaces.lifecycle.create',
+            ]
+
+    @workflow_test(
+        blueprint,
+        resources_to_copy=['resources/blueprints/minimal_types.yaml'],
+    )
+    def test_reinstall_node_id(self, cfy_local):
+        # both nodes are installed, but only n2 is reinstalled
+        cfy_local.execute('install')
+        cfy_local.execute('reinstall', {
+            'node_ids': ['n2'],
+        })
+        instances = cfy_local.storage.get_node_instances()
+        assert len(instances) == 2
+        for instance in instances:
+            invocations = self._invocations(cfy_local, instance.id)
+            expected = ['cloudify.interfaces.lifecycle.create']
+            if instance.node_id == 'n2':
+                # only node2 was reinstalled
+                expected += [
+                    'cloudify.interfaces.lifecycle.delete',
+                    'cloudify.interfaces.lifecycle.create',
+                ]
+            assert [inv['operation'] for inv in invocations] == expected
+
+    @workflow_test(
+        blueprint,
+        resources_to_copy=['resources/blueprints/minimal_types.yaml'],
+    )
+    def test_reinstall_without_install(self, cfy_local):
+        # without an install first, instances are still reinstalled,
+        # ie. that STILL calls delete first.
+        # This might very well change in the future, but for right now,
+        # let's assume that the user called reinstall (and not install),
+        # because they knew what they were doing!
+
+        cfy_local.execute('reinstall')
+        instances = cfy_local.storage.get_node_instances()
+        assert len(instances) == 2
+        for instance in instances:
+            invocations = self._invocations(cfy_local, instance.id)
+            assert [inv['operation'] for inv in invocations] == [
+                # instance was reinstalled only, not installed first
+                'cloudify.interfaces.lifecycle.delete',
+                'cloudify.interfaces.lifecycle.create',
+            ]
+
 
 class TestExecuteOperationWorkflow(LifecycleBaseTest):
     execute_blueprint_path = path.join('resources', 'blueprints',


### PR DESCRIPTION
Now that `heal` is much more complex, there's no longer a simple way to "reinstall". We have the `LifecycleProcessor` method right there, all we need to do is to expose it.