### PR TITLE
RD-6598 Allow functions in constraint values

### DIFF
--- a/dsl_parser/constraints.py
+++ b/dsl_parser/constraints.py
@@ -374,9 +374,12 @@ def validate_args(constraint_cls, args, ancestor):
     :param ancestor: ancestor element of this constraint.
     :raises DSLParsingFormatException: in case of a violation.
     """
-    if utils.get_function(args) \
-            or not VALIDATION_FUNCTIONS[
-                constraint_cls.constraint_data_type](args):
+    if utils.get_function(args):
+        # allow functions to be constraint values. Those need to be
+        # evaluated before actually checking the constraints (when creating
+        # the deployment, with concrete input values).
+        return
+    if not VALIDATION_FUNCTIONS[constraint_cls.constraint_data_type](args):
         raise exceptions.DSLParsingLogicException(
             exceptions.ERROR_INVALID_CONSTRAINT_ARGUMENT,
             'Invalid constraint operator argument "{0}", for constraint '

--- a/dsl_parser/tests/test_constraints.py
+++ b/dsl_parser/tests/test_constraints.py
@@ -34,16 +34,6 @@ class TestGeneralUtilFunctions(unittest.TestCase):
                 None,
                 None)
 
-    def test_validate_args_raises_with_func_as_input(self):
-        constraint_cls_mock = MagicMock()
-        constraint_cls_mock.constraint_data_type = 'some_type'
-        self.assertRaises(
-            exceptions.DSLParsingLogicException,
-            constraints.validate_args,
-            constraint_cls_mock,
-            {'get_input': 'shouldnt matter'},
-            None)
-
     def test_validate_args_successful(self):
         validation_funcs_mock = {'some_type': lambda _: True}
         with patch.dict('dsl_parser.constraints.VALIDATION_FUNCTIONS',


### PR DESCRIPTION
It seems it just works. We already evaluate them in create-dep-env.

Of course, sometimes the output of the function won't make sense for the given constraint (e.g. giving a string, rather than an umber, to max_length), but then that just has to be a runtime error...