### PR TITLE
RND-928 select plugin supporting the newest python version

### DIFF
--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -644,8 +644,9 @@ class _PythonExecutables(object):
         except subprocess.CalledProcessError:
             return
 
-        if m := self.PYTHON_VERSION_RE.match(version_string):
-            major, minor, patch = m.groups()
+        match = self.PYTHON_VERSION_RE.match(version_string)
+        if match:
+            major, minor, patch = match.groups()
             key = int(major), int(minor)
             return key
 


### PR DESCRIPTION
- examine available python versions
- when selecting a plugin to download, grab the one with the highest package version, and supporting the newest python version
- if no python version available is supported, default to the current version, and attempt installation anyway
- similarly, attempt installation even if the OS doesn't quite match. The "build host OS" is advisory anyway, not a strict requirement. (or, should be)

To do this, rewrite the PATH examination, to look at what python versions we have available - by checking `python --version`, not by filename. Then, switch the sorting of plugins a bit, to also include "maybe unsupported" plugins (but sorted lower than "supported")