### PR TITLE
RD-6597 get_input: don't break on empty data type attributes

### DIFF
--- a/cloudify/tests/test_builtin_workflows.py
+++ b/cloudify/tests/test_builtin_workflows.py
@@ -19,7 +19,7 @@ import unittest
 from collections import Counter
 from os import path
 
-import mock
+from unittest import mock
 
 from cloudify import exceptions
 from cloudify.plugins import lifecycle

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -14,16 +14,16 @@
 #    * limitations under the License.
 
 import logging
-import mock
 import sys
 import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import pytest
 import requests
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from cloudify_rest_client.exceptions import CloudifyClientError
 

--- a/cloudify/tests/test_decorators.py
+++ b/cloudify/tests/test_decorators.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 import warnings
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from cloudify import ctx as ctx_proxy
 from cloudify import context

--- a/cloudify/tests/test_dispatch.py
+++ b/cloudify/tests/test_dispatch.py
@@ -14,7 +14,7 @@
 #    * limitations under the License.
 
 import unittest
-from mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 
 from cloudify import dispatch
 from cloudify import exceptions

--- a/cloudify/tests/test_keep_trying_http.py
+++ b/cloudify/tests/test_keep_trying_http.py
@@ -1,5 +1,5 @@
 import pytest
-from mock.mock import patch, Mock
+from unittest.mock import patch, Mock
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 from cloudify.context import CloudifyContext

--- a/cloudify/tests/test_operation_retry.py
+++ b/cloudify/tests/test_operation_retry.py
@@ -17,7 +17,7 @@ import unittest
 from io import StringIO
 from os import path
 
-from mock import patch
+from unittest.mock import patch
 
 from cloudify import context
 from cloudify import decorators

--- a/cloudify/tests/test_task_retry_event_context.py
+++ b/cloudify/tests/test_task_retry_event_context.py
@@ -16,7 +16,7 @@
 from os import path
 
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from cloudify import decorators
 from cloudify import exceptions

--- a/cloudify/tests/test_task_subgraph.py
+++ b/cloudify/tests/test_task_subgraph.py
@@ -13,8 +13,8 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import mock
 import unittest
+from unittest import mock
 
 from cloudify import decorators
 from cloudify.workflows import tasks

--- a/cloudify/tests/test_tasks_graph.py
+++ b/cloudify/tests/test_tasks_graph.py
@@ -13,10 +13,10 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import mock
 import time
 import unittest
 from contextlib import contextmanager
+from unittest import mock
 
 from cloudify_rest_client.operations import Operation
 

--- a/cloudify/tests/test_utils.py
+++ b/cloudify/tests/test_utils.py
@@ -14,11 +14,10 @@
 #    * limitations under the License.
 
 import os
-import mock
 import shutil
 import logging
 import tempfile
-from unittest import TestCase
+from unittest import TestCase, mock
 from datetime import datetime, timedelta
 
 from cloudify import utils

--- a/cloudify_rest_client/tests/__init__.py
+++ b/cloudify_rest_client/tests/__init__.py
@@ -1,7 +1,7 @@
 from cloudify import constants
 from cloudify_rest_client import CloudifyClient
 
-import mock
+from unittest import mock
 
 
 class MockHTTPClient(CloudifyClient.client_class):

--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -227,7 +227,6 @@ class GetInput(Function):
                 "unknown input '{0}'.".format(input_value))
 
     def evaluate(self, handler):
-        return_value = None
         if isinstance(self.input_value, list):
             if any(get_function(x) for x in self.input_value):
                 raise exceptions.FunctionEvaluationError(
@@ -236,12 +235,12 @@ class GetInput(Function):
 
             return_value = self._get_input_attribute(
                 handler.get_input(self.input_value[0]))
-
-        if get_function(self.input_value):
-            raise exceptions.FunctionEvaluationError(
-                '{0}: found an unresolved argument: {1}'
-                .format(self.name, self.input_value))
-        return_value = return_value or handler.get_input(self.input_value)
+        else:
+            if get_function(self.input_value):
+                raise exceptions.FunctionEvaluationError(
+                    '{0}: found an unresolved argument: {1}'
+                    .format(self.name, self.input_value))
+            return_value = handler.get_input(self.input_value)
 
         if self.return_type:
             _, ok = parse_simple_type_value(return_value, self.return_type)

--- a/dsl_parser/tests/abstract_test_parser.py
+++ b/dsl_parser/tests/abstract_test_parser.py
@@ -20,7 +20,7 @@ from urllib.request import pathname2url
 from urllib.parse import urljoin
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 
 from cloudify.utils import uuid4
 from dsl_parser.exceptions import DSLParsingException

--- a/dsl_parser/tests/scaling/test_multi_instance.py
+++ b/dsl_parser/tests/scaling/test_multi_instance.py
@@ -15,8 +15,7 @@
 
 import itertools
 import random
-
-from mock import patch
+from unittest.mock import patch
 
 from dsl_parser import exceptions
 from dsl_parser.tests import scaling

--- a/dsl_parser/tests/test_constraints.py
+++ b/dsl_parser/tests/test_constraints.py
@@ -14,7 +14,7 @@
 #    * limitations under the License.
 
 import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from dsl_parser import exceptions
 from dsl_parser import constraints

--- a/dsl_parser/tests/test_default_import_resolver.py
+++ b/dsl_parser/tests/test_default_import_resolver.py
@@ -13,9 +13,9 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import mock
 import requests
 import unittest
+from unittest import mock
 
 from dsl_parser.exceptions import DSLParsingLogicException
 from dsl_parser.import_resolver.default_import_resolver import \

--- a/dsl_parser/tests/test_functions.py
+++ b/dsl_parser/tests/test_functions.py
@@ -927,6 +927,38 @@ node_templates:
                 exceptions.InputEvaluationError, 'does not match data type'):
             prepare_deployment_plan(self.parse(yaml))
 
+    def test_get_input_fetch_from_datatype(self):
+        yaml = """
+inputs:
+    inp1:
+        type: type1
+        default: {}
+data_types:
+    type1:
+        properties:
+            property1:
+                default: 'abc'
+            property2:
+                default:
+                    nested:
+                        x:
+                            'def'
+            property3:
+                default: ''
+outputs:
+    out1:
+        value: {get_input: [inp1, property1]}
+    out2:
+        value: {get_input: [inp1, property2, nested, x]}
+    out3:
+        value: {get_input: [inp1, property3]}
+"""
+        plan = prepare_deployment_plan(self.parse_1_5(yaml))
+        assert plan
+        assert plan['outputs']['out1']['value'] == 'abc'
+        assert plan['outputs']['out2']['value'] == 'def'
+        assert plan['outputs']['out3']['value'] == ''
+
 
 class TestGetAttribute(AbstractTestParser):
 

--- a/dsl_parser/tests/test_get_secret.py
+++ b/dsl_parser/tests/test_get_secret.py
@@ -13,7 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-from mock import Mock
+from unittest.mock import Mock
 
 from dsl_parser import functions
 from dsl_parser import exceptions

--- a/dsl_parser/tests/test_plugin_properties.py
+++ b/dsl_parser/tests/test_plugin_properties.py
@@ -1,5 +1,6 @@
+from unittest.mock import patch
+
 import pytest
-from mock import patch
 
 from dsl_parser.exceptions import (DSLParsingFormatException,
                                    DSLParsingLogicException)

--- a/script_runner/tests/test_script_runner.py
+++ b/script_runner/tests/test_script_runner.py
@@ -19,9 +19,9 @@ import shutil
 import os
 import unittest
 from collections import namedtuple
+from unittest.mock import patch
 
 import requests
-from mock import patch
 import pytest
 
 from . import string_in_log

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-mock>=1.0.1
 pytest
 pytest-cov
 pytest-xdist==2.5.0


### PR DESCRIPTION
If input_value is a list, under no circumstances pass it to handler.get_input. That doesn't make any sense.
It'll be just a typeerror.