### PR TITLE
Pin urllib3 in tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,5 @@ pytest
 pytest-cov
 pytest-xdist
 coverage
+# Pin urllib3 to the version which does not depend on appengine
+urllib3<1.27,>=1.21.1


### PR DESCRIPTION
Version urllib3-2.0.2 attempts to include `appengine` (which fails)