### PR TITLE
RD-6226 Optimize all tasks graphs when storing them

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -243,7 +243,6 @@ class LifecycleProcessor(object):
                 'stub_{0}'.format(instance.id))
 
         graph_finisher_func(self.graph, subgraphs)
-        self.graph.optimize()
         return self.graph
 
     def _finish_install(self, graph, subgraphs):

--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -1029,8 +1029,9 @@ def _make_check_status_graph(
             operation='cloudify.interfaces.validation.check_status'
         )
         task.info = {'instance_id': instance.id}
-        task.on_success = check_status_on_success
-        task.on_failure = on_fail
+        if not task.is_nop():
+            task.on_success = check_status_on_success
+            task.on_failure = on_fail
         graph.add_task(task)
         tasks[instance.id] = task
 
@@ -1101,8 +1102,9 @@ def _make_check_drift_graph(
             operation='cloudify.interfaces.lifecycle.check_drift'
         )
         task.info = {'instance_id': instance.id}
-        task.on_success = check_drift_on_success
-        task.on_failure = on_fail
+        if not task.is_nop():
+            task.on_success = check_drift_on_success
+            task.on_failure = on_fail
         graph.add_task(task)
         tasks[instance.id] = task
         for rel in instance.relationships:
@@ -1110,8 +1112,9 @@ def _make_check_drift_graph(
                 'cloudify.interfaces.relationship_lifecycle.check_drift')
             target_task = rel.execute_target_operation(
                 'cloudify.interfaces.relationship_lifecycle.check_drift')
-            source_task.on_success = check_drift_on_success
-            source_task.on_failure = on_fail
+            if not source_task.is_nop():
+                source_task.on_success = check_drift_on_success
+                source_task.on_failure = on_fail
             graph.add_task(source_task)
             graph.add_dependency(source_task, task)
             source_task.info = {
@@ -1119,8 +1122,9 @@ def _make_check_drift_graph(
                 'relationship_target': rel.target_id,
             }
 
-            target_task.on_success = check_drift_on_success
-            target_task.on_failure = on_fail
+            if not target_task.is_nop():
+                target_task.on_success = check_drift_on_success
+                target_task.on_failure = on_fail
             graph.add_task(target_task)
             graph.add_dependency(target_task, task)
             target_task.info = {

--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -125,13 +125,17 @@ def _find_healthy_instances(instances, require_task=False):
     for instance in instances:
         try:
             status = instance.system_properties['status']
-            if not status['ok']:
-                continue
-            if require_task and not status['task']:
-                continue
-            healthy_instances.add(instance)
+            task = status['task']
+            ok = status['ok']
         except KeyError:
-            pass
+            task = None
+            ok = None
+
+        if (
+            ok or
+            task is None and not require_task
+        ):
+            healthy_instances.add(instance)
     return healthy_instances
 
 

--- a/cloudify/tests/resources/blueprints/test-check-status.yaml
+++ b/cloudify/tests/resources/blueprints/test-check-status.yaml
@@ -19,8 +19,11 @@ node_templates:
     interfaces:
       cloudify.interfaces.validation:
         check_status: mock.cloudify.tests.test_builtin_workflows.node_operation
-  node_undefined:
+  node_related:
     type: cloudify.nodes.Root
     relationships:
       - type: cloudify.relationships.depends_on
         target: node_failing
+    interfaces:
+      cloudify.interfaces.validation:
+        check_status: mock.cloudify.tests.test_builtin_workflows.node_operation

--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -1188,17 +1188,17 @@ class TestCheckStatus(unittest.TestCase):
             node_id='node_passing')
         fail_instances = cfy_local.storage.get_node_instances(
             node_id='node_failing')
-        noop_instances = cfy_local.storage.get_node_instances(
-            node_id='node_undefined')
+        rel_instances = cfy_local.storage.get_node_instances(
+            node_id='node_related')
         assert len(pass_instances) == 1
         assert len(fail_instances) == 1
-        assert len(noop_instances) == 1
+        assert len(rel_instances) == 1
 
         pass_instance = pass_instances[0]
         assert pass_instance['system_properties']['status']['ok']
 
         # the noop instance did run, even though it depends on a failing one
-        noop_instance = noop_instances[0]
+        noop_instance = rel_instances[0]
         assert 'status' in noop_instance['system_properties']
         assert noop_instance['system_properties']['status']['ok']
 
@@ -1220,10 +1220,10 @@ class TestCheckStatus(unittest.TestCase):
         )
         fail_instances = cfy_local.storage.get_node_instances(
             node_id='node_failing')
-        noop_instances = cfy_local.storage.get_node_instances(
-            node_id='node_undefined')
+        rel_instances = cfy_local.storage.get_node_instances(
+            node_id='node_related')
         assert len(fail_instances) == 1
-        assert len(noop_instances) == 1
+        assert len(rel_instances) == 1
 
         fail_instance = fail_instances[0]
         assert fail_instance['system_properties']['status']
@@ -1231,7 +1231,7 @@ class TestCheckStatus(unittest.TestCase):
 
         # with run_by_dependency_order, the noop instance didn't even run,
         # because it depends on a failing task
-        noop_instance = noop_instances[0]
+        noop_instance = rel_instances[0]
         assert 'status' not in noop_instance['system_properties']
 
 
@@ -1262,7 +1262,6 @@ class TestCheckDrift(unittest.TestCase):
             'target_relationships_configuration_drift'
         }
         assert set(relation_instances[0].system_properties.keys()) == {
-            'configuration_drift',
             'source_relationships_configuration_drift'
         }
 

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -814,7 +814,10 @@ class NOPLocalWorkflowTask(WorkflowTask):
         return self.async_result
 
     def is_nop(self):
-        return True
+        # If a nop has a success/failure handler, then it's not really
+        # a nop, because it does _do_ something, and can't be just dropped
+        # from the graph
+        return self.on_success is None and self.on_failure is None
 
     def is_local(self):
         return True

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -337,7 +337,9 @@ class TaskDependencyGraph(object):
         self._op_types_cache[task_type] = op_cls
         return op_cls
 
-    def store(self, name):
+    def store(self, name, optimize=True):
+        if optimize:
+            self.optimize()
         serialized_tasks = []
         for task in self._tasks.values():
             serialized = task.dump()


### PR DESCRIPTION
- optimize on store
- keep NOP tasks that aren't "really" NOPs
- make heal cope with missing status

This way, we'll drop "real" NOPs from the graph (check_drift/check_status), but we'll still keep tasks that do have success/failure handlers