### PR TITLE
RND-1207 plugin installer: return None when no plugin found

### DIFF
--- a/cloudify/plugin_installer.py
+++ b/cloudify/plugin_installer.py
@@ -418,6 +418,8 @@ def get_managed_plugin(plugin):
         query_parameters['package_version'] = package_version
     client = get_rest_client()
     plugins = client.plugins.list(**query_parameters)
+    if not plugins:
+        return None
     return max(plugins, key=_managed_plugin_sort_key)
 
 

--- a/dsl_parser/parser.py
+++ b/dsl_parser/parser.py
@@ -147,5 +147,5 @@ def _resolve_blueprint_imports(dsl_location,
         element_cls=blueprint.BlueprintImporter,
         strict=False)
 
-    return result['resource_base'],\
+    return result['resource_base'], \
         result['merged_blueprint']


### PR DESCRIPTION
Trying to max() an empty list is just going to be a ValueError. Return None instead.