### PR TITLE
SecretProviders create: fixup connection_parameters syntax

### DIFF
--- a/cloudify_rest_client/secrets_providers.py
+++ b/cloudify_rest_client/secrets_providers.py
@@ -102,7 +102,7 @@ class SecretsProvidersClient(object):
         }
 
         if connection_parameters:
-            data['connection_parameters']: connection_parameters
+            data['connection_parameters'] = connection_parameters
 
         response = self.api.put('/secrets-providers', data=data)
 


### PR DESCRIPTION
Funnily, the `:` was valid syntax, because it was then a... type declaration?