### PR TITLE
NE-19591 Mark not-complete executions as cancelled

### DIFF
--- a/cloudify_rest_client/executions.py
+++ b/cloudify_rest_client/executions.py
@@ -1,8 +1,16 @@
 import warnings
 
+from cloudify.models_states import ExecutionState
 from cloudify_rest_client import utils
 from cloudify_rest_client.exceptions import CloudifyClientError
 from cloudify_rest_client.responses import ListResponse
+
+
+RESTORE_STATUS_ERROR_MAP = dict(zip(
+    ExecutionState.IN_PROGRESS_STATES,
+    len(ExecutionState.IN_PROGRESS_STATES)
+    * [(ExecutionState.CANCELLED, "Marked as cancelled by snapshot restore")]
+))
 
 
 class Execution(dict):
@@ -599,7 +607,11 @@ class ExecutionsClient(object):
         """
         for entity in entities:
             entity['execution_id'] = entity.pop('id')
-            entity['force_status'] = entity.pop('status')
+            entity['force_status'], entity['error'] = \
+                restore_status_error_mapped(
+                    entity.pop('status'),
+                    entity.pop('error'),
+                )
             entity['dry_run'] = entity.pop('is_dry_run')
             entity['deployment_id'] = entity['deployment_id'] or ''
             try:
@@ -607,3 +619,7 @@ class ExecutionsClient(object):
             except CloudifyClientError as exc:
                 logger.error("Error restoring execution "
                              f"{entity['execution_id']}: {exc}")
+
+
+def restore_status_error_mapped(status: str, error: str) -> tuple[str, str]:
+    return RESTORE_STATUS_ERROR_MAP.get(status, (status, error))

--- a/cloudify_rest_client/executions.py
+++ b/cloudify_rest_client/executions.py
@@ -6,13 +6,6 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 from cloudify_rest_client.responses import ListResponse
 
 
-RESTORE_STATUS_ERROR_MAP = dict(zip(
-    ExecutionState.IN_PROGRESS_STATES,
-    len(ExecutionState.IN_PROGRESS_STATES)
-    * [(ExecutionState.CANCELLED, "Marked as cancelled by snapshot restore")]
-))
-
-
 class Execution(dict):
     """Cloudify workflow execution."""
     TERMINATED = 'terminated'
@@ -622,4 +615,9 @@ class ExecutionsClient(object):
 
 
 def restore_status_error_mapped(status: str, error: str) -> tuple[str, str]:
-    return RESTORE_STATUS_ERROR_MAP.get(status, (status, error))
+    if status in ExecutionState.IN_PROGRESS_STATES:
+        return (
+            ExecutionState.CANCELLED,
+            "Marked as cancelled by snapshot restore",
+        )
+    return status, error

--- a/cloudify_rest_client/executions.py
+++ b/cloudify_rest_client/executions.py
@@ -614,7 +614,7 @@ class ExecutionsClient(object):
                              f"{entity['execution_id']}: {exc}")
 
 
-def restore_status_error_mapped(status: str, error: str) -> tuple[str, str]:
+def restore_status_error_mapped(status, error):
     if status in ExecutionState.IN_PROGRESS_STATES:
         return (
             ExecutionState.CANCELLED,


### PR DESCRIPTION
Executions which were still running (i.e. had one of the statuses: `pending`, `started`, `cancelling`, `force_cancelling` or `kill_cancelling`) when the snapshot was made, will be marked as `cancelled` and information about that modification will be save in the `error` column of the execution.  It means a manual examination may be required to determine their state.