### PR TITLE
Cleanup: drop CloudifySystemWideWorkflowContext

### DIFF
--- a/cloudify/dispatch.py
+++ b/cloudify/dispatch.py
@@ -201,9 +201,6 @@ class WorkflowHandler(TaskHandler):
         # be imported when handling an operation
         # (only when handling a workflow)
         from cloudify.workflows import workflow_context
-
-        if getattr(self.func, 'workflow_system_wide', False):
-            return workflow_context.CloudifySystemWideWorkflowContext
         return workflow_context.CloudifyWorkflowContext
 
     def handle(self):

--- a/cloudify/logs.py
+++ b/cloudify/logs.py
@@ -76,17 +76,6 @@ def message_context_from_workflow_context(ctx):
     }
 
 
-def message_context_from_sys_wide_wf_context(ctx):
-    """Build a message context from a CloudifyWorkflowContext instance"""
-    return {
-        'blueprint_id': None,
-        'deployment_id': None,
-        'execution_id': ctx.execution_id,
-        'workflow_id': ctx.workflow_id,
-        'tenant': {'name': ctx.tenant_name},
-    }
-
-
 def message_context_from_workflow_node_instance_context(ctx):
     """Build a message context from a CloudifyWorkflowNode instance"""
     message_context = message_context_from_workflow_context(ctx.ctx)
@@ -133,13 +122,6 @@ class CloudifyWorkflowLoggingHandler(CloudifyBaseLoggingHandler):
     def __init__(self, ctx, out_func=None):
         CloudifyBaseLoggingHandler.__init__(
             self, ctx, out_func, message_context_from_workflow_context)
-
-
-class SystemWideWorkflowLoggingHandler(CloudifyBaseLoggingHandler):
-    """Class for writing system-wide workflow log messages to RabbitMQ"""
-    def __init__(self, ctx, out_func=None):
-        CloudifyBaseLoggingHandler.__init__(
-            self, ctx, out_func, message_context_from_sys_wide_wf_context)
 
 
 class CloudifyWorkflowNodeLoggingHandler(CloudifyBaseLoggingHandler):
@@ -206,21 +188,6 @@ def send_workflow_event(ctx, event_type,
     """
     _send_event(
         message_context_from_workflow_context(ctx),
-        event_type, message, args, additional_context, out_func)
-
-
-def send_sys_wide_wf_event(ctx, event_type, message=None, args=None,
-                           additional_context=None, out_func=None):
-    """Send a workflow event
-
-    :param ctx: A CloudifySystemWideWorkflowContext instance
-    :param event_type: The event type
-    :param message: The message
-    :param args: additional arguments that may be added to the message
-    :param additional_context: additional context to be added to the context
-    """
-    _send_event(
-        message_context_from_sys_wide_wf_context(ctx),
         event_type, message, args, additional_context, out_func)
 
 

--- a/cloudify/workflows/workflow_context.py
+++ b/cloudify/workflows/workflow_context.py
@@ -57,10 +57,8 @@ from cloudify.workflows import events
 from cloudify.workflows.tasks_graph import TaskDependencyGraph
 from cloudify.logs import (CloudifyWorkflowLoggingHandler,
                            CloudifyWorkflowNodeLoggingHandler,
-                           SystemWideWorkflowLoggingHandler,
                            init_cloudify_logger,
-                           send_workflow_event,
-                           send_sys_wide_wf_event)
+                           send_workflow_event)
 from cloudify.models_states import DeploymentModificationState
 
 
@@ -1216,14 +1214,6 @@ class CloudifyWorkflowContext(_WorkflowContextBase):
             *args, **kwargs)
 
 
-class CloudifySystemWideWorkflowContext(_WorkflowContextBase):
-    def __init__(self, ctx):
-        super(CloudifySystemWideWorkflowContext, self).__init__(
-            ctx,
-            SystemWideWfRemoteContextHandler
-        )
-
-
 class CloudifyWorkflowContextInternal(object):
 
     def __init__(self, workflow_context, handler):
@@ -1853,22 +1843,6 @@ class RemoteCloudifyWorkflowContextHandler(RemoteContextHandler):
                 deployment_id, _include=['scaling_groups'])
             self._scaling_groups = deployment['scaling_groups']
         return self._scaling_groups
-
-
-class SystemWideWfRemoteContextHandler(RemoteContextHandler):
-
-    def get_context_logging_handler(self):
-        return SystemWideWorkflowLoggingHandler(self.workflow_ctx,
-                                                out_func=logs.manager_log_out)
-
-    def send_workflow_event(self, event_type, message=None, args=None,
-                            additional_context=None):
-        send_sys_wide_wf_event(self.workflow_ctx,
-                               event_type=event_type,
-                               message=message,
-                               args=args,
-                               additional_context=additional_context,
-                               out_func=logs.manager_event_out)
 
 
 class LocalCloudifyWorkflowContextHandler(CloudifyWorkflowContextHandler):


### PR DESCRIPTION
We note that there's a few layers, but at the end, the only difference between the regular WorkflowContext and a SystemWideWorkflowContext is that one sends logs with `blueprint_id: ctx.blueprint.id`, and the other with `blueprint_id: None` (and deployment_id).

Alas, `ctx.blueprint.id` is already None for system-wide executions. So they are exactly the same, so we can simplify this.