### PR TITLE
CYBL-2097 Update snapshot_restoring flag file path

### DIFF
--- a/cloudify/snapshots.py
+++ b/cloudify/snapshots.py
@@ -13,8 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-SNAPSHOT_RESTORE_FLAG_FILE = ('/opt/manager/snapshot_status'
-                              '/snapshot_restoring')
+SNAPSHOT_RESTORE_FLAG_FILE = '/run/cloudify/snapshot_restoring'
 
 
 class STATES(object):


### PR DESCRIPTION
Because we are running more often in a distributed environment, and /run/cloudify is a common place to keep the "work" files.