### PR TITLE
RD-6652 Scale: don't run unnecessary operations

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -115,15 +115,18 @@ def execute_unlink_relationships(graph,
     processor.uninstall()
 
 
-def rollback_node_instances(graph,
-                            node_instances,
-                            related_nodes=None,
-                            name_prefix=''):
+def rollback_node_instances(
+    graph,
+    node_instances,
+    related_nodes=None,
+    name_prefix='',
+    ignore_failure=True,
+):
     processor = LifecycleProcessor(graph=graph,
                                    node_instances=node_instances,
                                    related_nodes=related_nodes,
                                    name_prefix=name_prefix,
-                                   ignore_failure=True)
+                                   ignore_failure=ignore_failure)
 
     processor.rollback()
 

--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -686,7 +686,7 @@ def scale_entity(ctx,
                 ctx.logger.error('Scale out failed, scaling back in.')
                 for task in graph.tasks:
                     graph.remove_task(task)
-                lifecycle.uninstall_node_instances(
+
                 # refresh the added instances, to get new and updated
                 # instance statuses, after the failed install
                 ctx.refresh_node_instances()
@@ -696,6 +696,7 @@ def scale_entity(ctx,
                     if i.modification == 'added'
                 }
 
+                lifecycle.rollback_node_instances(
                     graph=graph,
                     node_instances=added,
                     ignore_failure=ignore_failure,

--- a/cloudify/plugins/workflows.py
+++ b/cloudify/plugins/workflows.py
@@ -658,15 +658,22 @@ def scale_entity(ctx,
                 # 'removed_ids_include_hint': []
             }
         })
+    ctx.refresh_node_instances()
     graph = ctx.graph_mode()
     try:
         ctx.logger.info('Deployment modification started. '
                         '[modification_id={0}]'.format(modification.id))
         if delta > 0:
-            added_and_related = set(modification.added.node_instances)
-            added = set(i for i in added_and_related
-                        if i.modification == 'added')
-            related = added_and_related - added
+            added = {
+                ctx.get_node_instance(i.id)
+                for i in modification.added.node_instances
+                if i.modification == 'added'
+            }
+            related = {
+                ctx.get_node_instance(i.id)
+                for i in modification.added.node_instances
+                if i.modification != 'added'
+            }
             try:
                 lifecycle.install_node_instances(
                     graph=graph,
@@ -676,21 +683,35 @@ def scale_entity(ctx,
                 if not rollback_if_failed:
                     ctx.logger.error('Scale out failed.')
                     raise
-
                 ctx.logger.error('Scale out failed, scaling back in.')
                 for task in graph.tasks:
                     graph.remove_task(task)
                 lifecycle.uninstall_node_instances(
+                # refresh the added instances, to get new and updated
+                # instance statuses, after the failed install
+                ctx.refresh_node_instances()
+                added = {
+                    ctx.get_node_instance(i.id)
+                    for i in modification.added.node_instances
+                    if i.modification == 'added'
+                }
+
                     graph=graph,
                     node_instances=added,
                     ignore_failure=ignore_failure,
                     related_nodes=related)
                 raise
         else:
-            removed_and_related = set(modification.removed.node_instances)
-            removed = set(i for i in removed_and_related
-                          if i.modification == 'removed')
-            related = removed_and_related - removed
+            removed = {
+                ctx.get_node_instance(i.id)
+                for i in modification.removed.node_instances
+                if i.modification == 'removed'
+            }
+            related = {
+                ctx.get_node_instance(i.id)
+                for i in modification.removed.node_instances
+                if i.modification != 'removed'
+            }
             lifecycle.uninstall_node_instances(
                 graph=graph,
                 node_instances=removed,


### PR DESCRIPTION
When rolling back after a failed scale, only run the operations that are actually needed to roll back.

For example, if an instance failed creating, we don't need to `stop` it, only `delete`.