### PR TITLE
NE-7793 Implement LogBundlesClient.upload_archive

### DIFF
--- a/cloudify_rest_client/log_bundles.py
+++ b/cloudify_rest_client/log_bundles.py
@@ -110,6 +110,21 @@ class LogBundlesClient(object):
 
             return output_file
 
+    def upload_archive(self, log_bundle_id, archive_file):
+        """Uploads a log bundle archive, e.g. created by mgmtworker.
+        :param log_bundle_id: The id of the log bundle to be uploaded.
+        :param archive_file: The file path of the log bundle archive to upload.
+        :return: The file path of the downloaded log bundle.
+        """
+        archive_data = bytes_stream_utils.request_data_file_stream(
+            archive_file,
+            client=self.api,
+        )
+        self.api.put(
+            f"{self.base_url}/{log_bundle_id}/archive",
+            data=archive_data,
+        )
+
     def update_status(self, log_bundle_id, status, error=None):
         """Update log bundle with the provided status and optional error.
         :param log_bundle_id: Id of the log bundle to update.

--- a/cloudify_rest_client/log_bundles.py
+++ b/cloudify_rest_client/log_bundles.py
@@ -114,7 +114,6 @@ class LogBundlesClient(object):
         """Uploads a log bundle archive, e.g. created by mgmtworker.
         :param log_bundle_id: The id of the log bundle to be uploaded.
         :param archive_file: The file path of the log bundle archive to upload.
-        :return: The file path of the downloaded log bundle.
         """
         archive_data = bytes_stream_utils.request_data_file_stream(
             archive_file,


### PR DESCRIPTION
The method is used by mgmtworker's log-bundle create workflow to upload a created archive.  The manager (which receives the file) in this case acts as kind of proxy for a file server service (e.g. SeaweedFS, local storage).