### PR TITLE
RD-6846 Allow explicit scripts in script_runner

### DIFF
--- a/cloudify/tests/test_local_workflows.py
+++ b/cloudify/tests/test_local_workflows.py
@@ -838,7 +838,10 @@ class LocalWorkflowTest(BaseWorkflowTest):
 
     def test_node_instance_version_conflict(self):
         # run a workflow to create the storage and node instances
-        self._execute_workflow(lambda ctx, **_: None)
+        def wf(ctx, **_):
+            return None
+
+        self._execute_workflow(wf)
         storage = self.env.storage
         instance = storage.get_node_instances()[0]
 

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -660,10 +660,22 @@ class RemoteWorkflowTask(WorkflowTask):
         one that is available via deployment proxying.
         """
         executor = self.cloudify_context['executor']
+        node_instance_id = self.cloudify_context['node_id']
+
+        if executor == 'auto':
+            # for executor=auto, we'll be a host_agent script if we do have
+            # a host, otherwise CDA
+            client = get_rest_client()
+            node_instance = client.node_instances.get(node_instance_id)
+            if node_instance.host_id:
+                executor = 'host_agent'
+            else:
+                executor = 'central_deployment_agent'
+
         if executor == 'host_agent':
             if self._cloudify_agent is None:
                 self._cloudify_agent, tenant = self._get_agent_settings(
-                    node_instance_id=self.cloudify_context['node_id'],
+                    node_instance_id=node_instance_id,
                     deployment_id=self.cloudify_context['deployment_id'],
                     tenant=None)
             return (self._cloudify_agent['queue'],

--- a/dsl_parser/constants.py
+++ b/dsl_parser/constants.py
@@ -85,6 +85,7 @@ SCRIPT_PLUGIN_NAME = 'script'
 SCRIPT_PLUGIN_RUN_TASK = 'script_runner.tasks.run'
 SCRIPT_PLUGIN_EXECUTE_WORKFLOW_TASK = 'script_runner.tasks.execute_workflow'
 SCRIPT_PATH_PROPERTY = 'script_path'
+SCRIPT_SOURCE_PROPERTY = 'script_source'
 
 FUNCTION_NAME_PATH_SEPARATOR = '__sep__'
 

--- a/dsl_parser/elements/operation.py
+++ b/dsl_parser/elements/operation.py
@@ -465,7 +465,7 @@ def _is_inline_script(script):
         return False
 
     if (
-        script.count('.') > 0 and
+        '.' in script and
         all(part.isidentifier() for part in script.split('.'))
     ):
         # this looks like a dotted path - identifiers separated by dots

--- a/dsl_parser/elements/operation.py
+++ b/dsl_parser/elements/operation.py
@@ -312,7 +312,7 @@ def process_operation(
     if is_valid_url or local_resource_exists:
         is_script = False
     else:
-        is_script = _is_explicit_script(operation_mapping)
+        is_script = _is_inline_script(operation_mapping)
 
     if (
         is_valid_url or
@@ -439,7 +439,7 @@ def process_operation(
         raise exceptions.DSLParsingLogicException(error_code, error_message)
 
 
-def _is_explicit_script(script):
+def _is_inline_script(script):
     """Check if the string `script` contains a script.
 
     The string, which is coming from an operation mapping in the blueprint,

--- a/dsl_parser/elements/operation.py
+++ b/dsl_parser/elements/operation.py
@@ -321,13 +321,22 @@ def process_operation(
         (not candidate_plugins and _is_remote_script_resource(
             operation_mapping, remote_resources_namespaces))
     ):
-        if constants.SCRIPT_PATH_PROPERTY in operation_payload:
-            message = "Cannot define '{0}' property in '{1}' for {2} '{3}'" \
-                .format(constants.SCRIPT_PATH_PROPERTY,
-                        operation_mapping,
-                        'workflow' if is_workflows else 'operation',
-                        operation_name)
-            raise exceptions.DSLParsingLogicException(60, message)
+        if (
+            constants.SCRIPT_PATH_PROPERTY in operation_payload or
+            constants.SCRIPT_SOURCE_PROPERTY in operation_payload
+        ):
+            # if `implementation` is already a script source/path,
+            # disallow also providing that argument in inputs
+            wf_or_op = 'workflow' if is_workflows else 'operation'
+            offending_property = constants.SCRIPT_PATH_PROPERTY
+            if constants.SCRIPT_SOURCE_PROPERTY in operation_payload:
+                offending_property = constants.SCRIPT_PATH_PROPERTY
+
+            raise exceptions.DSLParsingLogicException(
+                60,
+                f"Cannot define '{offending_property}' property "
+                f"in '{operation_mapping}' for {wf_or_op} '{operation_name}'"
+            )
 
         script_path = operation_mapping
         operation_payload = copy.deepcopy(operation_payload or {})

--- a/dsl_parser/elements/operation.py
+++ b/dsl_parser/elements/operation.py
@@ -450,6 +450,13 @@ def _is_inline_script(script):
         # multiple lines? this for sure isn't a dotted path
         return True
 
+    if utils.NAMESPACE_DELIMITER in script:
+        ns, _, _rest = script.partition(utils.NAMESPACE_DELIMITER)
+        if ns.isidentifier():
+            # a namespace delimiter, separating a single identifier? this
+            # for sure is not a script!
+            return False
+
     if '/' in script or '\\' in script:
         # script is one line and contains a slash/backslash - interpret
         # this as a path (posix or windows).

--- a/dsl_parser/tests/namespace/test_node_templates.py
+++ b/dsl_parser/tests/namespace/test_node_templates.py
@@ -108,7 +108,7 @@ imports:
                                               constants.SCRIPT_PLUGIN_NAME),
                 mapping=constants.SCRIPT_PLUGIN_RUN_TASK,
                 inputs=inputs,
-                executor='central_deployment_agent'))
+                executor='auto'))
 
         assert_operation(operation)
         assert_operation(operation2, extra_properties=True)
@@ -193,7 +193,7 @@ imports:
                                               constants.SCRIPT_PLUGIN_NAME),
                 mapping=constants.SCRIPT_PLUGIN_RUN_TASK,
                 inputs=inputs,
-                executor='central_deployment_agent'))
+                executor='auto'))
 
         assert_operation(operation)
         assert_operation(operation2, extra_properties=True)

--- a/script_runner/tests/blueprint/blueprint.yaml
+++ b/script_runner/tests/blueprint/blueprint.yaml
@@ -2,6 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_0
 
 inputs:
   script_path: {}
+  script_source: {}
   process:     {}
   env_var:
     default: value
@@ -15,6 +16,7 @@ node_templates:
           implementation: script.script_runner.tasks.run
           inputs:
             script_path: { get_input: script_path }
+            script_source: { get_input: script_source }
             process:     { get_input: process     }
             input_as_env_var: { get_input: env_var }
         script: script.script_runner.tasks.run

--- a/script_runner/tests/test_script_runner.py
+++ b/script_runner/tests/test_script_runner.py
@@ -67,12 +67,16 @@ class BaseScriptRunner(object):
             f.write(script)
         return script_path
 
-    def _run(self, script_path,
-             process=None,
-             workflow_name='execute_operation',
-             parameters=None,
-             env_var='value',
-             task_retries=0):
+    def _run(
+        self,
+        script_path=None,
+        script_source=None,
+        process=None,
+        workflow_name='execute_operation',
+        parameters=None,
+        env_var='value',
+        task_retries=0,
+    ):
 
         process = process or {}
         process.update({
@@ -81,6 +85,7 @@ class BaseScriptRunner(object):
 
         inputs = {
             'script_path': script_path,
+            'script_source': script_source,
             'process': process,
             'env_var': env_var
         }
@@ -585,6 +590,19 @@ if __name__ == '__main__':
 
         # Only delete if test succeeded (to help troubleshooting).
         shutil.rmtree(tmpdir_override)
+
+    def test_script_source_bash(self):
+        props = self._run(script_source='''
+            ctx instance runtime-properties map.key value
+        ''')
+        self.assertEqual(props['map']['key'], 'value')
+
+    def test_script_source_python(self):
+        props = self._run(script_source='''
+            from cloudify import ctx
+            ctx.instance.runtime_properties = {'map': {'key': 'value'} }
+        ''')
+        self.assertEqual(props['map']['key'], 'value')
 
     def _normpath(self, path):
         """Normalize path to behave the same way under windows and unix


### PR DESCRIPTION
- not only specialcase `implementation: script/path.py`, but also a script written right there
- set those operations to executor=auto, which means it'll be either host_agent, or CDA, depending on whether it is contained_in a Compute or not