### PR TITLE
RND-430 dsl_parser: download resources from the fileserver

### DIFF
--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -15,8 +15,7 @@
 
 import os
 from collections import deque, OrderedDict
-from dataclasses import dataclass
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Optional
 
 from urllib.request import pathname2url
 
@@ -364,15 +363,26 @@ def _normalize_plugin_import(plugin, imported_dsl, namespace):
             namespace)
 
 
-@dataclass
 class _ImportedDSL:
     url: str
-    parsed: Holder | None = None
-    namespace: str | None = None
-    properties: dict | None = None
+    parsed: Optional[Holder]
+    namespace: Optional[str]
+    properties: Optional[dict]
+
+    def __init__(
+        self,
+        url,
+        parsed=None,
+        namespace=None,
+        properties=None,
+    ):
+        self.url = url
+        self.parsed = parsed
+        self.namespace = namespace
+        self.properties = properties
 
     @property
-    def key(self) -> Tuple[str, str | None]:
+    def key(self) -> Tuple[str, Optional[str]]:
         return (self.url, self.namespace)
 
     @property
@@ -383,7 +393,7 @@ class _ImportedDSL:
     def is_cloudify_types(self) -> bool:
         return is_cloudify_basic_types(self.parsed)
 
-    def get_imports(self) -> Iterable[Tuple[str, dict | None]]:
+    def get_imports(self) -> Iterable[Tuple[str, Optional[dict]]]:
         _, imports_value_holder = self.parsed.get_item(constants.IMPORTS)
         if not imports_value_holder:
             return
@@ -420,9 +430,9 @@ def _fetch_import(
     resources_base_path: str,
     properties: dict,
     dsl_version: str,
-    namespaces_mapping: dict[str, _ImportedDSL],
-    already_imported: dict[str, _ImportedDSL],
-) -> dict | None:
+    namespaces_mapping: dict,
+    already_imported: dict,
+) -> Optional[dict]:
     namespace, resolved_url = \
         _split_import_namespace(original_import_url)
     namespace = _prefix_namespace(parent.namespace, namespace)

--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -462,13 +462,7 @@ def _build_ordered_imports(parsed_dsl_holder,
                     )
                 namespaces_mapping[namespace] = blueprint_id
 
-            if (import_url, namespace) in imports_graph:
-                import_key = (import_url, namespace)
-            elif (import_url, None) in imports_graph:
-                # In case of Cloudify basic types
-                import_key = (import_url, None)
-            else:
-                import_key = (import_url, namespace)
+            import_key = (import_url, namespace)
 
             import_context = (location(_current_import), context_namespace)
             if import_key in imports_graph:

--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -317,10 +317,6 @@ def _dsl_version(parsed_dsl_holder):
         return version.replace('cloudify_dsl_', '', 1)
 
 
-def location(value):
-    return value or constants.ROOT_ELEMENT_VALUE
-
-
 def is_parsed_resource(item):
     """
     Checking if the given item is in parsed yaml type.
@@ -396,7 +392,7 @@ def _build_ordered_imports(parsed_dsl_holder,
     blueprint_imports = set()
     namespaces_mapping = {}
 
-    imports_graph.add(location(dsl_location), parsed_dsl_holder)
+    imports_graph.add(dsl_location, parsed_dsl_holder)
 
     to_visit = [
         (
@@ -462,7 +458,7 @@ def _build_ordered_imports(parsed_dsl_holder,
 
             import_key = (import_url, namespace)
 
-            import_context = (location(_current_import), context_namespace)
+            import_context = (_current_import, context_namespace)
             if import_key in imports_graph:
                 is_cloudify_types = imports_graph[import_key]['cloudify_types']
                 validate_import_namespace(namespace,

--- a/dsl_parser/elements/imports.py
+++ b/dsl_parser/elements/imports.py
@@ -222,7 +222,8 @@ def _get_resource_location(resource_name,
         return 'file:{0}'.format(
             pathname2url(os.path.abspath(full_path)))
 
-    return None
+    for fn in _possible_resource_locations(resource_name, dsl_version):
+        yield f'resource:{fn}'
 
 
 def _possible_resource_locations(resource_name, dsl_version):

--- a/dsl_parser/import_resolver/abstract_import_resolver.py
+++ b/dsl_parser/import_resolver/abstract_import_resolver.py
@@ -19,7 +19,7 @@ import time
 import requests
 
 from dsl_parser import exceptions
-
+from cloudify.manager import get_resource_from_manager
 
 DEFAULT_RETRY_DELAY = 1
 MAX_NUMBER_RETRIES = 5
@@ -61,6 +61,13 @@ def read_import(import_url):
             filename = import_url[len('file:'):]
             with open(filename) as f:
                 return f.read()
+        except Exception as ex:
+            raise exceptions.DSLParsingLogicException(
+                13, f"{error_str} {import_url}; {ex}")
+    elif import_url.startswith('resource:'):
+        try:
+            filename = import_url[len('resource:'):]
+            return get_resource_from_manager(filename)
         except Exception as ex:
             raise exceptions.DSLParsingLogicException(
                 13, f"{error_str} {import_url}; {ex}")

--- a/dsl_parser/tests/test_plugin_properties.py
+++ b/dsl_parser/tests/test_plugin_properties.py
@@ -95,7 +95,7 @@ imports:
   - plugin:dummy
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})) as p:
+                   return_value=({}, {})) as p:
             self.parse_1_4(yaml)
         assert p.call_count == 1
 
@@ -107,7 +107,7 @@ imports:
       prop2: bar
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})) as p:
+                   return_value=({}, {})) as p:
             self.parse_1_5(yaml)
         assert p.call_count == 1
 
@@ -120,7 +120,7 @@ imports:
       aws_secret_access_key: {get_secret: my_secret}
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})) as p:
+                   return_value=({}, {})) as p:
             self.parse_1_5(yaml)
         assert p.call_count == 1
 
@@ -133,7 +133,7 @@ imports:
       aws_secret_access_key: {get_secret: my_secret}
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})):
+                   return_value=({}, {})):
             with pytest.raises(DSLParsingLogicException):
                 self.parse_1_4(yaml)
 
@@ -147,7 +147,7 @@ imports:
     plugin:foobar: {}
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})):
+                   return_value=({}, {})):
             with pytest.raises(DSLParsingFormatException,
                                match='single-entry dictionary'):
                 self.parse_1_5(yaml)
@@ -160,7 +160,7 @@ imports:
       - bar
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})):
+                   return_value=({}, {})):
             with pytest.raises(DSLParsingFormatException):
                 self.parse_1_5(yaml)
 
@@ -176,7 +176,7 @@ imports:
       fn_property: {get_secret: something}
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})):
+                   return_value=({}, {})):
             self.parse_1_5(yaml)
 
     def test_invalid_properties(self):
@@ -187,6 +187,6 @@ imports:
       property: { not_a_intrinsic_function: something }
 """
         with patch('dsl_parser.elements.imports._build_ordered_imports',
-                   return_value=({}, set(), {})):
+                   return_value=({}, {})):
             with pytest.raises(DSLParsingFormatException):
                 self.parse_1_5(yaml)

--- a/dsl_parser/utils.py
+++ b/dsl_parser/utils.py
@@ -313,11 +313,11 @@ def load_yaml(raw_yaml, error_message, filename=None):
 
 
 def url_exists(url):
-    request = Request(url)
     try:
+        request = Request(url)
         with contextlib.closing(urlopen(request)):
             return True
-    except URLError:
+    except (ValueError, URLError):
         return False
 
 


### PR DESCRIPTION
The main idea here is that we add a `resource:` scheme (next to `file:`), which will mean that the resource will have to be downloaded from the manager (i.e. from the fileserver, using essentially ctx.get_resource).

But, that means we might need to try and resolve multiple targets - one for each candidate dsl version, so `_get_resource_location` will be a generator now.

To do this sanely, there's a TON of refactors around that file, including replacing the recursive `_build_ordered_imports` with an iterative (BFS) approach.