### PR TITLE
RD-6445 Add `get_attribute: node_instance_index`

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -651,14 +651,14 @@ def _get_attribute_from_node_instance(ni, node, attribute_path, path,
                                 raise_if_not_found=False,
                                 func_name=fn_name)
 
-    if value is None:
-        # attribute not found in instance runtime properties
-        # special case for { get_attributes_list: [
-        #                        ..., node_instance_id] }
-        # returns the node-instance-id
-        if len(attribute_path) == 1\
-                and attribute_path[0] == 'node_instance_id':
+    if value is None and len(attribute_path) == 1:
+        # specialcase some get_attribute parameters:
+        # - node_instance_id returns the node instance ID
+        # - node_instance_index returns the node instance index
+        if attribute_path[0] == 'node_instance_id':
             value = ni['id']
+        elif attribute_path[0] == 'node_instance_index':
+            value = ni['index']
     # still nothing? look in node properties
     if value is None:
         value = _get_property_value(node['id'],

--- a/dsl_parser/tests/test_get_attribute.py
+++ b/dsl_parser/tests/test_get_attribute.py
@@ -520,3 +520,54 @@ class TestEvaluateFunctions(AbstractTestParser):
             '.*unambiguously.*',
         ):
             functions.evaluate_functions(payload, {}, storage)
+
+    def test_get_node_instance_id(self):
+        """{get_attribute: [x, node_instance_id]} returns the ID"""
+        node_instances = [{
+            'id': 'node_1',
+            'node_id': 'node',
+        }]
+        nodes = [{'id': 'node'}]
+        storage = self.mock_evaluation_storage(node_instances, nodes)
+        payload = {'value': {'get_attribute': ['node', 'node_instance_id']}}
+        functions.evaluate_functions(payload, {}, storage)
+        assert payload['value'] == 'node_1'
+
+    def test_get_node_instance_id_override(self):
+        """node_instance_id can be overridden by runtime-props"""
+        node_instances = [{
+            'id': 'node_1',
+            'node_id': 'node',
+            'runtime_properties': {'node_instance_id': 'overridden'},
+        }]
+        nodes = [{'id': 'node'}]
+        storage = self.mock_evaluation_storage(node_instances, nodes)
+        payload = {'value': {'get_attribute': ['node', 'node_instance_id']}}
+        functions.evaluate_functions(payload, {}, storage)
+        assert payload['value'] == 'overridden'
+
+    def test_get_node_instance_index(self):
+        """{get_attribute: [x, node_instance_index]} returns the index"""
+        node_instances = [{
+            'id': 'node_1',
+            'node_id': 'node',
+            'index': 1,
+        }]
+        nodes = [{'id': 'node'}]
+        storage = self.mock_evaluation_storage(node_instances, nodes)
+        payload = {'value': {'get_attribute': ['node', 'node_instance_index']}}
+        functions.evaluate_functions(payload, {}, storage)
+        assert payload['value'] == 1
+
+    def test_get_node_instance_index_override(self):
+        """node_instance_id can be overridden by runtime-props"""
+        node_instances = [{
+            'id': 'node_1',
+            'node_id': 'node',
+            'runtime_properties': {'node_instance_index': 42},
+        }]
+        nodes = [{'id': 'node'}]
+        storage = self.mock_evaluation_storage(node_instances, nodes)
+        payload = {'value': {'get_attribute': ['node', 'node_instance_index']}}
+        functions.evaluate_functions(payload, {}, storage)
+        assert payload['value'] == 42


### PR DESCRIPTION
Now, you can do `{get_attribute: [n1, node_instance_index]}` in your blueprints (similar to node_instance_id).

Before, the index was only available python-side, as ctx.instance.index