### PR TITLE
CYBL-2097 Snapshot restore fixups

### DIFF
--- a/cloudify_rest_client/bytes_stream_utils.py
+++ b/cloudify_rest_client/bytes_stream_utils.py
@@ -1,4 +1,5 @@
 import cgi
+import errno
 import os
 
 CONTENT_DISPOSITION_HEADER = 'content-disposition'
@@ -88,7 +89,11 @@ def write_response_stream_to_file(streamed_response,
         output_file = os.path.join(output_file, output_filename)
 
     if os.path.exists(output_file):
-        raise OSError("Output file '{0}' already exists".format(output_file))
+        raise OSError(
+            errno.EEXIST,
+            "Output file '{0}' already exists".format(output_file),
+            output_filename,
+        )
 
     total_file_size = int(streamed_response.headers['content-length'])
     total_bytes_written = 0

--- a/cloudify_rest_client/executions.py
+++ b/cloudify_rest_client/executions.py
@@ -342,7 +342,7 @@ class ExecutionGroupsClient(object):
             entity['executions'] = entity.pop('execution_ids')
             try:
                 self.create(**entity)
-            except CloudifyClientError as exc:
+            except (CloudifyClientError, RuntimeError) as exc:
                 logger.error("Error restoring execution group "
                              f"{entity['id']}: {exc}")
 


### PR DESCRIPTION
* Provide more information in OSError at writing a stream response to a file

* Just log RuntimeErrors as well as CloudifyClientErrors when restoring execution groups from a snapshot

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-common/pull/1311