### PR TITLE
RND-347 add client.resources.get_file

### DIFF
--- a/cloudify_rest_client/client.py
+++ b/cloudify_rest_client/client.py
@@ -9,7 +9,7 @@ from requests.packages import urllib3
 from cloudify import constants
 from cloudify.utils import ipv6_url_compat
 
-from .utils import is_kerberos_env
+from cloudify_rest_client.utils import is_kerberos_env, StreamedResponse
 from cloudify_rest_client import exceptions
 from cloudify_rest_client.idp import IdentityProviderClient
 from cloudify_rest_client.ldap import LdapClient
@@ -411,25 +411,6 @@ class HTTPClient(object):
         self.headers[key] = value
         value = value if log_value else '*'
         self.logger.debug('Setting `%s` header: %s', key, value)
-
-
-class StreamedResponse(object):
-
-    def __init__(self, response):
-        self._response = response
-
-    @property
-    def headers(self):
-        return self._response.headers
-
-    def bytes_stream(self, chunk_size=8192):
-        return self._response.iter_content(chunk_size)
-
-    def lines_stream(self):
-        return self._response.iter_lines()
-
-    def close(self):
-        self._response.close()
 
 
 class CloudifyClient(object):

--- a/cloudify_rest_client/resources.py
+++ b/cloudify_rest_client/resources.py
@@ -28,18 +28,18 @@ class ResourcesClient:
         return f'/resources/deployments/{self.api.tenant_name}/'\
                f'{deployment_id}/'
 
-    def get_file(self, path: str, params=None) -> StreamedResponse:
+    def get_file(self, path: str, **kwargs) -> StreamedResponse:
         """Fetch a file from the fileserver.
 
         :param path: the file to download, including the leading /resources
-        :param params: additional querystring params
+        :param kwargs: additional kwargs to requests.get
         """
         try:
             return self.api.get(
                 path,
-                params=params,
                 stream=True,
                 url_prefix=False,
+                **kwargs,
             )
         except requests.RequestException as exception:
             raise CloudifyClientError(

--- a/cloudify_rest_client/resources.py
+++ b/cloudify_rest_client/resources.py
@@ -14,6 +14,7 @@ from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 from cloudify_rest_client.exceptions import CloudifyClientError
 from cloudify_rest_client._datetime_compat import datetime_fromisoformat
+from cloudify_rest_client.utils import StreamedResponse
 
 INDEX_JSON_FILENAME = '.cloudify-index.json'
 LAST_MODIFIED_FMT = '%Y-%m-%dT%H:%M:%S%z'
@@ -26,6 +27,24 @@ class ResourcesClient:
     def _deployment_workdir_uri(self, deployment_id: str) -> str:
         return f'/resources/deployments/{self.api.tenant_name}/'\
                f'{deployment_id}/'
+
+    def get_file(self, path: str, params=None) -> StreamedResponse:
+        """Fetch a file from the fileserver.
+
+        :param path: the file to download, including the leading /resources
+        :param params: additional querystring params
+        """
+        try:
+            return self.api.get(
+                path,
+                params=params,
+                stream=True,
+                url_prefix=False,
+            )
+        except requests.RequestException as exception:
+            raise CloudifyClientError(
+                f'Unable to download {path}: {exception}'
+            ) from exception
 
     def download_deployment_workdir(self, deployment_id: str, dst_dir: str):
         """
@@ -43,18 +62,7 @@ class ResourcesClient:
         return self._download_deployment_workdir_archive(uri, dst_dir)
 
     def _download_deployment_workdir_archive(self, uri: str, dst_dir: str):
-        try:
-            response = self.api.get(
-                uri,
-                params={'archive': True},
-                stream=True,
-                url_prefix=False,
-            )
-        except requests.RequestException as exception:
-            raise CloudifyClientError(
-                f"Unable to download single deployment's file "
-                f"from {uri}") from exception
-
+        response = self.get_file(uri, params={'archive': True})
         with tempfile.NamedTemporaryFile('wb', delete=False) as tmp_file:
             for data in response.bytes_stream():
                 tmp_file.write(data)
@@ -81,16 +89,7 @@ class ResourcesClient:
                               dst_dir: str,
                               file_path: str,
                               file_mtime: str):
-        try:
-            response = self.api.get(
-                f'{base_uri}{file_path}',
-                stream=True,
-                url_prefix=False,
-            )
-        except requests.RequestException as exception:
-            raise CloudifyClientError(
-                f"Unable to download single deployment's file "
-                f"from {base_uri}{file_path}") from exception
+        response = self.get_file(f'{base_uri}{file_path}')
         with tempfile.NamedTemporaryFile('wb',
                                          dir=dst_dir,
                                          delete=False) as tmp_file:

--- a/cloudify_rest_client/utils.py
+++ b/cloudify_rest_client/utils.py
@@ -106,3 +106,22 @@ def find_executable(executable, path=None):
         return None
     else:
         return executable
+
+
+class StreamedResponse(object):
+
+    def __init__(self, response):
+        self._response = response
+
+    @property
+    def headers(self):
+        return self._response.headers
+
+    def bytes_stream(self, chunk_size=8192):
+        return self._response.iter_content(chunk_size)
+
+    def lines_stream(self):
+        return self._response.iter_lines()
+
+    def close(self):
+        self._response.close()


### PR DESCRIPTION
A shorthand for getting a single file. Pretty much exposes a `requests.get`, but with the credentials already in place.

Also use this method in other calls.

Also move StreamedResponse to utils so I can import it easily for typehints.