### PR TITLE
RND-390 Summary restclient: omit None subfield

### DIFF
--- a/cloudify_rest_client/summary.py
+++ b/cloudify_rest_client/summary.py
@@ -24,8 +24,9 @@ class SummaryClient(object):
     def get(self, _target_field, _sub_field=None, **kwargs):
         params = {
             '_target_field': _target_field,
-            '_sub_field': _sub_field,
         }
+        if _sub_field:
+            params['_sub_field'] = _sub_field
         params.update(kwargs)
         response = self.api.get(
             '/summary/{summary_type}'.format(summary_type=self.summary_type),


### PR DESCRIPTION
Subfield is optional, and can be None: this goes into the querystring so it needs to be omitted entirely, otherwise we do send the value as the string "none" otherwise