### PR TITLE
RD-7060 process_operation: don't override explicit executor

### DIFF
--- a/dsl_parser/elements/operation.py
+++ b/dsl_parser/elements/operation.py
@@ -339,7 +339,7 @@ def process_operation(
 
         script_path = operation_mapping
         operation_payload = copy.deepcopy(operation_payload or {})
-        operation_executor = 'auto'
+        operation_executor = operation_executor or 'auto'
 
         script_property = constants.SCRIPT_PATH_PROPERTY
         if is_script:


### PR DESCRIPTION
if `executor` was passed in by the user (not None), keep it. No need for the auto-detection then.

This only matters when there is an inline script, for a node that IS contained in a compute, but we want it to run on c_d_a nonetheless.