### PR TITLE
RD-6537 client.agents.list(): include all agents

### DIFF
--- a/cloudify_rest_client/agents.py
+++ b/cloudify_rest_client/agents.py
@@ -160,7 +160,6 @@ class AgentsClient(object):
             _include = ['id', 'host_id', 'ip', 'install_method', 'system',
                         'version', 'node', 'deployment', 'tenant_name']
 
-        kwargs.setdefault('state', [AgentState.STARTED])
         response = self.api.get('/{self._uri_prefix}'.format(self=self),
                                 _include=_include,
                                 params=kwargs)

--- a/cloudify_rest_client/agents.py
+++ b/cloudify_rest_client/agents.py
@@ -154,12 +154,6 @@ class AgentsClient(object):
         if sort:
             kwargs['_sort'] = '-' + sort if is_descending else sort
 
-        if _include is None:
-            # Default the _include to what was available before, to avoid
-            # defaulting to including credentials, etc
-            _include = ['id', 'host_id', 'ip', 'install_method', 'system',
-                        'version', 'node', 'deployment', 'tenant_name']
-
         response = self.api.get('/{self._uri_prefix}'.format(self=self),
                                 _include=_include,
                                 params=kwargs)


### PR DESCRIPTION
I don't really see a reason to have this default filter. The original ticket didn't mention it.
Possibly back then we were creating many failed agents? But now, it's more stable, so let's just list all of them.