### PR TITLE
RD-6744 Bring back python 3.6 CI

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -16,7 +16,7 @@
 import errno
 import os
 import warnings
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 
 from cloudify_rest_client.exceptions import CloudifyClientError
 from cloudify.endpoint import ManagerEndpoint, LocalEndpoint
@@ -122,11 +122,11 @@ class DeploymentWorkdirMixin:
         ```
         """
         if not deployment_workdirs_sync_required():
-            return nullcontext()
+            return utils.nullcontext()
 
         local_dir = self.local_deployment_workdir()
         if not local_dir:
-            return nullcontext()
+            return utils.nullcontext()
 
         return self._endpoint.sync_deployment_workdir(self.deployment.id,
                                                       local_dir)

--- a/cloudify/endpoint.py
+++ b/cloudify/endpoint.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 
 import os
-from contextlib import nullcontext
 
 from cloudify import constants
 from cloudify import manager
@@ -472,4 +471,4 @@ class LocalEndpoint(Endpoint):
         pass
 
     def sync_deployment_workdir(self, deployment_id, local_dir):
-        return nullcontext()
+        return utils.nullcontext()

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -412,13 +412,13 @@ class CloudifyContextTest(unittest.TestCase):
             with patch('cloudify_rest_client.client.HTTPClient.put',
                        return_value=Mock(ok=True)) as put_call:
                 ctx.upload_deployment_workdir()
-            assert put_call.call_args.args ==\
+            call_args, call_kwargs = put_call.call_args
+            assert call_args ==\
                    ('/resources/deployments/default_tenant/test_deployment/',)
-            assert put_call.call_args.kwargs['params'] == {'extract': 'yes'}
-            assert put_call.call_args.kwargs['url_prefix'] is False
-            assert isinstance(put_call.call_args.kwargs['data'],
-                              io.BufferedReader)
-            assert put_call.call_args.kwargs['data'].name.endswith('.tar.gz')
+            assert call_kwargs['params'] == {'extract': 'yes'}
+            assert call_kwargs['url_prefix'] is False
+            assert isinstance(call_kwargs['data'], io.BufferedReader)
+            assert call_kwargs['data'].name.endswith('.tar.gz')
         finally:
             shutil.rmtree(deployment_workdir_path)
 

--- a/cloudify/utils.py
+++ b/cloudify/utils.py
@@ -62,6 +62,27 @@ ENV_AGENT_LOG_MAX_HISTORY = 'AGENT_LOG_MAX_HISTORY'
 
 ADMIN_API_TOKEN_PATH = '/opt/mgmtworker/work/admin_token'
 
+try:
+    from contextlib import nullcontext
+except ImportError:
+    # python 3.6 doesn't have nullcontext, so let's pretty much copy over
+    # 3.7+'s implementation'
+    class nullcontext:
+        def __init__(self, enter_result=None):
+            self.enter_result = enter_result
+
+        def __enter__(self):
+            return self.enter_result
+
+        def __exit__(self, *excinfo):
+            pass
+
+        async def __aenter__(self):
+            return self.enter_result
+
+        async def __aexit__(self, *excinfo):
+            pass
+
 
 class ManagerVersion(object):
     """Cloudify manager version helper class."""

--- a/cloudify_rest_client/_datetime_compat.py
+++ b/cloudify_rest_client/_datetime_compat.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timezone, timedelta
+
+if hasattr(datetime, 'fromisoformat'):
+    datetime_fromisoformat = datetime.fromisoformat
+else:
+    # for python 3.6 compat, this is datetime.fromisoformat implementation
+    # copied straight from the cpython source code.
+    # When 3.6 requirement is dropped, this can be removed.
+
+    # Helpers for parsing the result of isoformat()
+    def _parse_isoformat_date(dtstr):
+        # It is assumed that this function will only be called with a
+        # string of length exactly 10, and (though this is not used) ASCII-only
+        year = int(dtstr[0:4])
+        if dtstr[4] != '-':
+            raise ValueError('Invalid date separator: %s' % dtstr[4])
+
+        month = int(dtstr[5:7])
+
+        if dtstr[7] != '-':
+            raise ValueError('Invalid date separator')
+
+        day = int(dtstr[8:10])
+
+        return [year, month, day]
+
+    def _parse_hh_mm_ss_ff(tstr):
+        # Parses things of the form HH[:MM[:SS[.fff[fff]]]]
+        len_str = len(tstr)
+
+        time_comps = [0, 0, 0, 0]
+        pos = 0
+        for comp in range(0, 3):
+            if (len_str - pos) < 2:
+                raise ValueError('Incomplete time component')
+
+            time_comps[comp] = int(tstr[pos:pos+2])
+
+            pos += 2
+            next_char = tstr[pos:pos+1]
+
+            if not next_char or comp >= 2:
+                break
+
+            if next_char != ':':
+                raise ValueError('Invalid time separator: %c' % next_char)
+
+            pos += 1
+
+        if pos < len_str:
+            if tstr[pos] != '.':
+                raise ValueError('Invalid microsecond component')
+            else:
+                pos += 1
+
+                len_remainder = len_str - pos
+                if len_remainder not in (3, 6):
+                    raise ValueError('Invalid microsecond component')
+
+                time_comps[3] = int(tstr[pos:])
+                if len_remainder == 3:
+                    time_comps[3] *= 1000
+
+        return time_comps
+
+    def _parse_isoformat_time(tstr):
+        # Format supported is HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]
+        len_str = len(tstr)
+        if len_str < 2:
+            raise ValueError('Isoformat time too short')
+
+        # This is equivalent to re.search('[+-]', tstr), but faster
+        tz_pos = (tstr.find('-') + 1 or tstr.find('+') + 1)
+        timestr = tstr[:tz_pos-1] if tz_pos > 0 else tstr
+
+        time_comps = _parse_hh_mm_ss_ff(timestr)
+
+        tzi = None
+        if tz_pos > 0:
+            tzstr = tstr[tz_pos:]
+
+            # Valid time zone strings are:
+            # HH:MM               len: 5
+            # HH:MM:SS            len: 8
+            # HH:MM:SS.ffffff     len: 15
+
+            if len(tzstr) not in (5, 8, 15):
+                raise ValueError('Malformed time zone string')
+
+            tz_comps = _parse_hh_mm_ss_ff(tzstr)
+            if all(x == 0 for x in tz_comps):
+                tzi = timezone.utc
+            else:
+                tzsign = -1 if tstr[tz_pos - 1] == '-' else 1
+
+                td = timedelta(hours=tz_comps[0], minutes=tz_comps[1],
+                               seconds=tz_comps[2], microseconds=tz_comps[3])
+
+                tzi = timezone(tzsign * td)
+
+        time_comps.append(tzi)
+
+        return time_comps
+
+    def datetime_fromisoformat(date_string):
+        """Construct a datetime from the output of datetime.isoformat()."""
+        if not isinstance(date_string, str):
+            raise TypeError('fromisoformat: argument must be str')
+
+        # Split this at the separator
+        dstr = date_string[0:10]
+        tstr = date_string[11:]
+
+        try:
+            date_components = _parse_isoformat_date(dstr)
+        except ValueError:
+            raise ValueError(f'Invalid isoformat string: {date_string!r}')
+
+        if tstr:
+            try:
+                time_components = _parse_isoformat_time(tstr)
+            except ValueError:
+                raise ValueError(f'Invalid isoformat string: {date_string!r}')
+        else:
+            time_components = [0, 0, 0, 0, None]
+
+        return datetime(*(date_components + time_components))

--- a/cloudify_rest_client/resources.py
+++ b/cloudify_rest_client/resources.py
@@ -222,17 +222,18 @@ def _archive_type(file_name) -> str:
 def _extract_archive(file_name, dst_dir=None):
     if dst_dir is None:
         dst_dir = tempfile.mkdtemp()
-    archive_type = _archive_type(file_name)
-    match archive_type.lower():
-        case 'tar':
-            with tarfile.open(file_name, 'r:*') as archive:
-                archive.extractall(path=dst_dir)
-            return dst_dir
-        case 'zip':
-            with zipfile.ZipFile(file_name) as archive:
-                archive.extractall(path=dst_dir)
-            return dst_dir
-    raise CloudifyClientError(f'Unknown archive type: `{archive_type}`')
+    archive_type = _archive_type(file_name).lower()
+
+    if archive_type == 'tar':
+        with tarfile.open(file_name, 'r:*') as archive:
+            archive.extractall(path=dst_dir)
+        return dst_dir
+    elif archive_type == 'zip':
+        with zipfile.ZipFile(file_name) as archive:
+            archive.extractall(path=dst_dir)
+        return dst_dir
+    else:
+        raise CloudifyClientError(f'Unknown archive type: `{archive_type}`')
 
 
 def _create_archive(dir_name):

--- a/cloudify_rest_client/resources.py
+++ b/cloudify_rest_client/resources.py
@@ -11,6 +11,7 @@ from typing import Dict, Tuple
 import requests
 
 from cloudify_rest_client.exceptions import CloudifyClientError
+from cloudify_rest_client._datetime_compat import datetime_fromisoformat
 
 INDEX_JSON_FILENAME = '.cloudify-index.json'
 LAST_MODIFIED_FMT = '%Y-%m-%dT%H:%M:%S%z'
@@ -89,7 +90,7 @@ class ResourcesClient:
             for chunk in response.bytes_stream():
                 tmp_file.write(chunk)
         absolute_file_path = os.path.join(dst_dir, file_path)
-        file_timestamp = datetime.fromisoformat(file_mtime).timestamp()
+        file_timestamp = datetime_fromisoformat(file_mtime).timestamp()
         shutil.move(tmp_file.name, absolute_file_path)
         os.utime(absolute_file_path, (file_timestamp, file_timestamp))
 

--- a/cloudify_rest_client/tests/test_resources.py
+++ b/cloudify_rest_client/tests/test_resources.py
@@ -3,7 +3,6 @@ import shutil
 import tempfile
 import typing
 import uuid
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from unittest.mock import Mock
 
@@ -15,12 +14,17 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 from cloudify_rest_client.resources import ResourcesClient
 
 
-@dataclass(init=True)
 class _MockCall:
     function_name: str
     args: typing.Tuple[typing.Any]
     kwargs: typing.Dict[str, typing.Any]
     result: typing.Any
+
+    def __init__(self, function_name, args, kwargs, result):
+        self.function_name = function_name
+        self.args = args
+        self.kwargs = kwargs
+        self.result = result
 
     def __str__(self):
         return _call_fmt(self.function_name, self.args, self.kwargs)

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,5 +1,5 @@
 def install_test_dependencies(String cache_prefix) {
-  sh script: '''#!/bin/bash
+  sh script: '''
   pip install -r test-requirements.txt --user
   pip install -e '.[dispatcher]' --user
   ''', label: "install test dependencies"
@@ -17,7 +17,6 @@ def pytest(String target, int cov_target=60){
 }
 def build_docs(String project){
   sh script: """
-  #!/bin/bash
   sphinx-build \
     -d _build/doctrees \
     -D version="\$(python setup.py --version)" \

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
     PATH = "/root/.local/bin:$PATH"
   }
   stages{
-    stage ('flake8') {
+    stage ('flake8_py310') {
       steps{
         sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to separate workspace"
         container('py310'){
@@ -67,13 +67,45 @@ pipeline {
         }
       }
     }
-    stage('tests'){
+    stage('flake8_py36'){
+      steps{
+        sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to seperate workspace"
+        container('py36'){
+          dir("${env.WORKSPACE}/flake8") {
+          echo 'install flake 8'
+          sh "pip install flake8 --user"
+          echo 'run flake8'
+          sh "python -m flake8 dsl_parser script_runner cloudify cloudify_rest_client cloudify_async_client"
+          }
+        }
+      }
+    }
+    stage('test_py310'){
       steps{
         sh script: "mkdir -p ${env.WORKSPACE}/test-py310 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py310", label:
         "copying repo to separate workspace"
         container('py310'){
           dir("${env.WORKSPACE}/test-py310") {
             install_test_dependencies('py310')
+            pytest('dsl_parser')
+            pytest('script_runner')
+            pytest('cloudify')
+            pytest('cloudify_rest_client', 43)
+          }
+        }
+      }
+      post {
+        always {
+          junit '**/test-results/*.xml'
+        }
+      }
+    }
+    stage('test_py36'){
+      steps{
+        sh script: "mkdir -p ${env.WORKSPACE}/test-py36 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py36", label: "copying repo to seperate workspace"
+        container('py36'){
+          dir("${env.WORKSPACE}/test-py36") {
+            install_test_dependencies('py36')
             pytest('dsl_parser')
             pytest('script_runner')
             pytest('cloudify')

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,7 +5,7 @@ def install_test_dependencies(String cache_prefix) {
   ''', label: "install test dependencies"
 }
 def pytest(String target, int cov_target=60){
-  sh script: """#!/bin/bash
+  sh script: """
   pytest \
     -n auto \
     --cov-report term \
@@ -13,6 +13,13 @@ def pytest(String target, int cov_target=60){
     --cov-fail-under ${cov_target} \
     ${target}/tests \
     --junitxml=test-results/${target}.xml
+  """, label: "pytest << ${target} >>"
+}
+def pytest_nocover(String target, int cov_target=60){
+  sh script: """
+  pytest \
+    -n auto \
+    ${target}/tests \
   """, label: "pytest << ${target} >>"
 }
 def build_docs(String project){
@@ -58,9 +65,7 @@ pipeline {
         sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to separate workspace"
         container('py310'){
           dir("${env.WORKSPACE}/flake8") {
-          echo 'install flake 8'
-          sh "pip install flake8 --user"
-          echo 'run flake8'
+          sh script: "pip install flake8 --user", label: "install flake8"
           sh "python -m flake8 dsl_parser script_runner cloudify cloudify_rest_client cloudify_async_client"
           }
         }
@@ -105,16 +110,11 @@ pipeline {
         container('py36'){
           dir("${env.WORKSPACE}/test-py36") {
             install_test_dependencies('py36')
-            pytest('dsl_parser')
-            pytest('script_runner')
-            pytest('cloudify')
-            pytest('cloudify_rest_client', 43)
+            pytest_nocover('dsl_parser')
+            pytest_nocover('script_runner')
+            pytest_nocover('cloudify')
+            pytest_nocover('cloudify_rest_client')
           }
-        }
-      }
-      post {
-        always {
-          junit '**/test-results/*.xml'
         }
       }
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -60,60 +60,68 @@ pipeline {
     PATH = "/root/.local/bin:$PATH"
   }
   stages{
-    stage ('flake8_py310') {
-      steps{
-        sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to separate workspace"
-        container('py310'){
-          dir("${env.WORKSPACE}/flake8") {
-          sh script: "pip install flake8 --user", label: "install flake8"
-          sh "python -m flake8 dsl_parser script_runner cloudify cloudify_rest_client cloudify_async_client"
+    stage ('flake8'){
+      parallel {
+        stage ('flake8_py310') {
+          steps{
+            sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to separate workspace"
+            container('py310'){
+              dir("${env.WORKSPACE}/flake8") {
+              sh script: "pip install flake8 --user", label: "install flake8"
+              sh "python -m flake8 dsl_parser script_runner cloudify cloudify_rest_client cloudify_async_client"
+              }
+            }
+          }
+        }
+        stage('flake8_py36'){
+          steps{
+            sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to seperate workspace"
+            container('py36'){
+              dir("${env.WORKSPACE}/flake8") {
+              echo 'install flake 8'
+              sh "pip install flake8 --user"
+              echo 'run flake8'
+              sh "python -m flake8 dsl_parser script_runner cloudify cloudify_rest_client cloudify_async_client"
+              }
+            }
           }
         }
       }
     }
-    stage('flake8_py36'){
-      steps{
-        sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to seperate workspace"
-        container('py36'){
-          dir("${env.WORKSPACE}/flake8") {
-          echo 'install flake 8'
-          sh "pip install flake8 --user"
-          echo 'run flake8'
-          sh "python -m flake8 dsl_parser script_runner cloudify cloudify_rest_client cloudify_async_client"
+    stage ('tests') {
+      parallel {
+        stage('test_py310'){
+          steps{
+            sh script: "mkdir -p ${env.WORKSPACE}/test-py310 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py310", label:
+            "copying repo to separate workspace"
+            container('py310'){
+              dir("${env.WORKSPACE}/test-py310") {
+                install_test_dependencies('py310')
+                pytest('dsl_parser')
+                pytest('script_runner')
+                pytest('cloudify')
+                pytest('cloudify_rest_client', 43)
+              }
+            }
+          }
+          post {
+            always {
+              junit '**/test-results/*.xml'
+            }
           }
         }
-      }
-    }
-    stage('test_py310'){
-      steps{
-        sh script: "mkdir -p ${env.WORKSPACE}/test-py310 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py310", label:
-        "copying repo to separate workspace"
-        container('py310'){
-          dir("${env.WORKSPACE}/test-py310") {
-            install_test_dependencies('py310')
-            pytest('dsl_parser')
-            pytest('script_runner')
-            pytest('cloudify')
-            pytest('cloudify_rest_client', 43)
-          }
-        }
-      }
-      post {
-        always {
-          junit '**/test-results/*.xml'
-        }
-      }
-    }
-    stage('test_py36'){
-      steps{
-        sh script: "mkdir -p ${env.WORKSPACE}/test-py36 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py36", label: "copying repo to seperate workspace"
-        container('py36'){
-          dir("${env.WORKSPACE}/test-py36") {
-            install_test_dependencies('py36')
-            pytest_nocover('dsl_parser')
-            pytest_nocover('script_runner')
-            pytest_nocover('cloudify')
-            pytest_nocover('cloudify_rest_client')
+        stage('test_py36'){
+          steps{
+            sh script: "mkdir -p ${env.WORKSPACE}/test-py36 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/test-py36", label: "copying repo to seperate workspace"
+            container('py36'){
+              dir("${env.WORKSPACE}/test-py36") {
+                install_test_dependencies('py36')
+                pytest_nocover('dsl_parser')
+                pytest_nocover('script_runner')
+                pytest_nocover('cloudify')
+                pytest_nocover('cloudify_rest_client')
+              }
+            }
           }
         }
       }

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -13,9 +13,6 @@ spec:
     command:
     - cat
     tty: true
-    securityContext:
-      runAsUser: 0
-      privileged: true
     resources:
       requests:
         cpu: 1.5
@@ -28,9 +25,6 @@ spec:
     command:
     - cat
     tty: true
-    securityContext:
-      runAsUser: 0
-      privileged: true
     resources:
       requests:
         cpu: 1.5

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -23,6 +23,21 @@ spec:
       limits:
         cpu: 2.5
         memory: 2Gi
+  - name: py36
+    image: python:3.6
+    command:
+    - cat
+    tty: true
+    securityContext:
+      runAsUser: 0
+      privileged: true
+    resources:
+      requests:
+        cpu: 1.5
+        memory: 2Gi
+      limits:
+        cpu: 2.5
+        memory: 2Gi
   - name: rabbitmq374
     image: rabbitmq:3.7.4
     resources:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
-pytest-xdist==2.5.0
-coverage==6.4.4
+pytest-xdist
+coverage


### PR DESCRIPTION
We still need to support 3.6, because some plugins are still 3.6-only