### PR TITLE
RD-5953 Return context with IDDs

### DIFF
--- a/cloudify_rest_client/inter_deployment_dependencies.py
+++ b/cloudify_rest_client/inter_deployment_dependencies.py
@@ -28,6 +28,10 @@ class InterDeploymentDependency(dict):
         return self['id']
 
     @property
+    def target_deployment_func(self):
+        return self['target_deployment_func']
+
+    @property
     def dependency_creator(self):
         return self[DEPENDENCY_CREATOR]
 

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -1716,8 +1716,11 @@ class IDDFindingHandler(_EvaluationHandler):
         if func.scope == 'node_template':
             context['node'] = func.context['name']
         elif func.scope == 'node_template_relationship':
-            context['node'] = func.context['node_template']['name']
-            context['target'] = func.context['relationship']['target_id']
+            context = {
+                'node': func.context['node_template']['name'],
+                'target': func.context['relationship']['target_id'],
+                'type': func.context['relationship']['type'],
+            }
         dependency = IDDSpec(
             func.scope,
             context,

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -1670,8 +1670,9 @@ class IDDSpec(object):
 
         :param scope: func.scope of the creating function ("node_template")
         :param context: a dict containing optionally the keys:
-            - "node" - the node id - for node_template & relationship IDDs
-            - "target" - the relationship target node id - for rel. IDDs
+            - "node_name" - the node id - for node_template IDDs
+            - "target_node_name", "source_node_name" - the relationship
+              source and target node names - for relationship IDDs
         :param target_deployment: the IDDCreatingFunction's target_deployment -
             either a string target deployment id (if a literal was provided),
             or a function representation (arbitrarily-nested dict)
@@ -1702,12 +1703,12 @@ class IDDFindingHandler(_EvaluationHandler):
             return
         context = {}
         if func.scope == 'node_template':
-            context['node'] = func.context['name']
+            context['node_name'] = func.context['name']
         elif func.scope == 'node_template_relationship':
             context = {
-                'node': func.context['node_template']['name'],
-                'target': func.context['relationship']['target_id'],
-                'type': func.context['relationship']['type'],
+                'source_node_name': func.context['node_template']['name'],
+                'target_node_name': func.context['relationship']['target_id'],
+                'relationship_type': func.context['relationship']['type'],
             }
         dependency = IDDSpec(
             func.scope,

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -193,9 +193,6 @@ class Function(abc.ABC):
     def evaluate(self, handler):
         pass
 
-    def register_function_to_plan(self, plan):
-        pass
-
 
 @register(name='get_input', func_eval_type=HYBRID_FUNC)
 class GetInput(Function):
@@ -948,13 +945,6 @@ class MergeDicts(Function):
 
 
 class InterDeploymentDependencyCreatingFunction(Function):
-
-    def register_function_to_plan(self, plan):
-        plan.setdefault(
-            INTER_DEPLOYMENT_FUNCTIONS,
-            {}
-        )[self.function_identifier] = self.target_deployment
-
     @abc.abstractproperty
     def target_deployment(self):
         pass
@@ -1545,7 +1535,6 @@ class _PlanEvaluationHandler(_EvaluationHandler):
             if 'operation' in func.context:
                 func.context['operation']['has_intrinsic_functions'] = True
             return_value = func.raw
-        func.register_function_to_plan(self._plan)
         return return_value
 
     def get_input(self, input_name):

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -1719,6 +1719,24 @@ class IDDFindingHandler(_EvaluationHandler):
         self.dependencies.append(dependency)
 
 
+class SecretFindingHandler(_EvaluationHandler):
+    """An EvaluationHandler that finds secret names used in the plan."""
+    scan_replace = False
+
+    def __init__(self, plan):
+        self._plan = plan
+        self.secrets = set()
+
+    def evaluate_function(self, func):
+        if not isinstance(func, GetSecret):
+            return
+        secret_name = func.secret_id
+        if isinstance(secret_name, list):
+            secret_name = secret_name[0]
+        if isinstance(secret_name, str):
+            self.secrets.add(secret_name)
+
+
 def plan_evaluation_handler(plan, runtime_only_evaluation=False):
     return _PlanEvaluationHandler(plan, runtime_only_evaluation)
 

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -25,7 +25,6 @@ from dsl_parser import exceptions, scan, constants
 from dsl_parser.constants import (OUTPUTS,
                                   CAPABILITIES,
                                   NODE_INSTANCES,
-                                  INTER_DEPLOYMENT_FUNCTIONS,
                                   EVAL_FUNCS_PATH_PREFIX_KEY,
                                   EVAL_FUNCS_PATH_DEFAULT_PREFIX)
 from dsl_parser.utils import (TEMPLATE_FUNCTIONS,

--- a/dsl_parser/tasks.py
+++ b/dsl_parser/tasks.py
@@ -168,8 +168,8 @@ def _find_rel_target_by_iddspec(relationships, idd_spec):
     """
     assert idd_spec.scope == 'node_template_relationship'
 
-    target_name = idd_spec.context['target']  # target _node_ name
-    rel_type = idd_spec.context['type']
+    target_name = idd_spec.context['target_node_name']
+    rel_type = idd_spec.context['relationship_type']
 
     for relationship in relationships:
         if (
@@ -215,7 +215,7 @@ def _format_idds(plan, dep_specs):
         if idd_spec.scope == 'node_template':
             # the IDDSpec is a node one (e.g. in node properties):
             # create an instance of IDD, for every node-instance of the node
-            node_name = idd_spec.context['node']
+            node_name = idd_spec.context['node_name']
             for ni in nis_by_node[node_name]:
                 idd = idd_base.copy()
                 idd['context'] = {
@@ -227,7 +227,7 @@ def _format_idds(plan, dep_specs):
             # the IDDSpec is a relationship one (e.g. in relationship operation
             # inputs) - create an instance of IDD for every node-instance of
             # the source node
-            node_name = idd_spec.context['node']
+            node_name = idd_spec.context['source_node_name']
 
             for ni in nis_by_node[node_name]:
                 target_id = _find_rel_target_by_iddspec(

--- a/dsl_parser/tasks.py
+++ b/dsl_parser/tasks.py
@@ -219,7 +219,7 @@ def _format_idds(plan, dep_specs):
             for ni in nis_by_node[node_name]:
                 idd = idd_base.copy()
                 idd['context'] = {
-                    'SELF': ni['id'],
+                    'self': ni['id'],
                 }
                 idds.append(idd)
 
@@ -236,9 +236,9 @@ def _format_idds(plan, dep_specs):
                 )
                 idd = idd_base.copy()
                 idd['context'] = {
-                    'SELF': ni['id'],
-                    'SOURCE': ni['id'],
-                    'TARGET': target_id,
+                    'self': ni['id'],
+                    'source': ni['id'],
+                    'target': target_id,
                 }
                 idds.append(idd)
         else:

--- a/dsl_parser/tasks.py
+++ b/dsl_parser/tasks.py
@@ -25,7 +25,9 @@ from dsl_parser import (scan,
                         exceptions,
                         constraints,
                         multi_instance)
-from dsl_parser.constants import INPUTS, DEFAULT, DATA_TYPES, TYPE, ITEM_TYPE
+from dsl_parser.constants import (
+    INPUTS, DEFAULT, DATA_TYPES, TYPE, ITEM_TYPE, INTER_DEPLOYMENT_FUNCTIONS,
+)
 from dsl_parser.multi_instance import modify_deployment
 
 
@@ -293,5 +295,5 @@ def prepare_deployment_plan(plan, get_secret_method=None, inputs=None,
     _validate_secrets(plan, get_secret_method)
     dep_specs = _find_idd_creating_functions(plan)
     dep_plan = multi_instance.create_deployment_plan(plan, existing_ni_ids)
-    idds = _format_idds(dep_plan, dep_specs)
+    dep_plan[INTER_DEPLOYMENT_FUNCTIONS] = _format_idds(dep_plan, dep_specs)
     return dep_plan

--- a/dsl_parser/tests/test_get_capability.py
+++ b/dsl_parser/tests/test_get_capability.py
@@ -302,8 +302,8 @@ node_templates:
         instance_id = parsed['node_instances'][0]['id']
         idds = parsed[INTER_DEPLOYMENT_FUNCTIONS]
         assert len(idds) == 1
-        assert 'SELF' in idds[0]['context']
-        assert instance_id == idds[0]['context']['SELF']
+        assert 'self' in idds[0]['context']
+        assert instance_id == idds[0]['context']['self']
 
     def test_idd_stores_relationship_context(self):
         yaml = """
@@ -351,7 +351,7 @@ node_templates:
             ni['node_id']: ni['id'] for ni in parsed['node_instances']
         }
         contexts = {
-            (idd['context']['SOURCE'], idd['context']['TARGET'])
+            (idd['context']['source'], idd['context']['target'])
             for idd in idds
         }
         assert contexts == {

--- a/dsl_parser/tests/test_get_capability.py
+++ b/dsl_parser/tests/test_get_capability.py
@@ -305,7 +305,6 @@ node_templates:
         assert 'SELF' in idds[0]['context']
         assert instance_id == idds[0]['context']['SELF']
 
-
     def test_idd_stores_relationship_context(self):
         yaml = """
 node_types:
@@ -348,7 +347,9 @@ node_templates:
         parsed = prepare_deployment_plan(self.parse(yaml))
         idds = parsed[INTER_DEPLOYMENT_FUNCTIONS]
 
-        instance_ids = {ni['node_id']: ni['id'] for ni in parsed['node_instances']}
+        instance_ids = {
+            ni['node_id']: ni['id'] for ni in parsed['node_instances']
+        }
         contexts = {
             (idd['context']['SOURCE'], idd['context']['TARGET'])
             for idd in idds


### PR DESCRIPTION
When computing IDDs, it's not enough to just return the function representation, because to evaluate that function later, we also need the context!

That is because e.g. `{get_capability: [dep1, {get_attribute: [SELF, x]}]}` depends on SELF, so we need to know the node instance id in order to evaluate that.

So, in this PR, we make sure to return IDDs in a new format: instead of the old:
```python
{
   'nodes.n1.properties.xxx': {'get_capability': ['dep1', 'x']},
   'nodes.n2.properties.yyy': {'get_capability': ['dep2', 'y']}
}
```
we will now be returning IDDs in the deployment plan in the format of:
```python
[
    {
        'function_identifier': 'nodes.n1.properties.xxx',
        'target_deployment': {'get_capability': ['dep1', 'x']},
        'context': {
            'SELF': 'n1_abcdef',
        }
    }
]
```

In order to do this,
1. Rewrite IDD gathering - instead of registering to plan while evaluating functions, have a separate explicit step that goes through the plan and finds the functions
2. After creating the deployment plan, correlate the IDDCreatingFunctions, with actual node instances, so if there's a IDD function on `nodes.n1`, and there's 10 node-instances of n1, there will be 10 instances of IDD returned
3. ...and a bit unrelated, but since in 1 we learned how to do this, apply this plan-traversing idea to secrets as well, so we can lose the old `global` approach

(I do recommend viewing commits separately)