### PR TITLE
CYBL-2097 Fix get_all() method to retrieve ALL entities

### DIFF
--- a/cloudify_rest_client/utils.py
+++ b/cloudify_rest_client/utils.py
@@ -111,12 +111,14 @@ def find_executable(executable, path=None):
 def get_all(method, *args, **kwargs):
     """Generator of entities retrieved by a method called with args/kwargs."""
     include = kwargs.get('_include')
-    if kwargs.get('params', {}).get('_include_hash'):
+    params = kwargs.get('params', {})
+    if params.get('_include_hash'):
         include.append('password_hash')
     more_data = True
     entities_yielded, pagination_offset = 0, 0
     while more_data:
-        kwargs['_offset'] = pagination_offset
+        params['_offset'] = pagination_offset
+        kwargs['params'] = params
         result = method(*args, **kwargs)
         for item in result['items']:
             yield {k: v for k, v in item.items()


### PR DESCRIPTION
Pass `_offset` as an entry in the `params` dict, to actual parameter to the method used to fetch data.

https://github.com/cloudify-cosmo/cloudify-common/blob/ce0519542c7e8b66307ab8dbd82e53f095ee2bfa/cloudify_rest_client/client.py#L191