### PR TITLE
RD-7086 evaluate nodes: provide an instance id hint

### DIFF
--- a/cloudify/context.py
+++ b/cloudify/context.py
@@ -403,7 +403,10 @@ class NodeContext(EntityContext):
 
     def _get_node_if_needed(self):
         if self._node is None:
-            self._node = self._endpoint.get_node(self.id)
+            self._node = self._endpoint.get_node(
+                self.id,
+                instance_context=self._context.get('node_id'),
+            )
             props = self._node.get('properties', {})
             self._node['properties'] = ImmutableProperties(props)
 

--- a/cloudify/endpoint.py
+++ b/cloudify/endpoint.py
@@ -31,7 +31,7 @@ class Endpoint(object):
     def __init__(self, ctx):
         self.ctx = ctx
 
-    def get_node(self, node_id):
+    def get_node(self, node_id, instance_context=None):
         raise NotImplementedError('Implemented by subclasses')
 
     def get_node_instance(self, node_instance_id):
@@ -196,9 +196,13 @@ class ManagerEndpoint(Endpoint):
             self._rest_client = manager.get_rest_client(self.ctx.tenant_name)
         return self._rest_client
 
-    def get_node(self, node_id):
+    def get_node(self, node_id, instance_context=None):
         return self.rest_client.nodes.get(
-            self.ctx.deployment.id, node_id, evaluate_functions=True)
+            self.ctx.deployment.id,
+            node_id,
+            evaluate_functions=True,
+            instance_context=instance_context,
+        )
 
     def get_node_instance(self, node_instance_id):
         return manager.get_node_instance(node_instance_id,
@@ -373,7 +377,7 @@ class LocalEndpoint(Endpoint):
         super(LocalEndpoint, self).__init__(ctx)
         self.storage = storage
 
-    def get_node(self, node_id):
+    def get_node(self, node_id, instance_context=None):
         return self.storage.get_node(node_id)
 
     def get_node_instance(self, node_instance_id):


### PR DESCRIPTION
Sometimes when evaluating nodes, we need to know what _instance_ we're working with.

This is the case when node properties contain functions that can only be evaluated on a node, e.g. if properties contained a `{get_attribute: [node, attr]}`, and `attr` was only a runtime property. Then, `get_attribute` tries
to fetch that from runtime properties, but to do that, it needs to know which instance to fetch from.

Sometimes it's obvious, e.g. when there's only one instance, but in case of scaling, we do get the "cannot resolve instance unambiguously" error.

However, we usually already know what instance we want, so we can just pass the id through as a hint.