### PR TITLE
RD-6930 Don't run tasks with failed dependencies

### DIFF
--- a/cloudify/tests/test_tasks_graph.py
+++ b/cloudify/tests/test_tasks_graph.py
@@ -231,6 +231,24 @@ class TestTasksGraphExecute(unittest.TestCase):
             assert t.get_state() == 'succeeded'
         assert t2.get_state() == 'pending'
 
+    def test_dependency_failed(self):
+        wctx = MockWorkflowContext()
+        g = TaskDependencyGraph(wctx)
+
+        ft = FailedTask(wctx)
+        t1 = PassedTask(wctx)
+        t2 = PassedTask(wctx)
+        for t in [ft, t1, t2]:
+            g.add_task(t)
+
+        g.add_dependency(t2, t1)
+        g.add_dependency(t2, ft)
+
+        self.assertRaisesRegex(WorkflowFailed, 'failtask', g.execute)
+        assert t1.get_state() == 'succeeded'
+        assert ft.get_state() == 'failed'
+        assert t2.get_state() == 'pending'
+
 
 class _CustomRestorableTask(tasks.WorkflowTask):
     """A custom user-provided task, that can be restored"""

--- a/cloudify/workflows/tasks.py
+++ b/cloudify/workflows/tasks.py
@@ -154,6 +154,10 @@ class WorkflowTask(object):
         # task error response
         self.error = None
 
+        # this is set when a dependency errors out. Then, this task must not
+        # run!
+        self.dependency_error = False
+
     @classmethod
     def restore(cls, ctx, graph, task_descr):
         params = task_descr.parameters

--- a/cloudify/workflows/tasks_graph.py
+++ b/cloudify/workflows/tasks_graph.py
@@ -460,6 +460,11 @@ class TaskDependencyGraph(object):
 
             while self._ready:
                 task = self._ready.pop()
+                if task.dependency_error:
+                    # this task was "ready" because all of its dependencies
+                    # finished (at least one successfully), but one of the
+                    # dependencies finished with an error. It must not run.
+                    continue
                 self._run_task(task)
 
             self._tasks_wait.wait(1)
@@ -518,6 +523,11 @@ class TaskDependencyGraph(object):
                 task = task.failed_task
             result = self._task_error(result, task)
             self._ready -= dependents
+            # mark all the dependent tasks as having a dependency error, so
+            # that they will not run, even if all their other dependencies
+            # finish successfully
+            for d in dependents:
+                d.dependency_error = True
         elif handler_result.action == tasks.HandlerResult.HANDLER_RETRY:
             new_task = handler_result.retried_task
             if self.id is not None:


### PR DESCRIPTION
When a task has a dependency that failed, make sure to NOT run it, even if other dependencies succeed.