### PR TITLE
RND-882 Fix get_attribute for accessing dependency nodes 

### DIFF
--- a/dsl_parser/functions.py
+++ b/dsl_parser/functions.py
@@ -17,7 +17,7 @@ import abc
 import collections
 import json
 import pkg_resources
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 from functools import wraps
 
@@ -463,25 +463,14 @@ class GetAttribute(Function):
                                        self.path, self.name, self.scope, plan)
 
     def evaluate(self, handler):
-        if 'instance_id_hint' in self.context:
-            # we're evaluating a node in the context of a specific instance,
-            # and we were told exactly which instance is it
-            node_instance = handler.get_node_instance(
-                self.context['instance_id_hint'])
-        elif self.node_name in [SELF, SOURCE, TARGET]:
-            node_instance_id = self._resolve_available_node_targets(handler)
-            _validate_ref(node_instance_id, self.node_name, self.name,
-                          self.path, self.attribute_path)
-            node_instance = handler.get_node_instance(node_instance_id)
-        else:
-            try:
-                node_instance = self._resolve_node_instance_by_name(handler)
-            except exceptions.FunctionEvaluationError as e:
-                # Only in outputs scope we allow to continue when an error
-                # occurred
-                if not self.context.get('evaluate_outputs'):
-                    raise
-                return '<ERROR: {0}>'.format(e)
+        try:
+            node_instance = self._resolve_node_instance(handler)
+        except exceptions.FunctionEvaluationError as ex:
+            # Only in outputs scope we allow to continue when an error
+            # occurred
+            if not self.context.get('evaluate_outputs'):
+                raise
+            return '<ERROR: {0}>'.format(ex)
 
         node = handler.get_node(node_instance['node_id'])
         if self.context.get('self') and \
@@ -492,6 +481,25 @@ class GetAttribute(Function):
             node_instance, node, self.attribute_path, self.path,
             handler, self.context, 'get_attribute')
         return value
+
+    def _resolve_node_instance(self, handler) -> Dict[str, Any]:
+        if 'instance_id_hint' in self.context:
+            # we're evaluating a node in the context of a specific instance,
+            # and we were told exactly which instance is it, that is, unless
+            # we're retrieving an attribute of another node, in which case we
+            # should ignore the hint
+            node_instance = handler.get_node_instance(
+                self.context['instance_id_hint'])
+            if node_instance['node_id'] == self.node_name:
+                return node_instance
+
+        if self.node_name in [SELF, SOURCE, TARGET]:
+            node_instance_id = self._resolve_available_node_targets(handler)
+            _validate_ref(node_instance_id, self.node_name, self.name,
+                          self.path, self.attribute_path)
+            return handler.get_node_instance(node_instance_id)
+
+        return self._resolve_node_instance_by_name(handler)
 
     def _resolve_available_node_targets(self, handler):
         node_instance_id = self.context.get(self.node_name.lower())


### PR DESCRIPTION
This ports #1296 to 7.0.2

* RND-882 Fix get_attribute for accessing dependency nodes

* Factor-out GetAttribute._resolve_node_instance for better readibility

* Fixing a fix (a.k.a. good to have unittests)