### PR TITLE
RND-309 Extend rest client's `dump()` methods

### DIFF
--- a/cloudify_rest_client/blueprints.py
+++ b/cloudify_rest_client/blueprints.py
@@ -659,8 +659,15 @@ class BlueprintsClient(object):
             self=self, id=blueprint_id),
         )
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, blueprint_ids=None):
+        """Generate blueprints' attributes for a snapshot.
+
+        :param blueprint_ids: A list of blueprints identifiers, if not empty,
+         used to select specific blueprints to be dumped.
+        :returns: A generator of dictionaries, which describe blueprints'
+         attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 f'/{self._uri_prefix}',
                 params={'_get_data': True},
@@ -669,6 +676,9 @@ class BlueprintsClient(object):
                           'description', 'error', 'error_traceback',
                           'is_hidden', 'requirements'],
         )
+        if not blueprint_ids:
+            return entities
+        return (e for e in entities if e['id'] in blueprint_ids)
 
     def restore(self, entities, path_func=None):
         """Restore blueprints from a snapshot.

--- a/cloudify_rest_client/deployment_updates.py
+++ b/cloudify_rest_client/deployment_updates.py
@@ -254,8 +254,16 @@ class DeploymentUpdatesClient(object):
         response = self.api.post(uri)
         return DeploymentUpdate(response)
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, deployment_update_ids=None):
+        """Generate deployment updates' attributes for a snapshot.
+
+        :param deployment_update_ids: A list of deployment updates'
+         identifiers, if not empty, used to select specific deployment
+         updates to be dumped.
+        :returns: A generator of dictionaries, which describe deployment
+         updates' attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 '/deployment-updates',
                 params={'_get_data': True},
@@ -269,6 +277,9 @@ class DeploymentUpdatesClient(object):
                           'central_plugins_to_install', 'old_inputs',
                           'deployment_update_nodes', 'modified_entity_ids']
         )
+        if not deployment_update_ids:
+            return entities
+        return (e for e in entities if e['id'] in deployment_update_ids)
 
     def restore(self, entities):
         """Restore deployment updates from a snapshot.

--- a/cloudify_rest_client/deployments.py
+++ b/cloudify_rest_client/deployments.py
@@ -558,8 +558,16 @@ class DeploymentGroupsClient(object):
             expected_status_code=(200, 204),
         )
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, deployment_groups_ids=None):
+        """Generate deployment groups' attributes for a snapshot.
+
+        :param deployment_groups_ids: A list of deployment groups'
+         identifiers, if not empty, used to select deployment groups
+         to be dumped.
+        :returns: A generator of dictionaries, which describe deployment
+         groups' attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 '/deployment-groups',
                 params={'_get_data': True},
@@ -568,6 +576,9 @@ class DeploymentGroupsClient(object):
                           'deployment_ids', 'created_by', 'created_at',
                           'creation_counter'],
         )
+        if not deployment_groups_ids:
+            return entities
+        return (e for e in entities if e['id'] in deployment_groups_ids)
 
     def restore(self, entities):
         """Restore deployment groups from a snapshot.
@@ -989,8 +1000,15 @@ class DeploymentsClient(object):
             '/deployments/{0}'.format(deployment_id), data=kwargs)
         return Deployment(updated_dep)
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, deployment_ids=None):
+        """Generate deployments' attributes for a snapshot.
+
+        :param deployment_ids: A list of deployments' identifiers, if not
+         empty, used to select specific deployments to be dumped.
+        :returns: A generator of dictionaries, which describe deployments'
+         attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 '/deployments',
                 params={'_get_data': True},
@@ -1004,6 +1022,9 @@ class DeploymentsClient(object):
                           'sub_environments_status', 'sub_services_count',
                           'sub_environments_count'],
         )
+        if not deployment_ids:
+            return entities
+        return (e for e in entities if e['id'] in deployment_ids)
 
     def restore(self, entities, path_func=None):
         """Restore deployments from a snapshot.

--- a/cloudify_rest_client/events.py
+++ b/cloudify_rest_client/events.py
@@ -149,17 +149,34 @@ class EventsClient(object):
         return params
 
     def dump(self, execution_ids=None, execution_group_ids=None,
-             include_logs=None):
+             include_logs=None, event_storage_ids=None):
+        """Generate events' attributes for a snapshot.
+
+        :param execution_ids: A list of executions' identifiers used to
+         select events to be dumped.
+        :param execution_group_ids: A list of execution groups' identifiers
+         used to select events to be dumped.
+        :param include_logs: A flag, which determines if `cloudify_log` entries
+         should be included in the snapshot.
+        :param event_storage_ids: A list of events' storage identifiers, if
+         not empty, used to select specific events to be dumped.
+        :returns: A generator of dictionaries, which describe events'
+         attributes.
+        """
         if execution_ids:
             for entity in self._dump_events(include_logs, 'execution_id',
                                             execution_ids):
                 entity.update({'__source': 'executions'})
-                yield entity
+                if not event_storage_ids or \
+                        entity['__entity']['_storage_id'] in event_storage_ids:
+                    yield entity
         if execution_group_ids:
             for entity in self._dump_events(include_logs, 'execution_group_id',
                                             execution_group_ids):
                 entity.update({'__source': 'execution_groups'})
-                yield entity
+                if not event_storage_ids or \
+                        entity['__entity']['_storage_id'] in event_storage_ids:
+                    yield entity
 
     def _dump_events(self, include_logs, event_source_id_key, source_ids):
         if not source_ids:

--- a/cloudify_rest_client/execution_schedules.py
+++ b/cloudify_rest_client/execution_schedules.py
@@ -280,8 +280,16 @@ class ExecutionSchedulesClient(object):
         response = self.api.get(uri, _include=_include, params=params)
         return ExecutionSchedule(response)
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, execution_schedule_ids=None):
+        """Generate execution schedules' attributes for a snapshot.
+
+        :param execution_schedule_ids: A list of execution schedules'
+         identifiers, if not empty, used to select specific execution
+         schedules to be dumped.
+        :returns: A generator of dictionaries, which describe execution
+         schedules' attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 f'/{self._uri_prefix}',
                 _include=['id', 'rule', 'deployment_id', 'workflow_id',
@@ -289,6 +297,9 @@ class ExecutionSchedulesClient(object):
                           'parameters', 'execution_arguments', 'slip',
                           'enabled', 'created_by'],
         )
+        if not execution_schedule_ids:
+            return entities
+        return (e for e in entities if e['id'] in execution_schedule_ids)
 
     def restore(self, entities):
         """Restore execution schedules from a snapshot.

--- a/cloudify_rest_client/executions.py
+++ b/cloudify_rest_client/executions.py
@@ -309,14 +309,24 @@ class ExecutionGroupsClient(object):
         )
         return ExecutionGroup(response)
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, execution_group_ids=None):
+        """Generate execution groups' attributes for a snapshot.
+
+        :param execution_group_ids: A list of execution groups' identifiers,
+         if not empty, used to select specific execution groups to be dumped.
+        :returns: A generator of dictionaries, which describe execution
+         groups' attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 '/execution-groups',
                 params={'_get_data': True},
                 _include=['id', 'created_at', 'workflow_id', 'execution_ids',
                           'concurrency', 'deployment_group_id', 'created_by'],
         )
+        if not execution_group_ids:
+            return entities
+        return (e for e in entities if e['id'] in execution_group_ids)
 
     def restore(self, entities):
         """Restore execution groups from a snapshot.
@@ -547,8 +557,15 @@ class ExecutionsClient(object):
                                    expected_status_code=200)
         return response['items'][0]['count']
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, execution_ids=None):
+        """Generate executions' attributes for a snapshot.
+
+        :param execution_ids: A list of executions' identifiers, if not
+         empty, used to select specific executions to be dumped.
+        :returns: A generator of dictionaries, which describe executions'
+         attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 f'/{self._uri_prefix}',
                 _include=['deployment_id', 'workflow_id', 'parameters',
@@ -560,6 +577,9 @@ class ExecutionsClient(object):
                     '_include_system_workflows': True,
                 },
         )
+        if not execution_ids:
+            return entities
+        return (e for e in entities if e['id'] in execution_ids)
 
     def restore(self, entities):
         """Restore executions from a snapshot.

--- a/cloudify_rest_client/filters.py
+++ b/cloudify_rest_client/filters.py
@@ -136,7 +136,14 @@ class FiltersClient(object):
                                   data=data)
         return Filter(response)
 
-    def dump(self):
+    def dump(self, filter_ids=None):
+        """Generate filters' attributes for a snapshot.
+
+        :param filter_ids: A list of filter identifiers, if not empty,
+         used to select specific filters to be dumped.
+        :returns: A generator of dictionaries, which describe filters'
+         attributes.
+        """
         for entity in utils.get_all(
                 self.api.get,
                 self.uri,
@@ -145,7 +152,8 @@ class FiltersClient(object):
         ):
             if entity.pop('is_system_filter'):
                 continue
-            yield entity
+            if not filter_ids or entity['id'] in filter_ids:
+                yield entity
 
     def restore(self, entities):
         """Restore filters from a snapshot.

--- a/cloudify_rest_client/inter_deployment_dependencies.py
+++ b/cloudify_rest_client/inter_deployment_dependencies.py
@@ -204,8 +204,16 @@ class InterDeploymentDependencyClient(object):
         self.api.post('/{self._uri_prefix}/restore'.format(self=self),
                       data=data)
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, inter_deployment_dependency_ids=None):
+        """Generate inter-deployment dependencies' attributes for a snapshot.
+
+        :param inter_deployment_dependency_ids: A list of inter-deployment
+         dependencies' identifiers, if not empty, used to select specific
+         inter-deployment dependencies to be dumped.
+        :returns: A generator of dictionaries, which describe inter-deployment
+         dependencies' attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 f'/{self._uri_prefix}',
                 _include=['id', 'visibility', 'created_at', 'created_by',
@@ -213,6 +221,10 @@ class InterDeploymentDependencyClient(object):
                           'source_deployment_id', 'target_deployment_id',
                           'external_source', 'external_target'],
         )
+        if not inter_deployment_dependency_ids:
+            return entities
+        return (e for e in entities
+                if e['id'] in inter_deployment_dependency_ids)
 
     def restore(self, entities):
         """Restore inter-deployment dependencies from a snapshot.

--- a/cloudify_rest_client/node_instances.py
+++ b/cloudify_rest_client/node_instances.py
@@ -309,9 +309,21 @@ class NodeInstancesClient(object):
             expected_status_code=204,
         )
 
-    def dump(self, deployment_ids=None, get_broker_conf=None):
+    def dump(self, deployment_ids=None, get_broker_conf=None,
+             node_instance_ids=None):
+        """Generate node instances' attributes for a snapshot.
+
+        :param deployment_ids: A list of deployments' identifiers used to
+         select node instances to be dumped, should not be empty.
+        :param get_broker_conf: A function used to retrieve broker
+         configuration.
+        :param node_instance_ids: A list of node instances' identifiers, if
+         not empty, used to select specific node instances to be dumped.
+        :returns: A generator of dictionaries, which describe node instances'
+         attributes.
+        """
         if not deployment_ids:
-            return []
+            return
         for deployment_id in deployment_ids:
             for entity in utils.get_all(
                     self.api.get,
@@ -334,7 +346,8 @@ class NodeInstancesClient(object):
                     if 'cloudify_agent' in rp:
                         broker_conf = get_broker_conf(entity)
                         rp['cloudify_agent'].update(broker_conf)
-                yield {'__entity': entity, '__source_id': deployment_id}
+                if not node_instance_ids or entity['id'] in node_instance_ids:
+                    yield {'__entity': entity, '__source_id': deployment_id}
 
     def restore(self, entities, deployment_id, inject_broker_conf=None,):
         """Restore node instances from a snapshot.

--- a/cloudify_rest_client/nodes.py
+++ b/cloudify_rest_client/nodes.py
@@ -331,9 +331,18 @@ class NodesClient(object):
             expected_status_code=204,
         )
 
-    def dump(self, deployment_ids=None):
+    def dump(self, deployment_ids=None, node_ids=None):
+        """Generate nodes' attributes for a snapshot.
+
+        :param deployment_ids: A list of deployments' identifiers used to
+         select nodes to be dumped, should not be empty.
+        :param node_ids: A list of nodes' identifiers, if not empty, used to
+         select specific nodes to be dumped.
+        :returns: A generator of dictionaries, which describe nodes'
+         attributes.
+        """
         if not deployment_ids:
-            return []
+            return
         for deployment_id in deployment_ids:
             for entity in utils.get_all(
                     self.api.get,
@@ -348,7 +357,8 @@ class NodesClient(object):
                               'visibility', 'created_by',
                               'number_of_instances'],
             ):
-                yield {'__entity': entity, '__source_id': deployment_id}
+                if not node_ids or entity['id'] in node_ids:
+                    yield {'__entity': entity, '__source_id': deployment_id}
 
     def restore(self, entities, deployment_id):
         """Restore nodes from a snapshot.

--- a/cloudify_rest_client/permissions.py
+++ b/cloudify_rest_client/permissions.py
@@ -47,6 +47,11 @@ class PermissionsClient(object):
             '{0}/{1}/{2}'.format(self._uri_prefix, role, permission))
 
     def dump(self):
+        """Generate permissions' attributes for a snapshot.
+
+        :returns: A generator of dictionaries, which describe permissions'
+         attributes.
+        """
         return utils.get_all(
             self.api.get,
             self._uri_prefix,

--- a/cloudify_rest_client/plugins.py
+++ b/cloudify_rest_client/plugins.py
@@ -479,14 +479,24 @@ class PluginsClient(object):
                                   data=kwargs)
         return Plugin(response)
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, plugin_ids=None):
+        """Generate plugins' attributes for a snapshot.
+
+        :param plugin_ids: A list of plugin identifiers, if not empty,
+         used to select specific plugins to be dumped.
+        :returns: A generator of dictionaries, which describe plugins'
+         attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 '/plugins',
                 params={'_get_data': True},
                 _include=['id', 'title', 'visibility', 'uploaded_at',
                           'created_by']
         )
+        if not plugin_ids:
+            return entities
+        return (e for e in entities if e['id'] in plugin_ids)
 
     def restore(self, entities, path_func=None):
         """Restore plugins from a snapshot.

--- a/cloudify_rest_client/plugins_update.py
+++ b/cloudify_rest_client/plugins_update.py
@@ -193,8 +193,15 @@ class PluginsUpdateClient(object):
         )
         return PluginsUpdate(response)
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, plugins_update_ids=None):
+        """Generate plugins updates' attributes for a snapshot.
+
+        :param plugins_update_ids: A list of plugins updates' identifiers,
+         if not empty, used to select specific plugins updates to be dumped.
+        :returns: A generator of dictionaries, which describe plugins
+         updates' attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 f'/{self._uri_prefix}',
                 params={'_get_data': True},
@@ -203,6 +210,9 @@ class PluginsUpdateClient(object):
                           'created_at', 'deployments_to_update',
                           'deployments_per_tenant', 'temp_blueprint_id'],
         )
+        if not plugins_update_ids:
+            return entities
+        return (e for e in entities if e['id'] in plugins_update_ids)
 
     def restore(self, entities):
         """Restore plugins updates from a snapshot.

--- a/cloudify_rest_client/secrets_providers.py
+++ b/cloudify_rest_client/secrets_providers.py
@@ -222,13 +222,23 @@ class SecretsProvidersClient(object):
 
         return response
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, secrets_provider_ids=None):
+        """Generate secrets' providers' attributes for a snapshot.
+
+        :param secrets_provider_ids: A list of secrets' provider identifiers,
+         if not empty, used to select specific secrets' providers to be dumped.
+        :returns: A generator of dictionaries, which describe secrets'
+         providers' attributes.
+        """
+        for entity in utils.get_all(
                 self.api.get,
                 '/secrets-providers',
-                _include=['created_at', 'name', 'visibility', 'type',
+                _include=['id', 'created_at', 'name', 'visibility', 'type',
                           'connection_parameters', 'created_by', 'created_at'],
-        )
+        ):
+            entity_id = entity.pop('id')
+            if not secrets_provider_ids or entity_id in secrets_provider_ids:
+                yield entity
 
     def restore(self, entities):
         """Restore secrets' providers from a snapshot.

--- a/cloudify_rest_client/sites.py
+++ b/cloudify_rest_client/sites.py
@@ -142,14 +142,24 @@ class SitesClient(object):
             '/{self._uri_prefix}/{name}'.format(self=self, name=name)
         )
 
-    def dump(self):
-        return utils.get_all(
+    def dump(self, site_ids=None):
+        """Generate sites' attributes for a snapshot.
+
+        :param site_ids: A list of site identifiers, if not empty,
+         used to select specific sites to be dumped.
+        :returns: A generator of dictionaries, which describe sites'
+         attributes.
+        """
+        entities = utils.get_all(
                 self.api.get,
                 f'/{self._uri_prefix}',
                 params={'_get_data': True},
                 _include=['name', 'location', 'visibility', 'created_by',
                           'created_at']
         )
+        if not site_ids:
+            return entities
+        return (e for e in entities if e['name'] in site_ids)
 
     def restore(self, entities):
         """Restore sites from a snapshot.

--- a/cloudify_rest_client/tenants.py
+++ b/cloudify_rest_client/tenants.py
@@ -200,6 +200,11 @@ class TenantsClient(object):
         self.api.delete('/tenants/{0}'.format(tenant_name))
 
     def dump(self):
+        """Generate tenants' attributes for a snapshot.
+
+        :returns: A generator of dictionaries, which describe tenants'
+         attributes.
+        """
         return utils.get_all(
                 self.api.get,
                 '/tenants',

--- a/cloudify_rest_client/user_groups.py
+++ b/cloudify_rest_client/user_groups.py
@@ -107,6 +107,11 @@ class UserGroupsClient(object):
         self.api.delete('/user-groups/users', data=data)
 
     def dump(self):
+        """Generate user groups' attributes for a snapshot.
+
+        :returns: A generator of dictionaries, which describe user groups'
+         attributes.
+        """
         return utils.get_all(
                 self.api.get,
                 '/user-groups',

--- a/cloudify_rest_client/users.py
+++ b/cloudify_rest_client/users.py
@@ -185,6 +185,11 @@ class UsersClient(object):
         return User(response)
 
     def dump(self):
+        """Generate users' attributes for a snapshot.
+
+        :returns: A generator of dictionaries, which describe users'
+         attributes.
+        """
         return utils.get_all(
                 self.api.get,
                 '/users',


### PR DESCRIPTION
Make it possible to dump only specific entities, selected by additional iterable parameter (e.g. `agent_ids` in case of `AgentsClient` etc.) to `dump()` functions.

And also add function docstrings.